### PR TITLE
Fix Publish Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "branches": [
       "main"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This needs to be set or else the scoped package name cannot be published to npm registry properly.