### PR TITLE
feat: replace homepage photo with animated spider lily

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -232,16 +232,8 @@
     clip-path: inset(100% 0 0 0);
     opacity: 0;
   }
-  8% {
-    opacity: 0.6;
-  }
-  40% {
-    clip-path: inset(30% 0 0 0);
-    opacity: 0.85;
-  }
-  70% {
-    clip-path: inset(8% 0 0 0);
-    opacity: 0.95;
+  10% {
+    opacity: 0.8;
   }
   100% {
     clip-path: inset(0 0 0 0);

--- a/src/index.css
+++ b/src/index.css
@@ -309,10 +309,13 @@
 @keyframes lily-breathe {
   0%,
   100% {
-    filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.1));
+    filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.15))
+      drop-shadow(0 0 20px rgba(255, 255, 255, 0.06));
   }
   50% {
-    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.3));
+    filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.3))
+      drop-shadow(0 0 40px rgba(255, 255, 255, 0.1))
+      drop-shadow(0 0 80px rgba(255, 255, 255, 0.04));
   }
 }
 
@@ -391,9 +394,20 @@
   animation: lily-center-pulse 400ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-/* Breathing glow after bloom */
+/* Ethereal glow — fades in after bloom, then breathes */
 .spider-lily-container {
-  animation: lily-breathe 4s ease-in-out 1.8s infinite;
+  animation: lily-glow-in 2s ease-out 1.4s forwards,
+    lily-breathe 5s ease-in-out 3.4s infinite;
+}
+
+@keyframes lily-glow-in {
+  0% {
+    filter: drop-shadow(0 0 0 rgba(255, 255, 255, 0));
+  }
+  100% {
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2))
+      drop-shadow(0 0 30px rgba(255, 255, 255, 0.08));
+  }
 }
 
 .transmission-prose p {

--- a/src/index.css
+++ b/src/index.css
@@ -309,13 +309,14 @@
 @keyframes lily-breathe {
   0%,
   100% {
-    filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.15))
-      drop-shadow(0 0 20px rgba(255, 255, 255, 0.06));
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.25))
+      drop-shadow(0 0 30px rgba(255, 255, 255, 0.12))
+      drop-shadow(0 0 60px rgba(255, 255, 255, 0.05));
   }
   50% {
-    filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.3))
-      drop-shadow(0 0 40px rgba(255, 255, 255, 0.1))
-      drop-shadow(0 0 80px rgba(255, 255, 255, 0.04));
+    filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.45))
+      drop-shadow(0 0 50px rgba(255, 255, 255, 0.18))
+      drop-shadow(0 0 100px rgba(255, 255, 255, 0.08));
   }
 }
 
@@ -405,8 +406,9 @@
     filter: drop-shadow(0 0 0 rgba(255, 255, 255, 0));
   }
   100% {
-    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.2))
-      drop-shadow(0 0 30px rgba(255, 255, 255, 0.08));
+    filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.3))
+      drop-shadow(0 0 40px rgba(255, 255, 255, 0.14))
+      drop-shadow(0 0 70px rgba(255, 255, 255, 0.06));
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -318,7 +318,7 @@
 
 /* Stem — brush stroke aesthetic */
 .spider-lily-stem {
-  fill: rgba(255, 255, 255, 0.35);
+  fill: rgba(255, 255, 255, 0.9);
   stroke: none;
   opacity: 0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -232,8 +232,16 @@
     clip-path: inset(100% 0 0 0);
     opacity: 0;
   }
-  30% {
-    opacity: 0.8;
+  8% {
+    opacity: 0.6;
+  }
+  40% {
+    clip-path: inset(30% 0 0 0);
+    opacity: 0.85;
+  }
+  70% {
+    clip-path: inset(8% 0 0 0);
+    opacity: 0.95;
   }
   100% {
     clip-path: inset(0 0 0 0);
@@ -255,14 +263,23 @@
 @keyframes lily-petal-bloom {
   0% {
     opacity: 0;
-    transform: scale(0.3);
+    transform: scale(0) rotate(8deg);
   }
-  60% {
-    opacity: 0.85;
+  20% {
+    opacity: 0.5;
+    transform: scale(0.4) rotate(4deg);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(0.75) rotate(1deg);
+  }
+  80% {
+    opacity: 0.9;
+    transform: scale(0.95) rotate(-0.5deg);
   }
   100% {
     opacity: 0.92;
-    transform: scale(1);
+    transform: scale(1) rotate(0deg);
   }
 }
 
@@ -271,8 +288,13 @@
     stroke-dashoffset: 1;
     opacity: 0;
   }
+  25% {
+    stroke-dashoffset: 0.7;
+    opacity: 0.3;
+  }
   60% {
-    opacity: 0.5;
+    stroke-dashoffset: 0.2;
+    opacity: 0.55;
   }
   100% {
     stroke-dashoffset: 0;
@@ -283,15 +305,12 @@
 @keyframes lily-anther-appear {
   0% {
     opacity: 0;
-    r: 0;
   }
-  70% {
+  60% {
     opacity: 0.85;
-    r: 2.8;
   }
   100% {
     opacity: 0.75;
-    r: 2.2;
   }
 }
 
@@ -328,7 +347,7 @@
 }
 
 .spider-lily-stem-active {
-  animation: lily-stem-rise 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-stem-rise 800ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 /* Bract */
@@ -357,7 +376,7 @@
 }
 
 .spider-lily-petal-active {
-  animation: lily-petal-bloom 600ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-petal-bloom 700ms cubic-bezier(0.12, 0.8, 0.2, 1) forwards;
 }
 
 /* Stamens */
@@ -372,7 +391,7 @@
 }
 
 .spider-lily-stamen-active {
-  animation: lily-stamen-grow 550ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-stamen-grow 600ms cubic-bezier(0.12, 0.8, 0.2, 1) forwards;
 }
 
 /* Anther tips */
@@ -382,7 +401,7 @@
 }
 
 .spider-lily-anther-active {
-  animation: lily-anther-appear 300ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-anther-appear 350ms cubic-bezier(0.12, 0.8, 0.2, 1) forwards;
 }
 
 /* Center node */
@@ -392,13 +411,56 @@
 }
 
 .spider-lily-center-active {
-  animation: lily-center-pulse 400ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-center-pulse 500ms cubic-bezier(0.12, 0.8, 0.2, 1) forwards;
 }
 
-/* Ethereal glow — fades in after bloom, then breathes */
+/* Ethereal glow — fades in during bloom, then breathes */
 .spider-lily-container {
-  animation: lily-glow-in 2s ease-out 1.4s forwards,
+  animation: lily-glow-in 1.8s ease-out 1.2s forwards,
     lily-breathe 5s ease-in-out 3.4s infinite;
+}
+
+@keyframes lily-glitch {
+  0% {
+    translate: 0 0;
+    opacity: 1;
+  }
+  10% {
+    translate: 5px -2px;
+    opacity: 0.2;
+  }
+  20% {
+    translate: -4px 1px;
+    opacity: 1;
+  }
+  30% {
+    translate: 0 0;
+    opacity: 0;
+  }
+  40% {
+    translate: 3px -1px;
+    opacity: 0.7;
+  }
+  50% {
+    translate: -6px 2px;
+    opacity: 0.15;
+  }
+  60% {
+    translate: 4px 0;
+    opacity: 1;
+  }
+  70% {
+    translate: 0 -1px;
+    opacity: 0.5;
+  }
+  80% {
+    translate: -2px 0;
+    opacity: 1;
+  }
+  100% {
+    translate: 0 0;
+    opacity: 1;
+  }
 }
 
 @keyframes lily-glow-in {

--- a/src/index.css
+++ b/src/index.css
@@ -353,7 +353,7 @@
   stroke-width: 0.5;
   stroke-linejoin: round;
   opacity: 0;
-  transform-origin: 218px 195px;
+  transform-origin: 220px 230px;
 }
 
 .spider-lily-petal-active {

--- a/src/index.css
+++ b/src/index.css
@@ -229,15 +229,15 @@
 
 @keyframes lily-stem-rise {
   0% {
-    stroke-dashoffset: 1;
+    clip-path: inset(100% 0 0 0);
     opacity: 0;
   }
   30% {
-    opacity: 0.7;
+    opacity: 0.8;
   }
   100% {
-    stroke-dashoffset: 0;
-    opacity: 0.6;
+    clip-path: inset(0 0 0 0);
+    opacity: 1;
   }
 }
 
@@ -316,14 +316,10 @@
   }
 }
 
-/* Stem */
+/* Stem — brush stroke aesthetic */
 .spider-lily-stem {
-  fill: none;
-  stroke: rgba(255, 255, 255, 0.55);
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-dasharray: 1;
-  stroke-dashoffset: 1;
+  fill: rgba(255, 255, 255, 0.88);
+  stroke: none;
   opacity: 0;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -318,7 +318,7 @@
 
 /* Stem — brush stroke aesthetic */
 .spider-lily-stem {
-  fill: rgba(255, 255, 255, 0.88);
+  fill: rgba(255, 255, 255, 0.35);
   stroke: none;
   opacity: 0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -320,20 +320,20 @@
 @keyframes lily-breathe {
   0%,
   100% {
-    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.25))
-      drop-shadow(0 0 30px rgba(255, 255, 255, 0.12))
-      drop-shadow(0 0 60px rgba(255, 255, 255, 0.05));
+    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.2))
+      drop-shadow(0 0 25px rgba(255, 255, 255, 0.08))
+      drop-shadow(0 0 50px rgba(255, 255, 255, 0.03));
   }
   50% {
-    filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.45))
-      drop-shadow(0 0 50px rgba(255, 255, 255, 0.18))
-      drop-shadow(0 0 100px rgba(255, 255, 255, 0.08));
+    filter: drop-shadow(0 0 16px rgba(255, 255, 255, 0.35))
+      drop-shadow(0 0 45px rgba(255, 255, 255, 0.12))
+      drop-shadow(0 0 80px rgba(255, 255, 255, 0.05));
   }
 }
 
 /* Stem — brush stroke aesthetic */
 .spider-lily-stem {
-  fill: rgba(255, 255, 255, 0.9);
+  fill: rgba(255, 255, 255, 0.8);
   stroke: none;
   opacity: 0;
 }
@@ -359,8 +359,8 @@
 
 /* Petals — solid white filled */
 .spider-lily-petal {
-  fill: rgba(255, 255, 255, 0.9);
-  stroke: rgba(255, 255, 255, 0.95);
+  fill: rgba(255, 255, 255, 0.85);
+  stroke: rgba(255, 255, 255, 0.9);
   stroke-width: 0.5;
   stroke-linejoin: round;
   opacity: 0;
@@ -374,7 +374,7 @@
 /* Stamens */
 .spider-lily-stamen {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.65);
+  stroke: rgba(255, 255, 255, 0.55);
   stroke-width: 0.8;
   stroke-linecap: round;
   stroke-dasharray: 1;
@@ -388,7 +388,7 @@
 
 /* Anther tips */
 .spider-lily-anther {
-  fill: rgba(255, 255, 255, 0.8);
+  fill: rgba(255, 255, 255, 0.65);
   opacity: 0;
 }
 
@@ -408,8 +408,8 @@
 
 /* Ethereal glow — fades in during bloom, then breathes */
 .spider-lily-container {
-  animation: lily-glow-in 1.8s ease-out 1.2s forwards,
-    lily-breathe 5s ease-in-out 3.4s infinite;
+  animation: lily-glow-in 2.5s ease-out 1.2s forwards,
+    lily-breathe 7s ease-in-out 4s infinite;
 }
 
 @keyframes lily-glitch {
@@ -460,9 +460,9 @@
     filter: drop-shadow(0 0 0 rgba(255, 255, 255, 0));
   }
   100% {
-    filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.3))
-      drop-shadow(0 0 40px rgba(255, 255, 255, 0.14))
-      drop-shadow(0 0 70px rgba(255, 255, 255, 0.06));
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.22))
+      drop-shadow(0 0 30px rgba(255, 255, 255, 0.1))
+      drop-shadow(0 0 55px rgba(255, 255, 255, 0.04));
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -225,6 +225,181 @@
     opacity 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+/* Spider lily — side view bloom animation */
+
+@keyframes lily-stem-rise {
+  0% {
+    stroke-dashoffset: 1;
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.7;
+  }
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 0.6;
+  }
+}
+
+@keyframes lily-bract-open {
+  0% {
+    stroke-dashoffset: 1;
+    opacity: 0;
+  }
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 0.4;
+  }
+}
+
+@keyframes lily-petal-bloom {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  60% {
+    opacity: 0.85;
+  }
+  100% {
+    opacity: 0.92;
+    transform: scale(1);
+  }
+}
+
+@keyframes lily-stamen-grow {
+  0% {
+    stroke-dashoffset: 1;
+    opacity: 0;
+  }
+  60% {
+    opacity: 0.5;
+  }
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 0.7;
+  }
+}
+
+@keyframes lily-anther-appear {
+  0% {
+    opacity: 0;
+    r: 0;
+  }
+  70% {
+    opacity: 0.85;
+    r: 2.8;
+  }
+  100% {
+    opacity: 0.75;
+    r: 2.2;
+  }
+}
+
+@keyframes lily-center-pulse {
+  0% {
+    opacity: 0;
+    r: 0;
+  }
+  100% {
+    opacity: 0.85;
+    r: 3;
+  }
+}
+
+@keyframes lily-breathe {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.1));
+  }
+  50% {
+    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.3));
+  }
+}
+
+/* Stem */
+.spider-lily-stem {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.55);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  opacity: 0;
+}
+
+.spider-lily-stem-active {
+  animation: lily-stem-rise 1200ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Bract */
+.spider-lily-bract {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.4);
+  stroke-width: 0.8;
+  stroke-linecap: round;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  opacity: 0;
+}
+
+.spider-lily-bract-active {
+  animation: lily-bract-open 600ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Petals — solid white filled */
+.spider-lily-petal {
+  fill: rgba(255, 255, 255, 0.9);
+  stroke: rgba(255, 255, 255, 0.95);
+  stroke-width: 0.5;
+  stroke-linejoin: round;
+  opacity: 0;
+  transform-origin: 218px 195px;
+}
+
+.spider-lily-petal-active {
+  animation: lily-petal-bloom 1000ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Stamens */
+.spider-lily-stamen {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.65);
+  stroke-width: 0.8;
+  stroke-linecap: round;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  opacity: 0;
+}
+
+.spider-lily-stamen-active {
+  animation: lily-stamen-grow 900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Anther tips */
+.spider-lily-anther {
+  fill: rgba(255, 255, 255, 0.8);
+  opacity: 0;
+}
+
+.spider-lily-anther-active {
+  animation: lily-anther-appear 500ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+/* Center node */
+.spider-lily-center {
+  fill: rgba(255, 255, 255, 0.85);
+  opacity: 0;
+}
+
+.spider-lily-center-active {
+  animation: lily-center-pulse 600ms cubic-bezier(0.22, 1, 0.36, 1) 200ms forwards;
+}
+
+/* Breathing glow after bloom */
+.spider-lily-container {
+  animation: lily-breathe 4s ease-in-out 2.5s infinite;
+}
+
 .transmission-prose p {
   margin-bottom: 0.75em;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -324,7 +324,7 @@
 }
 
 .spider-lily-stem-active {
-  animation: lily-stem-rise 1200ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-stem-rise 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 /* Bract */
@@ -353,7 +353,7 @@
 }
 
 .spider-lily-petal-active {
-  animation: lily-petal-bloom 1000ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-petal-bloom 600ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 /* Stamens */
@@ -368,7 +368,7 @@
 }
 
 .spider-lily-stamen-active {
-  animation: lily-stamen-grow 900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-stamen-grow 550ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 /* Anther tips */
@@ -378,7 +378,7 @@
 }
 
 .spider-lily-anther-active {
-  animation: lily-anther-appear 500ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: lily-anther-appear 300ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 /* Center node */
@@ -388,12 +388,12 @@
 }
 
 .spider-lily-center-active {
-  animation: lily-center-pulse 600ms cubic-bezier(0.22, 1, 0.36, 1) 200ms forwards;
+  animation: lily-center-pulse 400ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 /* Breathing glow after bloom */
 .spider-lily-container {
-  animation: lily-breathe 4s ease-in-out 2.5s infinite;
+  animation: lily-breathe 4s ease-in-out 1.8s infinite;
 }
 
 .transmission-prose p {

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -146,46 +146,46 @@ const petals: { d: string; delay: number }[] = [
     delay: 280,
   },
 
-  // ==== LOWER PETALS — four ribbon curls, droop out then tips curl back up ====
+  // ==== LOWER PETALS — four parenthesis-shaped curves framing the stem ====
 
-  // Far left — sweeps wide left, droops, tip curls back up
+  // Outer left "(" — arcs out left then curves down
   {
     d: `M${CX} ${CY + W}
-       C${CX - 30} ${CY + W + 10}, ${CX - 75} ${CY + W + 30}, ${CX - 110} ${CY + W + 50}
-       C${CX - 135} ${CY + W + 65}, ${CX - 148} ${CY + W + 72}, ${CX - 150} ${CY + W + 60}
-       C${CX - 152} ${CY + W + 48}, ${CX - 142} ${CY + W + 38}, ${CX - 138} ${CY + W + 45}
-       C${CX - 132} ${CY + 52}, ${CX - 128} ${CY + 48}, ${CX - 115} ${CY + 38}
-       C${CX - 78} ${CY + 22}, ${CX - 35} ${CY + 8}, ${CX} ${CY - W} Z`,
+       C${CX - 35} ${CY + W + 5}, ${CX - 70} ${CY + W + 18}, ${CX - 85} ${CY + W + 40}
+       C${CX - 95} ${CY + W + 58}, ${CX - 88} ${CY + W + 78}, ${CX - 72} ${CY + W + 88}
+       L${CX - 65} ${CY - W + 85}
+       C${CX - 80} ${CY - W + 72}, ${CX - 88} ${CY - W + 52}, ${CX - 78} ${CY - W + 35}
+       C${CX - 65} ${CY - W + 16}, ${CX - 32} ${CY - W + 4}, ${CX} ${CY - W} Z`,
     delay: 280,
   },
-  // Far right — mirror
+  // Outer right ")" — mirror
   {
     d: `M${CX} ${CY + W}
-       C${CX + 32} ${CY + W + 12}, ${CX + 78} ${CY + W + 32}, ${CX + 114} ${CY + W + 52}
-       C${CX + 140} ${CY + W + 68}, ${CX + 152} ${CY + W + 75}, ${CX + 155} ${CY + W + 62}
-       C${CX + 157} ${CY + W + 50}, ${CX + 147} ${CY + W + 40}, ${CX + 142} ${CY + W + 48}
-       C${CX + 136} ${CY + 54}, ${CX + 132} ${CY + 50}, ${CX + 118} ${CY + 40}
-       C${CX + 82} ${CY + 24}, ${CX + 38} ${CY + 10}, ${CX} ${CY - W} Z`,
+       C${CX + 38} ${CY + W + 6}, ${CX + 72} ${CY + W + 20}, ${CX + 88} ${CY + W + 42}
+       C${CX + 98} ${CY + W + 60}, ${CX + 92} ${CY + W + 80}, ${CX + 76} ${CY + W + 90}
+       L${CX + 69} ${CY - W + 87}
+       C${CX + 84} ${CY - W + 74}, ${CX + 92} ${CY - W + 54}, ${CX + 82} ${CY - W + 37}
+       C${CX + 68} ${CY - W + 18}, ${CX + 35} ${CY - W + 5}, ${CX} ${CY - W} Z`,
     delay: 320,
   },
-  // Inner left — steeper droop, closer to center, tip curls up
+  // Inner left "(" — tighter, closer to stem
   {
     d: `M${CX} ${CY + W}
-       C${CX - 18} ${CY + W + 14}, ${CX - 48} ${CY + W + 40}, ${CX - 72} ${CY + W + 65}
-       C${CX - 90} ${CY + W + 82}, ${CX - 100} ${CY + W + 88}, ${CX - 102} ${CY + W + 76}
-       C${CX - 104} ${CY + W + 64}, ${CX - 95} ${CY + W + 56}, ${CX - 90} ${CY + W + 62}
-       C${CX - 85} ${CY + 68}, ${CX - 82} ${CY + 64}, ${CX - 72} ${CY + 52}
-       C${CX - 48} ${CY + 32}, ${CX - 20} ${CY + 12}, ${CX} ${CY - W} Z`,
+       C${CX - 20} ${CY + W + 6}, ${CX - 42} ${CY + W + 20}, ${CX - 52} ${CY + W + 38}
+       C${CX - 58} ${CY + W + 52}, ${CX - 52} ${CY + W + 68}, ${CX - 40} ${CY + W + 76}
+       L${CX - 34} ${CY - W + 73}
+       C${CX - 45} ${CY - W + 62}, ${CX - 50} ${CY - W + 46}, ${CX - 44} ${CY - W + 32}
+       C${CX - 36} ${CY - W + 18}, ${CX - 18} ${CY - W + 5}, ${CX} ${CY - W} Z`,
     delay: 360,
   },
-  // Inner right — mirror
+  // Inner right ")" — mirror
   {
     d: `M${CX} ${CY + W}
-       C${CX + 20} ${CY + W + 16}, ${CX + 52} ${CY + W + 42}, ${CX + 76} ${CY + W + 68}
-       C${CX + 94} ${CY + W + 85}, ${CX + 104} ${CY + W + 92}, ${CX + 106} ${CY + W + 80}
-       C${CX + 108} ${CY + W + 68}, ${CX + 98} ${CY + W + 58}, ${CX + 94} ${CY + W + 65}
-       C${CX + 88} ${CY + 70}, ${CX + 86} ${CY + 66}, ${CX + 76} ${CY + 54}
-       C${CX + 50} ${CY + 34}, ${CX + 22} ${CY + 14}, ${CX} ${CY - W} Z`,
+       C${CX + 22} ${CY + W + 8}, ${CX + 45} ${CY + W + 22}, ${CX + 55} ${CY + W + 40}
+       C${CX + 62} ${CY + W + 55}, ${CX + 56} ${CY + W + 70}, ${CX + 44} ${CY + W + 78}
+       L${CX + 38} ${CY - W + 75}
+       C${CX + 48} ${CY - W + 64}, ${CX + 54} ${CY - W + 48}, ${CX + 48} ${CY - W + 34}
+       C${CX + 40} ${CY - W + 20}, ${CX + 20} ${CY - W + 6}, ${CX} ${CY - W} Z`,
     delay: 400,
   },
 ];
@@ -196,24 +196,24 @@ const petalDelays = petals.map((p) => p.delay);
 // so nothing dips below the flower neck. Tips staggered naturally.
 const stamens = [
   // ==== OUTERMOST — wide, shallow curve ====
-  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 0 },
-  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 40 },
+  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 0, tipAngle: -15, tipLen: 3.8, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 40, tipAngle: 20, tipLen: 3.5, tipW: 2.6 },
 
   // ==== WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 80 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 120 },
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 80, tipAngle: -35, tipLen: 4, tipW: 2.3 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 120, tipAngle: 40, tipLen: 3.4, tipW: 2.7 },
 
   // ==== MID-WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 160 },
-  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 200 },
+  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 160, tipAngle: -50, tipLen: 3.8, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 200, tipAngle: 55, tipLen: 3.6, tipW: 2.5 },
 
   // ==== UPPER ====
-  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 240 },
-  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 280 },
+  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 240, tipAngle: -70, tipLen: 3.9, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 280, tipAngle: 65, tipLen: 3.4, tipW: 2.6 },
 
   // ==== CENTER ====
-  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 320 },
-  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 360 },
+  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 320, tipAngle: -80, tipLen: 3.6, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 360, tipAngle: 75, tipLen: 3.8, tipW: 2.3 },
 ];
 
 const STEM_DELAY = 150;
@@ -302,10 +302,12 @@ const SpiderLily = ({ className }: { className?: string }) => {
               filter="url(#stamen-glow)"
               pathLength={1}
             />
-            <circle
+            <ellipse
               cx={s.tipX}
               cy={s.tipY}
-              r="2.2"
+              rx={s.tipLen}
+              ry={s.tipW}
+              transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
               className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
               style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
               filter="url(#stamen-glow)"

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -146,27 +146,47 @@ const petals: { d: string; delay: number }[] = [
     delay: 280,
   },
 
-  // ==== LOWER PETALS — two short, curving down then bending inward ====
+  // ==== LOWER PETALS — four ribbon curls, droop out then tips curl back up ====
 
-  // Left — gentle arc down-left, curves back toward center at mid-point
+  // Far left — sweeps wide left, droops, tip curls back up
   {
     d: `M${CX} ${CY + W}
-       C${CX - 20} ${CY + W + 10}, ${CX - 45} ${CY + W + 25}, ${CX - 65} ${CY + W + 35}
-       C${CX - 78} ${CY + W + 42}, ${CX - 82} ${CY + W + 48}, ${CX - 76} ${CY + W + 52}
-       C${CX - 68} ${CY + W + 55}, ${CX - 60} ${CY + W + 48}, ${CX - 58} ${CY + W + 40}
-       C${CX - 55} ${CY + W + 32}, ${CX - 58} ${CY + 38}, ${CX - 50} ${CY + 28}
-       C${CX - 35} ${CY + 16}, ${CX - 18} ${CY + 6}, ${CX} ${CY - W} Z`,
-    delay: 300,
+       C${CX - 30} ${CY + W + 10}, ${CX - 75} ${CY + W + 30}, ${CX - 110} ${CY + W + 50}
+       C${CX - 135} ${CY + W + 65}, ${CX - 148} ${CY + W + 72}, ${CX - 150} ${CY + W + 60}
+       C${CX - 152} ${CY + W + 48}, ${CX - 142} ${CY + W + 38}, ${CX - 138} ${CY + W + 45}
+       C${CX - 132} ${CY + 52}, ${CX - 128} ${CY + 48}, ${CX - 115} ${CY + 38}
+       C${CX - 78} ${CY + 22}, ${CX - 35} ${CY + 8}, ${CX} ${CY - W} Z`,
+    delay: 280,
   },
-  // Right — mirror
+  // Far right — mirror
   {
     d: `M${CX} ${CY + W}
-       C${CX + 22} ${CY + W + 12}, ${CX + 48} ${CY + W + 28}, ${CX + 68} ${CY + W + 38}
-       C${CX + 82} ${CY + W + 45}, ${CX + 86} ${CY + W + 52}, ${CX + 80} ${CY + W + 55}
-       C${CX + 72} ${CY + W + 58}, ${CX + 64} ${CY + W + 50}, ${CX + 62} ${CY + W + 42}
-       C${CX + 58} ${CY + W + 34}, ${CX + 62} ${CY + 40}, ${CX + 54} ${CY + 30}
-       C${CX + 38} ${CY + 18}, ${CX + 20} ${CY + 8}, ${CX} ${CY - W} Z`,
-    delay: 340,
+       C${CX + 32} ${CY + W + 12}, ${CX + 78} ${CY + W + 32}, ${CX + 114} ${CY + W + 52}
+       C${CX + 140} ${CY + W + 68}, ${CX + 152} ${CY + W + 75}, ${CX + 155} ${CY + W + 62}
+       C${CX + 157} ${CY + W + 50}, ${CX + 147} ${CY + W + 40}, ${CX + 142} ${CY + W + 48}
+       C${CX + 136} ${CY + 54}, ${CX + 132} ${CY + 50}, ${CX + 118} ${CY + 40}
+       C${CX + 82} ${CY + 24}, ${CX + 38} ${CY + 10}, ${CX} ${CY - W} Z`,
+    delay: 320,
+  },
+  // Inner left — steeper droop, closer to center, tip curls up
+  {
+    d: `M${CX} ${CY + W}
+       C${CX - 18} ${CY + W + 14}, ${CX - 48} ${CY + W + 40}, ${CX - 72} ${CY + W + 65}
+       C${CX - 90} ${CY + W + 82}, ${CX - 100} ${CY + W + 88}, ${CX - 102} ${CY + W + 76}
+       C${CX - 104} ${CY + W + 64}, ${CX - 95} ${CY + W + 56}, ${CX - 90} ${CY + W + 62}
+       C${CX - 85} ${CY + 68}, ${CX - 82} ${CY + 64}, ${CX - 72} ${CY + 52}
+       C${CX - 48} ${CY + 32}, ${CX - 20} ${CY + 12}, ${CX} ${CY - W} Z`,
+    delay: 360,
+  },
+  // Inner right — mirror
+  {
+    d: `M${CX} ${CY + W}
+       C${CX + 20} ${CY + W + 16}, ${CX + 52} ${CY + W + 42}, ${CX + 76} ${CY + W + 68}
+       C${CX + 94} ${CY + W + 85}, ${CX + 104} ${CY + W + 92}, ${CX + 106} ${CY + W + 80}
+       C${CX + 108} ${CY + W + 68}, ${CX + 98} ${CY + W + 58}, ${CX + 94} ${CY + W + 65}
+       C${CX + 88} ${CY + 70}, ${CX + 86} ${CY + 66}, ${CX + 76} ${CY + 54}
+       C${CX + 50} ${CY + 34}, ${CX + 22} ${CY + 14}, ${CX} ${CY - W} Z`,
+    delay: 400,
   },
 ];
 
@@ -199,20 +219,18 @@ const stamens = [
 const STEM_DELAY = 150;
 const PETAL_DELAY = 650;
 const STAMEN_DELAY = 1000;
-const ANTHER_DELAY = STAMEN_DELAY + 550 + 360;
+const STAMEN_DURATION = 550;
 
 const SpiderLily = ({ className }: { className?: string }) => {
   const [stemActive, setStemActive] = useState(false);
   const [petalsActive, setPetalsActive] = useState(false);
   const [stamensActive, setStamensActive] = useState(false);
-  const [anthersActive, setAnthersActive] = useState(false);
 
   useEffect(() => {
     const t1 = setTimeout(() => setStemActive(true), STEM_DELAY);
     const t2 = setTimeout(() => setPetalsActive(true), PETAL_DELAY);
     const t3 = setTimeout(() => setStamensActive(true), STAMEN_DELAY);
-    const t4 = setTimeout(() => setAnthersActive(true), ANTHER_DELAY);
-    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); clearTimeout(t4); };
+    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
   }, []);
 
   return (
@@ -288,8 +306,8 @@ const SpiderLily = ({ className }: { className?: string }) => {
               cx={s.tipX}
               cy={s.tipY}
               r="2.2"
-              className={`spider-lily-anther ${anthersActive ? 'spider-lily-anther-active' : ''}`}
-              style={{ animationDelay: `${s.delay}ms` }}
+              className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
+              style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
               filter="url(#stamen-glow)"
             />
           </g>

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -149,26 +149,26 @@ const petalDelays = petals.map((p) => p.delay);
 
 // Stamens: smooth wide U-arcs. All control points stay above CY (the center)
 // so nothing dips below the flower neck. Tips staggered naturally.
-const stamens = [
+const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean }[] = [
   // ==== OUTERMOST — wide, shallow curve ====
-  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 0, tipAngle: -15, tipLen: 3.8, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 40, tipAngle: 20, tipLen: 3.5, tipW: 2.6 },
+  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 16}, ${CX - 310} ${CY - 20}, ${CX - 335} ${CY - 110}`, tipX: CX - 335, tipY: CY - 110, delay: 0, tipAngle: -15, tipLen: 3.8, tipW: 2.4, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 18}, ${CX + 306} ${CY - 24}, ${CX + 332} ${CY - 115}`, tipX: CX + 332, tipY: CY - 115, delay: 40, tipAngle: 20, tipLen: 3.5, tipW: 2.6 },
 
   // ==== WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 80, tipAngle: -35, tipLen: 4, tipW: 2.3 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 120, tipAngle: 40, tipLen: 3.4, tipW: 2.7 },
+  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 20}, ${CX - 280} ${CY - 30}, ${CX - 305} ${CY - 135}`, tipX: CX - 305, tipY: CY - 135, delay: 80, tipAngle: -35, tipLen: 4, tipW: 2.3 },
+  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 22}, ${CX + 276} ${CY - 34}, ${CX + 302} ${CY - 130}`, tipX: CX + 302, tipY: CY - 130, delay: 120, tipAngle: 40, tipLen: 3.4, tipW: 2.7, noTip: true },
 
   // ==== MID-WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 160, tipAngle: -50, tipLen: 3.8, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 200, tipAngle: 55, tipLen: 3.6, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX - 80} ${CY - 35}, ${CX - 225} ${CY - 65}, ${CX - 255} ${CY - 158}`, tipX: CX - 255, tipY: CY - 158, delay: 160, tipAngle: -50, tipLen: 3.8, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 78} ${CY - 38}, ${CX + 222} ${CY - 70}, ${CX + 252} ${CY - 162}`, tipX: CX + 252, tipY: CY - 162, delay: 200, tipAngle: 55, tipLen: 3.6, tipW: 2.5 },
 
   // ==== UPPER ====
-  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 240, tipAngle: -70, tipLen: 3.9, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 280, tipAngle: 65, tipLen: 3.4, tipW: 2.6 },
+  { d: `M${CX} ${CY - 12} C${CX - 52} ${CY - 50}, ${CX - 165} ${CY - 118}, ${CX - 182} ${CY - 178}`, tipX: CX - 182, tipY: CY - 178, delay: 240, tipAngle: -70, tipLen: 3.9, tipW: 2.2, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX + 50} ${CY - 52}, ${CX + 162} ${CY - 122}, ${CX + 180} ${CY - 174}`, tipX: CX + 180, tipY: CY - 174, delay: 280, tipAngle: 65, tipLen: 3.4, tipW: 2.6 },
 
   // ==== CENTER ====
-  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 320, tipAngle: -80, tipLen: 3.6, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 360, tipAngle: 75, tipLen: 3.8, tipW: 2.3 },
+  { d: `M${CX} ${CY - 12} C${CX - 25} ${CY - 65}, ${CX - 78} ${CY - 150}, ${CX - 75} ${CY - 190}`, tipX: CX - 75, tipY: CY - 190, delay: 320, tipAngle: -80, tipLen: 3.6, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 22} ${CY - 68}, ${CX + 75} ${CY - 154}, ${CX + 72} ${CY - 188}`, tipX: CX + 72, tipY: CY - 188, delay: 360, tipAngle: 75, tipLen: 3.8, tipW: 2.3, noTip: true },
 ];
 
 const STEM_DELAY = 150;
@@ -190,7 +190,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
   return (
     <svg
-      viewBox="-120 10 680 590"
+      viewBox="-180 10 800 590"
       className={className}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -9,186 +9,166 @@ import { useEffect, useState } from 'react';
 const CX = 220;
 const CY = 230;
 
-// Petals are thin ribbons (two-edge closed paths) with tight curling
-// spiral tips. Each one: narrow at base → slight widening → tight loop.
-// The "top edge" and "bottom edge" of the ribbon are offset by ~6-10px.
+// Reference analysis: most petal mass droops BELOW center, curling down
+// and outward like a skirt, with tips curling back up. Only 2-3 short
+// petals go upward. The shape is WIDE and DROOPING, not a vertical fan.
+// W = half-width of ribbon.
+const W = 4;
 const petals: { d: string; delay: number }[] = [
-  // ---- LEFT HORIZONTAL ----
-  // Far left — long sweep, tight downward spiral at tip
+  // ==== DROOPING LEFT — the main visual mass ====
+  // Far left — drops down-left, sweeps wide, tip curls up
   {
-    d: `M${CX} ${CY - 3}
-       L${CX - 40} ${CY - 12} L${CX - 85} ${CY - 16} L${CX - 125} ${CY - 10}
-       L${CX - 152} ${CY + 2} L${CX - 165} ${CY + 18} L${CX - 170} ${CY + 38}
-       C${CX - 170} ${CY + 52}, ${CX - 160} ${CY + 58}, ${CX - 150} ${CY + 52}
-       C${CX - 142} ${CY + 44}, ${CX - 148} ${CY + 32}, ${CX - 158} ${CY + 22}
-       L${CX - 155} ${CY + 8} L${CX - 140} ${CY - 2}
-       L${CX - 118} ${CY - 6} L${CX - 82} ${CY - 8} L${CX - 42} ${CY - 2}
-       L${CX - 5} ${CY + 5} Z`,
+    d: `M${CX} ${CY + W}
+       C${CX - 35} ${CY + W + 15}, ${CX - 80} ${CY + W + 45}, ${CX - 120} ${CY + W + 68}
+       C${CX - 145} ${CY + W + 80}, ${CX - 162} ${CY + 78}, ${CX - 165} ${CY + 62}
+       C${CX - 166} ${CY + 48}, ${CX - 155} ${CY + 45}, ${CX - 150} ${CY + 55}
+       C${CX - 145} ${CY + 65}, ${CX - 148} ${CY + 72}, ${CX - 130} ${CY - W + 65}
+       C${CX - 90} ${CY - W + 45}, ${CX - 40} ${CY - W + 18}, ${CX} ${CY - W} Z`,
     delay: 0,
   },
-  // Left mid-upper
+  // Left mid-drop — slightly less steep
   {
-    d: `M${CX} ${CY - 2}
-       L${CX - 35} ${CY - 14} L${CX - 72} ${CY - 28} L${CX - 108} ${CY - 34}
-       L${CX - 138} ${CY - 28} L${CX - 155} ${CY - 14} L${CX - 162} ${CY + 4}
-       C${CX - 165} ${CY + 18}, ${CX - 156} ${CY + 26}, ${CX - 146} ${CY + 20}
-       C${CX - 138} ${CY + 14}, ${CX - 142} ${CY + 2}, ${CX - 150} ${CY - 6}
-       L${CX - 142} ${CY - 16} L${CX - 125} ${CY - 22}
-       L${CX - 102} ${CY - 24} L${CX - 70} ${CY - 18} L${CX - 38} ${CY - 6}
-       L${CX - 6} ${CY + 6} Z`,
-    delay: 100,
+    d: `M${CX} ${CY + W}
+       C${CX - 40} ${CY + W + 10}, ${CX - 90} ${CY + W + 30}, ${CX - 130} ${CY + W + 42}
+       C${CX - 155} ${CY + W + 48}, ${CX - 170} ${CY + 38}, ${CX - 172} ${CY + 22}
+       C${CX - 172} ${CY + 8}, ${CX - 162} ${CY + 5}, ${CX - 158} ${CY + 15}
+       C${CX - 154} ${CY + 25}, ${CX - 158} ${CY + 32}, ${CX - 140} ${CY - W + 38}
+       C${CX - 100} ${CY - W + 25}, ${CX - 45} ${CY - W + 8}, ${CX} ${CY - W} Z`,
+    delay: 80,
   },
-  // Left low — sweeps down, curls up
+  // Left upper-drop — goes out left, slight downward, curls back
   {
-    d: `M${CX} ${CY + 2}
-       L${CX - 32} ${CY + 15} L${CX - 65} ${CY + 32} L${CX - 95} ${CY + 50}
-       L${CX - 115} ${CY + 66} L${CX - 125} ${CY + 82} L${CX - 126} ${CY + 98}
-       C${CX - 124} ${CY + 112}, ${CX - 114} ${CY + 116}, ${CX - 108} ${CY + 108}
-       C${CX - 102} ${CY + 98}, ${CX - 108} ${CY + 86}, ${CX - 116} ${CY + 78}
-       L${CX - 110} ${CY + 62} L${CX - 95} ${CY + 48}
-       L${CX - 72} ${CY + 34} L${CX - 45} ${CY + 20} L${CX - 18} ${CY + 8}
-       L${CX + 3} ${CY + 6} Z`,
-    delay: 190,
-  },
-
-  // ---- RIGHT HORIZONTAL ----
-  // Far right
-  {
-    d: `M${CX} ${CY - 4}
-       L${CX + 42} ${CY - 15} L${CX + 88} ${CY - 20} L${CX + 128} ${CY - 14}
-       L${CX + 155} ${CY} L${CX + 168} ${CY + 16} L${CX + 174} ${CY + 36}
-       C${CX + 175} ${CY + 50}, ${CX + 165} ${CY + 56}, ${CX + 155} ${CY + 50}
-       C${CX + 147} ${CY + 42}, ${CX + 152} ${CY + 30}, ${CX + 162} ${CY + 20}
-       L${CX + 158} ${CY + 6} L${CX + 145} ${CY - 4}
-       L${CX + 122} ${CY - 8} L${CX + 85} ${CY - 10} L${CX + 45} ${CY - 4}
-       L${CX + 6} ${CY + 4} Z`,
-    delay: 50,
-  },
-  // Right mid-upper
-  {
-    d: `M${CX} ${CY - 3}
-       L${CX + 38} ${CY - 16} L${CX + 76} ${CY - 32} L${CX + 112} ${CY - 38}
-       L${CX + 142} ${CY - 30} L${CX + 160} ${CY - 16} L${CX + 168} ${CY + 2}
-       C${CX + 172} ${CY + 16}, ${CX + 162} ${CY + 24}, ${CX + 152} ${CY + 18}
-       C${CX + 144} ${CY + 12}, ${CX + 148} ${CY}, ${CX + 155} ${CY - 8}
-       L${CX + 148} ${CY - 18} L${CX + 130} ${CY - 24}
-       L${CX + 106} ${CY - 28} L${CX + 74} ${CY - 22} L${CX + 40} ${CY - 8}
-       L${CX + 8} ${CY + 5} Z`,
-    delay: 140,
-  },
-  // Right low
-  {
-    d: `M${CX} ${CY + 3}
-       L${CX + 35} ${CY + 18} L${CX + 68} ${CY + 36} L${CX + 98} ${CY + 54}
-       L${CX + 118} ${CY + 70} L${CX + 128} ${CY + 86} L${CX + 130} ${CY + 102}
-       C${CX + 128} ${CY + 115}, ${CX + 118} ${CY + 118}, ${CX + 112} ${CY + 110}
-       C${CX + 106} ${CY + 100}, ${CX + 112} ${CY + 88}, ${CX + 120} ${CY + 80}
-       L${CX + 114} ${CY + 66} L${CX + 100} ${CY + 52}
-       L${CX + 76} ${CY + 38} L${CX + 48} ${CY + 22} L${CX + 20} ${CY + 10}
-       L${CX - 2} ${CY + 6} Z`,
-    delay: 230,
-  },
-
-  // ---- UPPER LEFT DIAGONAL ----
-  {
-    d: `M${CX - 2} ${CY}
-       L${CX - 20} ${CY - 22} L${CX - 42} ${CY - 52} L${CX - 62} ${CY - 78}
-       L${CX - 76} ${CY - 100} L${CX - 82} ${CY - 118} L${CX - 80} ${CY - 132}
-       C${CX - 76} ${CY - 144}, ${CX - 66} ${CY - 146}, ${CX - 60} ${CY - 138}
-       C${CX - 56} ${CY - 130}, ${CX - 62} ${CY - 120}, ${CX - 70} ${CY - 114}
-       L${CX - 68} ${CY - 98} L${CX - 58} ${CY - 78}
-       L${CX - 42} ${CY - 54} L${CX - 24} ${CY - 30} L${CX - 6} ${CY - 8}
-       L${CX + 3} ${CY + 5} Z`,
-    delay: 70,
-  },
-
-  // ---- UPPER RIGHT DIAGONAL ----
-  {
-    d: `M${CX + 2} ${CY}
-       L${CX + 22} ${CY - 24} L${CX + 46} ${CY - 56} L${CX + 68} ${CY - 82}
-       L${CX + 82} ${CY - 104} L${CX + 88} ${CY - 122} L${CX + 86} ${CY - 136}
-       C${CX + 82} ${CY - 148}, ${CX + 72} ${CY - 150}, ${CX + 66} ${CY - 142}
-       C${CX + 62} ${CY - 134}, ${CX + 68} ${CY - 124}, ${CX + 76} ${CY - 118}
-       L${CX + 74} ${CY - 102} L${CX + 64} ${CY - 82}
-       L${CX + 46} ${CY - 58} L${CX + 26} ${CY - 32} L${CX + 8} ${CY - 10}
-       L${CX - 2} ${CY + 4} Z`,
+    d: `M${CX} ${CY - W}
+       C${CX - 42} ${CY - W - 2}, ${CX - 95} ${CY - W + 8}, ${CX - 135} ${CY - W + 18}
+       C${CX - 158} ${CY - W + 25}, ${CX - 170} ${CY + 15}, ${CX - 168} ${CY}
+       C${CX - 166} ${CY - 14}, ${CX - 156} ${CY - 18}, ${CX - 152} ${CY - 8}
+       C${CX - 148} ${CY + 2}, ${CX - 152} ${CY + 10}, ${CX - 135} ${CY + W + 10}
+       C${CX - 95} ${CY + W + 2}, ${CX - 42} ${CY + W - 2}, ${CX} ${CY + W} Z`,
     delay: 160,
   },
+  // Left steep drop — goes sharply down-left
+  {
+    d: `M${CX} ${CY + W}
+       C${CX - 25} ${CY + W + 20}, ${CX - 55} ${CY + W + 55}, ${CX - 80} ${CY + W + 85}
+       C${CX - 95} ${CY + W + 100}, ${CX - 108} ${CY + 102}, ${CX - 112} ${CY + 88}
+       C${CX - 115} ${CY + 75}, ${CX - 105} ${CY + 70}, ${CX - 100} ${CY + 80}
+       C${CX - 95} ${CY + 90}, ${CX - 98} ${CY + 95}, ${CX - 78} ${CY - W + 82}
+       C${CX - 52} ${CY - W + 55}, ${CX - 25} ${CY - W + 22}, ${CX} ${CY - W} Z`,
+    delay: 240,
+  },
 
-  // ---- TOP PETALS ----
+  // ==== DROOPING RIGHT — mirror mass ====
+  // Far right drop
+  {
+    d: `M${CX} ${CY + W}
+       C${CX + 38} ${CY + W + 16}, ${CX + 85} ${CY + W + 48}, ${CX + 125} ${CY + W + 72}
+       C${CX + 150} ${CY + W + 84}, ${CX + 168} ${CY + 80}, ${CX + 170} ${CY + 64}
+       C${CX + 172} ${CY + 50}, ${CX + 160} ${CY + 46}, ${CX + 155} ${CY + 56}
+       C${CX + 150} ${CY + 66}, ${CX + 152} ${CY + 74}, ${CX + 135} ${CY - W + 68}
+       C${CX + 95} ${CY - W + 48}, ${CX + 42} ${CY - W + 20}, ${CX} ${CY - W} Z`,
+    delay: 40,
+  },
+  // Right mid-drop
+  {
+    d: `M${CX} ${CY + W}
+       C${CX + 42} ${CY + W + 12}, ${CX + 95} ${CY + W + 32}, ${CX + 135} ${CY + W + 44}
+       C${CX + 160} ${CY + W + 50}, ${CX + 175} ${CY + 40}, ${CX + 178} ${CY + 24}
+       C${CX + 178} ${CY + 10}, ${CX + 168} ${CY + 6}, ${CX + 162} ${CY + 16}
+       C${CX + 158} ${CY + 26}, ${CX + 162} ${CY + 34}, ${CX + 145} ${CY - W + 40}
+       C${CX + 105} ${CY - W + 28}, ${CX + 48} ${CY - W + 10}, ${CX} ${CY - W} Z`,
+    delay: 120,
+  },
+  // Right upper-drop
+  {
+    d: `M${CX} ${CY - W}
+       C${CX + 45} ${CY - W - 4}, ${CX + 100} ${CY - W + 5}, ${CX + 140} ${CY - W + 15}
+       C${CX + 162} ${CY - W + 22}, ${CX + 175} ${CY + 12}, ${CX + 172} ${CY - 2}
+       C${CX + 170} ${CY - 16}, ${CX + 160} ${CY - 20}, ${CX + 156} ${CY - 10}
+       C${CX + 152} ${CY}, ${CX + 156} ${CY + 8}, ${CX + 140} ${CY + W + 8}
+       C${CX + 100} ${CY + W}, ${CX + 45} ${CY + W - 4}, ${CX} ${CY + W} Z`,
+    delay: 200,
+  },
+  // Right steep drop
+  {
+    d: `M${CX} ${CY + W}
+       C${CX + 28} ${CY + W + 22}, ${CX + 58} ${CY + W + 58}, ${CX + 85} ${CY + W + 88}
+       C${CX + 100} ${CY + W + 104}, ${CX + 112} ${CY + 105}, ${CX + 116} ${CY + 90}
+       C${CX + 118} ${CY + 78}, ${CX + 108} ${CY + 72}, ${CX + 104} ${CY + 82}
+       C${CX + 100} ${CY + 92}, ${CX + 102} ${CY + 98}, ${CX + 82} ${CY - W + 85}
+       C${CX + 56} ${CY - W + 58}, ${CX + 28} ${CY - W + 24}, ${CX} ${CY - W} Z`,
+    delay: 280,
+  },
+
+  // ==== UPPER — spreading out wide at various angles ====
+  // Upper far-left — goes up and out left, curls back
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 15} ${CY - 18}, ${CX - W - 45} ${CY - 45}, ${CX - W - 78} ${CY - 62}
+       C${CX - W - 100} ${CY - 72}, ${CX - W - 118} ${CY - 68}, ${CX - W - 125} ${CY - 52}
+       C${CX - W - 130} ${CY - 38}, ${CX - W - 120} ${CY - 32}, ${CX - W - 112} ${CY - 42}
+       C${CX - W - 105} ${CY - 52}, ${CX - W - 108} ${CY - 58}, ${CX + W - 95} ${CY - 55}
+       C${CX + W - 60} ${CY - 42}, ${CX + W - 25} ${CY - 20}, ${CX + W} ${CY} Z`,
+    delay: 60,
+  },
+  // Upper far-right — mirror
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 18} ${CY - 20}, ${CX + W + 48} ${CY - 48}, ${CX + W + 82} ${CY - 66}
+       C${CX + W + 105} ${CY - 76}, ${CX + W + 122} ${CY - 72}, ${CX + W + 130} ${CY - 55}
+       C${CX + W + 135} ${CY - 42}, ${CX + W + 125} ${CY - 34}, ${CX + W + 116} ${CY - 44}
+       C${CX + W + 108} ${CY - 54}, ${CX + W + 112} ${CY - 62}, ${CX - W + 100} ${CY - 58}
+       C${CX - W + 65} ${CY - 45}, ${CX - W + 28} ${CY - 22}, ${CX - W} ${CY} Z`,
+    delay: 130,
+  },
+  // Upper-left diagonal — steeper
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 10} ${CY - 25}, ${CX - W - 28} ${CY - 62}, ${CX - W - 42} ${CY - 95}
+       C${CX - W - 52} ${CY - 118}, ${CX - W - 48} ${CY - 140}, ${CX - W - 35} ${CY - 148}
+       C${CX - W - 22} ${CY - 155}, ${CX - W - 12} ${CY - 145}, ${CX - W - 16} ${CY - 132}
+       C${CX - W - 20} ${CY - 120}, ${CX - W - 28} ${CY - 115}, ${CX + W - 38} ${CY - 100}
+       C${CX + W - 25} ${CY - 65}, ${CX + W - 8} ${CY - 28}, ${CX + W} ${CY} Z`,
+    delay: 100,
+  },
+  // Upper-right diagonal — steeper
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 12} ${CY - 28}, ${CX + W + 32} ${CY - 65}, ${CX + W + 48} ${CY - 98}
+       C${CX + W + 58} ${CY - 122}, ${CX + W + 54} ${CY - 144}, ${CX + W + 40} ${CY - 152}
+       C${CX + W + 28} ${CY - 158}, ${CX + W + 16} ${CY - 148}, ${CX + W + 20} ${CY - 135}
+       C${CX + W + 24} ${CY - 122}, ${CX + W + 32} ${CY - 118}, ${CX - W + 42} ${CY - 104}
+       C${CX - W + 28} ${CY - 68}, ${CX - W + 10} ${CY - 30}, ${CX - W} ${CY} Z`,
+    delay: 190,
+  },
   // Top left-lean
   {
-    d: `M${CX - 1} ${CY}
-       L${CX - 10} ${CY - 28} L${CX - 18} ${CY - 65} L${CX - 24} ${CY - 102}
-       L${CX - 26} ${CY - 132} L${CX - 22} ${CY - 155} L${CX - 14} ${CY - 170}
-       C${CX - 6} ${CY - 180}, ${CX + 2} ${CY - 176}, ${CX + 2} ${CY - 166}
-       C${CX + 2} ${CY - 156}, ${CX - 8} ${CY - 152}, ${CX - 16} ${CY - 148}
-       L${CX - 18} ${CY - 132} L${CX - 16} ${CY - 105}
-       L${CX - 12} ${CY - 68} L${CX - 4} ${CY - 32} L${CX + 4} ${CY - 4}
-       L${CX + 3} ${CY + 5} Z`,
-    delay: 40,
+    d: `M${CX - W} ${CY}
+       C${CX - W - 3} ${CY - 30}, ${CX - W - 10} ${CY - 72}, ${CX - W - 14} ${CY - 108}
+       C${CX - W - 16} ${CY - 132}, ${CX - W - 8} ${CY - 150}, ${CX + 2} ${CY - 155}
+       C${CX + 10} ${CY - 158}, ${CX + 14} ${CY - 148}, ${CX + 10} ${CY - 135}
+       C${CX + 6} ${CY - 122}, ${CX - 2} ${CY - 118}, ${CX + W - 10} ${CY - 105}
+       C${CX + W - 6} ${CY - 72}, ${CX + W - 1} ${CY - 30}, ${CX + W} ${CY} Z`,
+    delay: 50,
   },
   // Top right-lean
   {
-    d: `M${CX + 1} ${CY}
-       L${CX + 12} ${CY - 30} L${CX + 22} ${CY - 68} L${CX + 30} ${CY - 106}
-       L${CX + 34} ${CY - 138} L${CX + 30} ${CY - 160} L${CX + 22} ${CY - 175}
-       C${CX + 14} ${CY - 185}, ${CX + 4} ${CY - 182}, ${CX + 4} ${CY - 172}
-       C${CX + 4} ${CY - 162}, ${CX + 14} ${CY - 156}, ${CX + 22} ${CY - 152}
-       L${CX + 24} ${CY - 138} L${CX + 22} ${CY - 108}
-       L${CX + 16} ${CY - 72} L${CX + 8} ${CY - 34} L${CX} ${CY - 6}
-       L${CX - 2} ${CY + 4} Z`,
-    delay: 110,
+    d: `M${CX + W} ${CY}
+       C${CX + W + 5} ${CY - 32}, ${CX + W + 14} ${CY - 75}, ${CX + W + 18} ${CY - 112}
+       C${CX + W + 20} ${CY - 135}, ${CX + W + 12} ${CY - 152}, ${CX + 2} ${CY - 158}
+       C${CX - 8} ${CY - 162}, ${CX - 12} ${CY - 152}, ${CX - 8} ${CY - 138}
+       C${CX - 4} ${CY - 125}, ${CX + 4} ${CY - 120}, ${CX - W + 14} ${CY - 108}
+       C${CX - W + 10} ${CY - 75}, ${CX - W + 3} ${CY - 32}, ${CX - W} ${CY} Z`,
+    delay: 150,
   },
-  // Top center-left narrow
+  // Top center
   {
-    d: `M${CX - 1} ${CY}
-       L${CX - 6} ${CY - 22} L${CX - 14} ${CY - 55} L${CX - 24} ${CY - 88}
-       L${CX - 36} ${CY - 115} L${CX - 42} ${CY - 135} L${CX - 42} ${CY - 150}
-       C${CX - 38} ${CY - 162}, ${CX - 28} ${CY - 164}, ${CX - 24} ${CY - 155}
-       C${CX - 20} ${CY - 146}, ${CX - 28} ${CY - 138}, ${CX - 35} ${CY - 132}
-       L${CX - 32} ${CY - 115} L${CX - 22} ${CY - 90}
-       L${CX - 12} ${CY - 58} L${CX - 4} ${CY - 26} L${CX + 4} ${CY - 2}
-       Z`,
-    delay: 200,
-  },
-  // Top center-right narrow
-  {
-    d: `M${CX + 1} ${CY}
-       L${CX + 8} ${CY - 24} L${CX + 18} ${CY - 58} L${CX + 30} ${CY - 92}
-       L${CX + 42} ${CY - 118} L${CX + 48} ${CY - 138} L${CX + 48} ${CY - 152}
-       C${CX + 44} ${CY - 164}, ${CX + 34} ${CY - 166}, ${CX + 30} ${CY - 158}
-       C${CX + 26} ${CY - 148}, ${CX + 34} ${CY - 140}, ${CX + 42} ${CY - 135}
-       L${CX + 38} ${CY - 118} L${CX + 28} ${CY - 94}
-       L${CX + 16} ${CY - 62} L${CX + 6} ${CY - 28} L${CX - 2} ${CY - 4}
-       Z`,
-    delay: 260,
-  },
-
-  // ---- EXTRA DENSITY PETALS ----
-  // Left far-upper — tighter angle
-  {
-    d: `M${CX - 1} ${CY - 1}
-       L${CX - 28} ${CY - 18} L${CX - 58} ${CY - 42} L${CX - 85} ${CY - 58}
-       L${CX - 108} ${CY - 66} L${CX - 124} ${CY - 64} L${CX - 134} ${CY - 52}
-       C${CX - 140} ${CY - 40}, ${CX - 134} ${CY - 30}, ${CX - 124} ${CY - 32}
-       C${CX - 116} ${CY - 34}, ${CX - 118} ${CY - 44}, ${CX - 124} ${CY - 50}
-       L${CX - 114} ${CY - 54} L${CX - 98} ${CY - 52}
-       L${CX - 75} ${CY - 44} L${CX - 50} ${CY - 30} L${CX - 25} ${CY - 12}
-       L${CX + 2} ${CY + 5} Z`,
-    delay: 280,
-  },
-  // Right far-upper
-  {
-    d: `M${CX + 1} ${CY - 1}
-       L${CX + 30} ${CY - 20} L${CX + 62} ${CY - 46} L${CX + 90} ${CY - 62}
-       L${CX + 112} ${CY - 70} L${CX + 128} ${CY - 68} L${CX + 138} ${CY - 56}
-       C${CX + 144} ${CY - 44}, ${CX + 138} ${CY - 34}, ${CX + 128} ${CY - 36}
-       C${CX + 120} ${CY - 38}, ${CX + 122} ${CY - 48}, ${CX + 128} ${CY - 54}
-       L${CX + 118} ${CY - 58} L${CX + 102} ${CY - 56}
-       L${CX + 80} ${CY - 48} L${CX + 54} ${CY - 34} L${CX + 28} ${CY - 14}
-       L${CX - 1} ${CY + 4} Z`,
-    delay: 310,
+    d: `M${CX - W} ${CY}
+       C${CX - W} ${CY - 28}, ${CX - W - 3} ${CY - 65}, ${CX - W - 5} ${CY - 98}
+       C${CX - W - 6} ${CY - 120}, ${CX - W} ${CY - 138}, ${CX + 2} ${CY - 142}
+       C${CX + W + 2} ${CY - 145}, ${CX + W + 5} ${CY - 135}, ${CX + W + 3} ${CY - 122}
+       C${CX + W} ${CY - 108}, ${CX + W - 2} ${CY - 102}, ${CX + W} ${CY - 85}
+       C${CX + W} ${CY - 58}, ${CX + W} ${CY - 28}, ${CX + W} ${CY} Z`,
+    delay: 220,
   },
 ];
 

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -194,28 +194,28 @@ const petals: { d: string; delay: number }[] = [
 
 const petalDelays = petals.map((p) => p.delay);
 
-// Stamens: smooth wide U-arcs. Tips staggered naturally around petal height.
-// Outer ones have a gentler, shallower curve. Inner ones arc higher.
+// Stamens: smooth wide U-arcs. All control points stay above CY (the center)
+// so nothing dips below the flower neck. Tips staggered naturally.
 const stamens = [
-  // ==== OUTERMOST — very wide, shallow gentle curve, tips a bit lower ====
-  { d: `M${CX} ${CY - 8} C${CX - 140} ${CY + 10}, ${CX - 278} ${CY + 8}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 550 },
-  { d: `M${CX} ${CY - 8} C${CX + 138} ${CY + 6}, ${CX + 274} ${CY + 5}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 600 },
+  // ==== OUTERMOST — wide, shallow curve, control points above center ====
+  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 550 },
+  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 600 },
 
-  // ==== WIDE — slightly higher tips ====
-  { d: `M${CX} ${CY - 8} C${CX - 115} ${CY - 2}, ${CX - 250} ${CY - 8}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 650 },
-  { d: `M${CX} ${CY - 8} C${CX + 112} ${CY - 5}, ${CX + 246} ${CY - 12}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 700 },
+  // ==== WIDE ====
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 650 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 700 },
 
-  // ==== MID-WIDE — tips near petal height ====
-  { d: `M${CX} ${CY - 8} C${CX - 72} ${CY - 28}, ${CX - 195} ${CY - 60}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 750 },
-  { d: `M${CX} ${CY - 8} C${CX + 70} ${CY - 30}, ${CX + 192} ${CY - 65}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 800 },
+  // ==== MID-WIDE ====
+  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 750 },
+  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 800 },
 
-  // ==== UPPER — tips at petal height ====
-  { d: `M${CX} ${CY - 8} C${CX - 45} ${CY - 50}, ${CX - 138} ${CY - 120}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 850 },
-  { d: `M${CX} ${CY - 8} C${CX + 42} ${CY - 52}, ${CX + 135} ${CY - 125}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 900 },
+  // ==== UPPER ====
+  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 850 },
+  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 900 },
 
-  // ==== CENTER — tallest, just above petal height ====
-  { d: `M${CX} ${CY - 8} C${CX - 20} ${CY - 65}, ${CX - 62} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 950 },
-  { d: `M${CX} ${CY - 8} C${CX + 18} ${CY - 68}, ${CX + 60} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 1000 },
+  // ==== CENTER ====
+  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 950 },
+  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 1000 },
 ];
 
 const SpiderLily = ({ className }: { className?: string }) => {
@@ -263,20 +263,6 @@ const SpiderLily = ({ className }: { className?: string }) => {
         <path
           d={`M195 580 C198 520, 205 445, 212 380 C218 320, 220 275, ${CX} ${CY + 15}`}
           className={`spider-lily-stem ${bloomed ? 'spider-lily-stem-active' : ''}`}
-          pathLength={1}
-        />
-
-        {/* Bracts */}
-        <path
-          d={`M${CX - 2} ${CY + 8} C${CX - 10} ${CY + 20}, ${CX - 16} ${CY + 35}, ${CX - 20} ${CY + 52}`}
-          className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
-          style={{ animationDelay: '120ms' }}
-          pathLength={1}
-        />
-        <path
-          d={`M${CX + 2} ${CY + 8} C${CX + 8} ${CY + 20}, ${CX + 12} ${CY + 35}, ${CX + 14} ${CY + 52}`}
-          className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
-          style={{ animationDelay: '150ms' }}
           pathLength={1}
         />
 

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -167,31 +167,20 @@ const PETAL_DELAY = STEM_DELAY + STEM_DURATION;
 const STAMEN_DELAY = PETAL_DELAY + 300;
 const STAMEN_DURATION = 600;
 
-const HOVER_RADIUS = 120;
-const HOVER_STRENGTH = 12;
-const LERP_SPEED = 0.08;
-const RETURN_SPEED = 0.06;
+const HOVER_RADIUS = 140;
+const HOVER_STRENGTH = 8;
+const LERP_SPEED = 0.045;
+const RETURN_SPEED = 0.025;
 
-const WIND_SPEED = 0.0006;
-const WIND_STRENGTH_X = 2.5;
-const WIND_STRENGTH_Y = 1.0;
+const WIND_SPEED = 0.0005;
+const WIND_STRENGTH_X = 1.8;
+const WIND_STRENGTH_Y = 0.7;
+
+const PRESS_RADIUS = 160;
+const PRESS_STRENGTH = 20;
 
 type Vec2 = { x: number; y: number };
 
-function computeDisplacement(
-  elCx: number,
-  elCy: number,
-  mouseX: number,
-  mouseY: number,
-): Vec2 {
-  const dx = elCx - mouseX;
-  const dy = elCy - mouseY;
-  const dist = Math.sqrt(dx * dx + dy * dy);
-  if (dist > HOVER_RADIUS || dist < 0.1) return { x: 0, y: 0 };
-  const factor = (1 - dist / HOVER_RADIUS) ** 2;
-  const norm = HOVER_STRENGTH * factor;
-  return { x: (dx / dist) * norm, y: (dy / dist) * norm };
-}
 
 const SpiderLily = ({ className }: { className?: string }) => {
   const [stemActive, setStemActive] = useState(false);
@@ -199,12 +188,13 @@ const SpiderLily = ({ className }: { className?: string }) => {
   const [stamensActive, setStamensActive] = useState(false);
 
   const svgRef = useRef<SVGSVGElement>(null);
-  const mouseRef = useRef<{ x: number; y: number; active: boolean }>({ x: 0, y: 0, active: false });
+  const mouseRef = useRef<{ x: number; y: number; active: boolean; pressed: boolean }>({ x: 0, y: 0, active: false, pressed: false });
   const petalOffsetsRef = useRef<Vec2[]>(petals.map(() => ({ x: 0, y: 0 })));
   const stamenOffsetsRef = useRef<Vec2[]>(stamens.map(() => ({ x: 0, y: 0 })));
   const petalElsRef = useRef<(SVGPathElement | null)[]>([]);
   const stamenGroupElsRef = useRef<(SVGGElement | null)[]>([]);
   const wholeFlowerRef = useRef<SVGGElement>(null);
+  const leanRef = useRef(0);
   const rafRef = useRef<number>(0);
 
   useEffect(() => {
@@ -228,22 +218,50 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
     const coords = toSVGCoords(e.clientX, e.clientY);
-    mouseRef.current = { x: coords.x, y: coords.y, active: true };
+    mouseRef.current.x = coords.x;
+    mouseRef.current.y = coords.y;
+    mouseRef.current.active = true;
   }, [toSVGCoords]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    const coords = toSVGCoords(e.clientX, e.clientY);
+    mouseRef.current.x = coords.x;
+    mouseRef.current.y = coords.y;
+    mouseRef.current.active = true;
+    mouseRef.current.pressed = true;
+  }, [toSVGCoords]);
+
+  const handleMouseUp = useCallback(() => {
+    mouseRef.current.pressed = false;
+  }, []);
 
   const handleMouseLeave = useCallback(() => {
     mouseRef.current.active = false;
+    mouseRef.current.pressed = false;
   }, []);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    const coords = toSVGCoords(touch.clientX, touch.clientY);
+    mouseRef.current.x = coords.x;
+    mouseRef.current.y = coords.y;
+    mouseRef.current.active = true;
+    mouseRef.current.pressed = true;
+  }, [toSVGCoords]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const touch = e.touches[0];
     if (!touch) return;
     const coords = toSVGCoords(touch.clientX, touch.clientY);
-    mouseRef.current = { x: coords.x, y: coords.y, active: true };
+    mouseRef.current.x = coords.x;
+    mouseRef.current.y = coords.y;
+    mouseRef.current.active = true;
   }, [toSVGCoords]);
 
   const handleTouchEnd = useCallback(() => {
     mouseRef.current.active = false;
+    mouseRef.current.pressed = false;
   }, []);
 
   useEffect(() => {
@@ -257,18 +275,28 @@ const SpiderLily = ({ className }: { className?: string }) => {
       const mouse = mouseRef.current;
       const petalOffsets = petalOffsetsRef.current;
       const stamenOffsets = stamenOffsetsRef.current;
+      const strength = mouse.pressed ? PRESS_STRENGTH : HOVER_STRENGTH;
+      const radius = mouse.pressed ? PRESS_RADIUS : HOVER_RADIUS;
 
       for (let i = 0; i < petals.length; i++) {
         const phase = petalPhases[i];
         const windX = Math.sin(t + phase) * WIND_STRENGTH_X + Math.sin(t * 1.7 + phase * 0.6) * WIND_STRENGTH_X * 0.3;
         const windY = Math.cos(t * 0.8 + phase * 1.3) * WIND_STRENGTH_Y;
 
-        const hover = mouse.active
-          ? computeDisplacement(petals[i].cx, petals[i].cy, mouse.x, mouse.y)
-          : { x: 0, y: 0 };
+        let pushX = 0, pushY = 0;
+        if (mouse.active) {
+          const dx = petals[i].cx - mouse.x;
+          const dy = petals[i].cy - mouse.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < radius && dist > 0.1) {
+            const factor = (1 - dist / radius) ** 2;
+            pushX = (dx / dist) * strength * factor;
+            pushY = (dy / dist) * strength * factor;
+          }
+        }
 
-        const targetX = windX + hover.x;
-        const targetY = windY + hover.y;
+        const targetX = windX + pushX;
+        const targetY = windY + pushY;
         const speed = mouse.active ? LERP_SPEED : RETURN_SPEED;
 
         petalOffsets[i] = {
@@ -286,12 +314,20 @@ const SpiderLily = ({ className }: { className?: string }) => {
         const windX = Math.sin(t + phase) * WIND_STRENGTH_X * 1.2 + Math.sin(t * 1.4 + phase * 0.8) * WIND_STRENGTH_X * 0.4;
         const windY = Math.cos(t * 0.7 + phase * 1.1) * WIND_STRENGTH_Y * 0.8;
 
-        const hover = mouse.active
-          ? computeDisplacement(stamens[i].cx, stamens[i].cy, mouse.x, mouse.y)
-          : { x: 0, y: 0 };
+        let pushX = 0, pushY = 0;
+        if (mouse.active) {
+          const dx = stamens[i].cx - mouse.x;
+          const dy = stamens[i].cy - mouse.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < radius && dist > 0.1) {
+            const factor = (1 - dist / radius) ** 2;
+            pushX = (dx / dist) * strength * factor * 1.2;
+            pushY = (dy / dist) * strength * factor * 1.2;
+          }
+        }
 
-        const targetX = windX + hover.x;
-        const targetY = windY + hover.y;
+        const targetX = windX + pushX;
+        const targetY = windY + pushY;
         const speed = mouse.active ? LERP_SPEED : RETURN_SPEED;
 
         stamenOffsets[i] = {
@@ -304,9 +340,19 @@ const SpiderLily = ({ className }: { className?: string }) => {
         }
       }
 
+      let leanTarget = 0;
+      if (mouse.active && mouse.pressed) {
+        const side = mouse.x < CX ? -1 : 1;
+        const dx = Math.abs(mouse.x - CX);
+        const dy = Math.abs(mouse.y - CY);
+        const proximity = Math.max(0, 1 - Math.sqrt(dx * dx + dy * dy) / PRESS_RADIUS);
+        leanTarget = side * proximity * 3.5;
+      }
+      leanRef.current += (leanTarget - leanRef.current) * (mouse.active ? 0.03 : 0.015);
+
       const flowerEl = wholeFlowerRef.current;
       if (flowerEl) {
-        const swayAngle = Math.sin(t * 0.8) * 0.6 + Math.sin(t * 1.3) * 0.25;
+        const swayAngle = Math.sin(t * 0.8) * 0.5 + Math.sin(t * 1.3) * 0.2 + leanRef.current;
         flowerEl.setAttribute('transform', `rotate(${swayAngle.toFixed(3)} ${CX} 598)`);
       }
 
@@ -325,7 +371,10 @@ const SpiderLily = ({ className }: { className?: string }) => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       onMouseMove={handleMouseMove}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
+      onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -151,21 +151,21 @@ const petalDelays = petals.map((p) => p.delay);
 // so nothing dips below the flower neck. Tips staggered naturally.
 const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean }[] = [
   // ==== OUTER cluster (dense, wide fan) ====
-  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 3.8, tipW: 2.4, noTip: true },
-  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 3.7, tipW: 2.5 },
-  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 3.6, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 3.4, tipW: 2.6, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 5.2, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 5.0, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 4.8, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 4.6, tipW: 2.6 },
 
-  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 3.6, tipW: 2.5 },
-  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 3.8, tipW: 2.4, noTip: true },
-  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 3.7, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 3.9, tipW: 2.3 },
+  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 4.9, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 5.1, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 5.0, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 5.3, tipW: 2.3 },
 
   // ==== MIDDLE (sparse) ====
-  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 3.6, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 3.4, tipW: 2.6, noTip: true },
-  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 3.8, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 3.5, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 4.8, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 4.6, tipW: 2.6 },
+  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 5.1, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 4.7, tipW: 2.5 },
 ];
 
 const STEM_DELAY = 150;
@@ -215,6 +215,13 @@ const SpiderLily = ({ className }: { className?: string }) => {
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
+        <filter id="petal-glow" x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="softGlow" />
+          <feMerge>
+            <feMergeNode in="softGlow" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
       </defs>
 
       <g filter="url(#ink-texture)">
@@ -233,8 +240,8 @@ const SpiderLily = ({ className }: { className?: string }) => {
           className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
         />
 
-        {/* Flower head — subtle lean */}
-        <g transform={`rotate(-4 ${CX} ${CY})`}>
+        {/* Flower head — subtle lean + ethereal glow */}
+        <g transform={`rotate(-4 ${CX} ${CY})`} filter="url(#petal-glow)">
           {/* Petals */}
           {petals.map((p, i) => (
             <path

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -215,10 +215,12 @@ const SpiderLily = ({ className }: { className?: string }) => {
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
-        <filter id="petal-glow" x="-20%" y="-20%" width="140%" height="140%">
-          <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="softGlow" />
+        <filter id="petal-glow" x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="wideGlow" />
+          <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="tightGlow" />
           <feMerge>
-            <feMergeNode in="softGlow" />
+            <feMergeNode in="wideGlow" />
+            <feMergeNode in="tightGlow" />
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -11,7 +11,7 @@ const CY = 230;
 
 // Hand-drawn ribbon petals — thin, organic, dome-shaped arrangement.
 // W = half-width of ribbon. Kept narrow for paper/ribbon feel.
-const W = 3;
+const W = 4;
 const petals: { d: string; delay: number }[] = [
   // ==== UPPER DOME — organic ribbon petals, tips tracing a dome arc ====
 

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -13,134 +13,134 @@ const CY = 230;
 // W = half-width of ribbon. Kept narrow for paper/ribbon feel.
 const W = 4;
 const petals: { d: string; delay: number }[] = [
-  // ==== UPPER DOME — organic ribbon petals, tips tracing a dome arc ====
+  // ==== UPPER DOME — organic ribbon petals with natural irregularity ====
 
-  // Top center — straight up
+  // Top center — leans very slightly left
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 1} ${CY - 40}, ${CX - W - 3} ${CY - 85}, ${CX - W - 2} ${CY - 125}
-       C${CX - W - 1} ${CY - 145}, ${CX} ${CY - 156}, ${CX} ${CY - 158}
-       C${CX} ${CY - 156}, ${CX + W + 1} ${CY - 145}, ${CX + W} ${CY - 125}
-       C${CX + W - 1} ${CY - 85}, ${CX + W + 1} ${CY - 40}, ${CX + W} ${CY} Z`,
+       C${CX - W - 2} ${CY - 38}, ${CX - W - 5} ${CY - 82}, ${CX - W - 4} ${CY - 122}
+       C${CX - W - 3} ${CY - 144}, ${CX - 1} ${CY - 157}, ${CX - 1} ${CY - 160}
+       C${CX} ${CY - 157}, ${CX + W} ${CY - 143}, ${CX + W - 1} ${CY - 124}
+       C${CX + W} ${CY - 88}, ${CX + W + 2} ${CY - 42}, ${CX + W} ${CY} Z`,
     delay: 0,
   },
-  // Left ~20°
+  // Left ~18°
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 6} ${CY - 35}, ${CX - W - 18} ${CY - 78}, ${CX - W - 30} ${CY - 118}
-       C${CX - W - 38} ${CY - 140}, ${CX - W - 24} ${CY - 154}, ${CX - W - 18} ${CY - 155}
-       L${CX + W - 24} ${CY - 152}
-       C${CX + W - 22} ${CY - 138}, ${CX + W - 18} ${CY - 112}, ${CX + W - 14} ${CY - 76}
-       C${CX + W - 4} ${CY - 35}, ${CX + W} ${CY - 10}, ${CX + W} ${CY} Z`,
+       C${CX - W - 5} ${CY - 33}, ${CX - W - 16} ${CY - 75}, ${CX - W - 28} ${CY - 115}
+       C${CX - W - 36} ${CY - 138}, ${CX - W - 23} ${CY - 153}, ${CX - W - 16} ${CY - 156}
+       L${CX + W - 22} ${CY - 153}
+       C${CX + W - 20} ${CY - 136}, ${CX + W - 17} ${CY - 108}, ${CX + W - 12} ${CY - 74}
+       C${CX + W - 3} ${CY - 37}, ${CX + W + 1} ${CY - 12}, ${CX + W} ${CY} Z`,
     delay: 60,
   },
-  // Right ~20°
+  // Right ~22°
   {
     d: `M${CX + W} ${CY}
-       C${CX + W + 7} ${CY - 36}, ${CX + W + 20} ${CY - 80}, ${CX + W + 34} ${CY - 120}
-       C${CX + W + 42} ${CY - 142}, ${CX + W + 28} ${CY - 156}, ${CX + W + 22} ${CY - 158}
-       L${CX - W + 28} ${CY - 155}
-       C${CX - W + 26} ${CY - 140}, ${CX - W + 22} ${CY - 115}, ${CX - W + 18} ${CY - 78}
-       C${CX - W + 6} ${CY - 36}, ${CX - W} ${CY - 10}, ${CX - W} ${CY} Z`,
+       C${CX + W + 8} ${CY - 34}, ${CX + W + 22} ${CY - 78}, ${CX + W + 36} ${CY - 118}
+       C${CX + W + 44} ${CY - 141}, ${CX + W + 30} ${CY - 155}, ${CX + W + 23} ${CY - 157}
+       L${CX - W + 29} ${CY - 153}
+       C${CX - W + 27} ${CY - 139}, ${CX - W + 23} ${CY - 113}, ${CX - W + 19} ${CY - 76}
+       C${CX - W + 7} ${CY - 38}, ${CX - W + 1} ${CY - 11}, ${CX - W} ${CY} Z`,
     delay: 100,
   },
-  // Left ~42°
+  // Left ~40°
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 14} ${CY - 26}, ${CX - W - 38} ${CY - 62}, ${CX - W - 62} ${CY - 98}
-       C${CX - W - 78} ${CY - 122}, ${CX - W - 64} ${CY - 140}, ${CX - W - 56} ${CY - 142}
-       L${CX + W - 62} ${CY - 139}
-       C${CX + W - 58} ${CY - 122}, ${CX + W - 50} ${CY - 95}, ${CX + W - 34} ${CY - 60}
-       C${CX + W - 12} ${CY - 26}, ${CX + W} ${CY - 8}, ${CX + W} ${CY} Z`,
+       C${CX - W - 13} ${CY - 24}, ${CX - W - 36} ${CY - 58}, ${CX - W - 60} ${CY - 95}
+       C${CX - W - 76} ${CY - 120}, ${CX - W - 63} ${CY - 139}, ${CX - W - 54} ${CY - 143}
+       L${CX + W - 60} ${CY - 140}
+       C${CX + W - 57} ${CY - 120}, ${CX + W - 48} ${CY - 92}, ${CX + W - 33} ${CY - 58}
+       C${CX + W - 11} ${CY - 25}, ${CX + W + 1} ${CY - 9}, ${CX + W} ${CY} Z`,
     delay: 140,
   },
-  // Right ~42°
+  // Right ~44°
   {
     d: `M${CX + W} ${CY}
-       C${CX + W + 16} ${CY - 28}, ${CX + W + 42} ${CY - 65}, ${CX + W + 66} ${CY - 100}
-       C${CX + W + 82} ${CY - 124}, ${CX + W + 68} ${CY - 142}, ${CX + W + 60} ${CY - 144}
-       L${CX - W + 66} ${CY - 141}
-       C${CX - W + 62} ${CY - 124}, ${CX - W + 54} ${CY - 98}, ${CX - W + 38} ${CY - 62}
-       C${CX - W + 14} ${CY - 28}, ${CX - W} ${CY - 8}, ${CX - W} ${CY} Z`,
+       C${CX + W + 17} ${CY - 27}, ${CX + W + 44} ${CY - 63}, ${CX + W + 68} ${CY - 98}
+       C${CX + W + 84} ${CY - 123}, ${CX + W + 70} ${CY - 141}, ${CX + W + 62} ${CY - 145}
+       L${CX - W + 68} ${CY - 142}
+       C${CX - W + 64} ${CY - 123}, ${CX - W + 56} ${CY - 96}, ${CX - W + 40} ${CY - 61}
+       C${CX - W + 15} ${CY - 27}, ${CX - W + 1} ${CY - 9}, ${CX - W} ${CY} Z`,
     delay: 180,
   },
-  // Left ~62°
+  // Left ~60°
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 20} ${CY - 18}, ${CX - W - 55} ${CY - 42}, ${CX - W - 88} ${CY - 66}
-       C${CX - W - 108} ${CY - 82}, ${CX - W - 100} ${CY - 102}, ${CX - W - 95} ${CY - 105}
-       L${CX + W - 100} ${CY - 102}
-       C${CX + W - 95} ${CY - 85}, ${CX + W - 82} ${CY - 62}, ${CX + W - 50} ${CY - 40}
-       C${CX + W - 18} ${CY - 18}, ${CX + W} ${CY - 5}, ${CX + W} ${CY} Z`,
+       C${CX - W - 19} ${CY - 16}, ${CX - W - 52} ${CY - 39}, ${CX - W - 85} ${CY - 63}
+       C${CX - W - 106} ${CY - 80}, ${CX - W - 98} ${CY - 100}, ${CX - W - 92} ${CY - 104}
+       L${CX + W - 97} ${CY - 100}
+       C${CX + W - 93} ${CY - 83}, ${CX + W - 80} ${CY - 60}, ${CX + W - 48} ${CY - 38}
+       C${CX + W - 17} ${CY - 17}, ${CX + W + 1} ${CY - 5}, ${CX + W} ${CY} Z`,
     delay: 220,
   },
-  // Right ~62°
+  // Right ~64°
   {
     d: `M${CX + W} ${CY}
-       C${CX + W + 22} ${CY - 20}, ${CX + W + 58} ${CY - 44}, ${CX + W + 92} ${CY - 68}
-       C${CX + W + 112} ${CY - 84}, ${CX + W + 104} ${CY - 104}, ${CX + W + 100} ${CY - 108}
-       L${CX - W + 104} ${CY - 105}
-       C${CX - W + 100} ${CY - 88}, ${CX - W + 86} ${CY - 65}, ${CX - W + 54} ${CY - 42}
-       C${CX - W + 20} ${CY - 20}, ${CX - W} ${CY - 5}, ${CX - W} ${CY} Z`,
+       C${CX + W + 24} ${CY - 19}, ${CX + W + 60} ${CY - 43}, ${CX + W + 94} ${CY - 67}
+       C${CX + W + 114} ${CY - 83}, ${CX + W + 106} ${CY - 103}, ${CX + W + 101} ${CY - 107}
+       L${CX - W + 106} ${CY - 103}
+       C${CX - W + 102} ${CY - 87}, ${CX - W + 88} ${CY - 64}, ${CX - W + 56} ${CY - 41}
+       C${CX - W + 22} ${CY - 19}, ${CX - W + 1} ${CY - 6}, ${CX - W} ${CY} Z`,
     delay: 250,
   },
-  // Left ~80° — nearly horizontal
+  // Left ~78° — nearly horizontal, slight droop
   {
     d: `M${CX} ${CY - W}
-       C${CX - 28} ${CY - W - 4}, ${CX - 72} ${CY - W - 10}, ${CX - 115} ${CY - W - 12}
-       C${CX - 142} ${CY - W - 12}, ${CX - 156} ${CY - 22}, ${CX - 158} ${CY - 28}
-       L${CX - 155} ${CY + W - 22}
-       C${CX - 142} ${CY + W - 12}, ${CX - 112} ${CY + W - 6}, ${CX - 72} ${CY + W - 2}
-       C${CX - 28} ${CY + W}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
+       C${CX - 26} ${CY - W - 3}, ${CX - 68} ${CY - W - 8}, ${CX - 112} ${CY - W - 10}
+       C${CX - 140} ${CY - W - 11}, ${CX - 154} ${CY - 20}, ${CX - 157} ${CY - 27}
+       L${CX - 154} ${CY + W - 21}
+       C${CX - 140} ${CY + W - 11}, ${CX - 108} ${CY + W - 4}, ${CX - 70} ${CY + W}
+       C${CX - 30} ${CY + W + 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
     delay: 40,
   },
-  // Right ~80° — nearly horizontal
+  // Right ~82° — nearly horizontal, slight lift
   {
     d: `M${CX} ${CY - W}
-       C${CX + 30} ${CY - W - 5}, ${CX + 76} ${CY - W - 12}, ${CX + 120} ${CY - W - 14}
-       C${CX + 148} ${CY - W - 13}, ${CX + 162} ${CY - 24}, ${CX + 164} ${CY - 30}
-       L${CX + 161} ${CY + W - 24}
-       C${CX + 148} ${CY + W - 13}, ${CX + 118} ${CY + W - 8}, ${CX + 76} ${CY + W - 3}
-       C${CX + 30} ${CY + W - 1}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
+       C${CX + 32} ${CY - W - 6}, ${CX + 78} ${CY - W - 13}, ${CX + 122} ${CY - W - 16}
+       C${CX + 150} ${CY - W - 15}, ${CX + 164} ${CY - 25}, ${CX + 166} ${CY - 32}
+       L${CX + 163} ${CY + W - 26}
+       C${CX + 150} ${CY + W - 14}, ${CX + 120} ${CY + W - 9}, ${CX + 78} ${CY + W - 4}
+       C${CX + 32} ${CY + W - 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
     delay: 80,
   },
 
-  // ==== LOWER PETALS — four parenthesis curves, sharp pointed tips ====
+  // ==== LOWER PETALS — parenthesis curves with organic asymmetry ====
 
-  // Outer left "("
+  // Outer left "(" — wider arc, tip curls slightly inward
   {
     d: `M${CX} ${CY + W}
-       C${CX - 35} ${CY + W + 5}, ${CX - 70} ${CY + W + 18}, ${CX - 85} ${CY + W + 40}
-       C${CX - 95} ${CY + W + 58}, ${CX - 88} ${CY + W + 78}, ${CX - 68} ${CY + 86}
-       C${CX - 82} ${CY + 72}, ${CX - 88} ${CY + 52}, ${CX - 78} ${CY + 35}
-       C${CX - 65} ${CY + 16}, ${CX - 32} ${CY + 4}, ${CX} ${CY - W} Z`,
+       C${CX - 33} ${CY + W + 4}, ${CX - 68} ${CY + W + 16}, ${CX - 84} ${CY + W + 38}
+       C${CX - 96} ${CY + W + 57}, ${CX - 90} ${CY + W + 78}, ${CX - 70} ${CY + 87}
+       C${CX - 84} ${CY + 73}, ${CX - 89} ${CY + 53}, ${CX - 79} ${CY + 36}
+       C${CX - 66} ${CY + 17}, ${CX - 34} ${CY + 5}, ${CX} ${CY - W} Z`,
     delay: 280,
   },
-  // Outer right ")"
+  // Outer right ")" — slightly tighter than left
   {
     d: `M${CX} ${CY + W}
-       C${CX + 38} ${CY + W + 6}, ${CX + 72} ${CY + W + 20}, ${CX + 88} ${CY + W + 42}
-       C${CX + 98} ${CY + W + 60}, ${CX + 92} ${CY + W + 80}, ${CX + 72} ${CY + 88}
-       C${CX + 86} ${CY + 74}, ${CX + 92} ${CY + 54}, ${CX + 82} ${CY + 37}
-       C${CX + 68} ${CY + 18}, ${CX + 35} ${CY + 5}, ${CX} ${CY - W} Z`,
+       C${CX + 36} ${CY + W + 5}, ${CX + 70} ${CY + W + 19}, ${CX + 86} ${CY + W + 40}
+       C${CX + 97} ${CY + W + 59}, ${CX + 91} ${CY + W + 79}, ${CX + 70} ${CY + 86}
+       C${CX + 85} ${CY + 72}, ${CX + 90} ${CY + 52}, ${CX + 80} ${CY + 35}
+       C${CX + 66} ${CY + 17}, ${CX + 33} ${CY + 4}, ${CX} ${CY - W} Z`,
     delay: 320,
   },
-  // Inner left "("
+  // Inner left "(" — shorter, tighter curl
   {
     d: `M${CX} ${CY + W}
-       C${CX - 20} ${CY + W + 6}, ${CX - 42} ${CY + W + 20}, ${CX - 52} ${CY + W + 38}
-       C${CX - 58} ${CY + W + 52}, ${CX - 52} ${CY + W + 68}, ${CX - 37} ${CY + 74}
-       C${CX - 48} ${CY + 62}, ${CX - 52} ${CY + 46}, ${CX - 44} ${CY + 32}
-       C${CX - 36} ${CY + 18}, ${CX - 18} ${CY + 5}, ${CX} ${CY - W} Z`,
+       C${CX - 18} ${CY + W + 5}, ${CX - 40} ${CY + W + 18}, ${CX - 50} ${CY + W + 36}
+       C${CX - 57} ${CY + W + 51}, ${CX - 51} ${CY + W + 67}, ${CX - 36} ${CY + 73}
+       C${CX - 47} ${CY + 61}, ${CX - 51} ${CY + 45}, ${CX - 43} ${CY + 31}
+       C${CX - 34} ${CY + 17}, ${CX - 17} ${CY + 5}, ${CX} ${CY - W} Z`,
     delay: 360,
   },
-  // Inner right ")"
+  // Inner right ")" — slightly longer than inner left
   {
     d: `M${CX} ${CY + W}
-       C${CX + 22} ${CY + W + 8}, ${CX + 45} ${CY + W + 22}, ${CX + 55} ${CY + W + 40}
-       C${CX + 62} ${CY + W + 55}, ${CX + 56} ${CY + W + 70}, ${CX + 41} ${CY + 76}
-       C${CX + 52} ${CY + 64}, ${CX + 56} ${CY + 48}, ${CX + 48} ${CY + 34}
-       C${CX + 40} ${CY + 20}, ${CX + 20} ${CY + 6}, ${CX} ${CY - W} Z`,
+       C${CX + 24} ${CY + W + 7}, ${CX + 47} ${CY + W + 21}, ${CX + 57} ${CY + W + 39}
+       C${CX + 64} ${CY + W + 54}, ${CX + 58} ${CY + W + 70}, ${CX + 43} ${CY + 77}
+       C${CX + 54} ${CY + 65}, ${CX + 58} ${CY + 49}, ${CX + 50} ${CY + 35}
+       C${CX + 42} ${CY + 21}, ${CX + 22} ${CY + 7}, ${CX} ${CY - W} Z`,
     delay: 400,
   },
 ];

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -1,131 +1,214 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Side-view spider lily (彼岸花) — Japanese ink/anime aesthetic.
- * Solid white filled petals with irregular widths and aggressive curling tips.
- * Graceful curved stamens. Stem leans naturally.
+ * Side-view spider lily (彼岸花) — Japanese anime ink aesthetic.
+ * Thin ribbon petals with tight spiral curls at the tips.
+ * Dense, chaotic, overlapping. White on black.
  */
 
-const CX = 218;
-const CY = 195;
+const CX = 220;
+const CY = 230;
 
-// Each petal is a closed filled shape — ribbon-like, wider in the middle,
-// tapering at base and tip, with a tight curl at the end.
-// Irregularity in widths and angles makes it feel hand-drawn.
+// Petals are thin ribbons (two-edge closed paths) with tight curling
+// spiral tips. Each one: narrow at base → slight widening → tight loop.
+// The "top edge" and "bottom edge" of the ribbon are offset by ~6-10px.
 const petals: { d: string; delay: number }[] = [
-  // === FAR LEFT — wide sweep, aggressive curl down ===
+  // ---- LEFT HORIZONTAL ----
+  // Far left — long sweep, tight downward spiral at tip
   {
-    d: `M${CX} ${CY} C${CX - 15} ${CY - 2}, ${CX - 45} ${CY - 8}, ${CX - 80} ${CY - 6}
-       C${CX - 105} ${CY - 4}, ${CX - 128} ${CY + 2}, ${CX - 140} ${CY + 15}
-       C${CX - 148} ${CY + 25}, ${CX - 145} ${CY + 35}, ${CX - 135} ${CY + 32}
-       C${CX - 125} ${CY + 28}, ${CX - 128} ${CY + 18}, ${CX - 122} ${CY + 8}
-       C${CX - 110} ${CY - 2}, ${CX - 82} ${CY - 2}, ${CX - 55} ${CY + 2}
-       C${CX - 30} ${CY + 5}, ${CX - 10} ${CY + 4}, ${CX} ${CY} Z`,
+    d: `M${CX} ${CY - 3}
+       L${CX - 40} ${CY - 12} L${CX - 85} ${CY - 16} L${CX - 125} ${CY - 10}
+       L${CX - 152} ${CY + 2} L${CX - 165} ${CY + 18} L${CX - 170} ${CY + 38}
+       C${CX - 170} ${CY + 52}, ${CX - 160} ${CY + 58}, ${CX - 150} ${CY + 52}
+       C${CX - 142} ${CY + 44}, ${CX - 148} ${CY + 32}, ${CX - 158} ${CY + 22}
+       L${CX - 155} ${CY + 8} L${CX - 140} ${CY - 2}
+       L${CX - 118} ${CY - 6} L${CX - 82} ${CY - 8} L${CX - 42} ${CY - 2}
+       L${CX - 5} ${CY + 5} Z`,
     delay: 0,
   },
-  // Left-upper sweep with tight hook
+  // Left mid-upper
   {
-    d: `M${CX} ${CY} C${CX - 12} ${CY - 8}, ${CX - 38} ${CY - 22}, ${CX - 68} ${CY - 30}
-       C${CX - 92} ${CY - 35}, ${CX - 115} ${CY - 32}, ${CX - 130} ${CY - 20}
-       C${CX - 140} ${CY - 10}, ${CX - 142} ${CY + 2}, ${CX - 132} ${CY + 5}
-       C${CX - 122} ${CY + 6}, ${CX - 120} ${CY - 5}, ${CX - 112} ${CY - 15}
-       C${CX - 98} ${CY - 28}, ${CX - 72} ${CY - 25}, ${CX - 48} ${CY - 18}
-       C${CX - 25} ${CY - 10}, ${CX - 8} ${CY - 3}, ${CX} ${CY} Z`,
-    delay: 80,
+    d: `M${CX} ${CY - 2}
+       L${CX - 35} ${CY - 14} L${CX - 72} ${CY - 28} L${CX - 108} ${CY - 34}
+       L${CX - 138} ${CY - 28} L${CX - 155} ${CY - 14} L${CX - 162} ${CY + 4}
+       C${CX - 165} ${CY + 18}, ${CX - 156} ${CY + 26}, ${CX - 146} ${CY + 20}
+       C${CX - 138} ${CY + 14}, ${CX - 142} ${CY + 2}, ${CX - 150} ${CY - 6}
+       L${CX - 142} ${CY - 16} L${CX - 125} ${CY - 22}
+       L${CX - 102} ${CY - 24} L${CX - 70} ${CY - 18} L${CX - 38} ${CY - 6}
+       L${CX - 6} ${CY + 6} Z`,
+    delay: 100,
   },
-  // Left-low sweep curling under
+  // Left low — sweeps down, curls up
   {
-    d: `M${CX} ${CY} C${CX - 10} ${CY + 4}, ${CX - 35} ${CY + 14}, ${CX - 62} ${CY + 22}
-       C${CX - 85} ${CY + 28}, ${CX - 105} ${CY + 35}, ${CX - 115} ${CY + 48}
-       C${CX - 120} ${CY + 58}, ${CX - 115} ${CY + 65}, ${CX - 105} ${CY + 60}
-       C${CX - 98} ${CY + 55}, ${CX - 100} ${CY + 45}, ${CX - 95} ${CY + 35}
-       C${CX - 85} ${CY + 22}, ${CX - 60} ${CY + 18}, ${CX - 38} ${CY + 12}
-       C${CX - 18} ${CY + 6}, ${CX - 5} ${CY + 2}, ${CX} ${CY} Z`,
+    d: `M${CX} ${CY + 2}
+       L${CX - 32} ${CY + 15} L${CX - 65} ${CY + 32} L${CX - 95} ${CY + 50}
+       L${CX - 115} ${CY + 66} L${CX - 125} ${CY + 82} L${CX - 126} ${CY + 98}
+       C${CX - 124} ${CY + 112}, ${CX - 114} ${CY + 116}, ${CX - 108} ${CY + 108}
+       C${CX - 102} ${CY + 98}, ${CX - 108} ${CY + 86}, ${CX - 116} ${CY + 78}
+       L${CX - 110} ${CY + 62} L${CX - 95} ${CY + 48}
+       L${CX - 72} ${CY + 34} L${CX - 45} ${CY + 20} L${CX - 18} ${CY + 8}
+       L${CX + 3} ${CY + 6} Z`,
+    delay: 190,
+  },
+
+  // ---- RIGHT HORIZONTAL ----
+  // Far right
+  {
+    d: `M${CX} ${CY - 4}
+       L${CX + 42} ${CY - 15} L${CX + 88} ${CY - 20} L${CX + 128} ${CY - 14}
+       L${CX + 155} ${CY} L${CX + 168} ${CY + 16} L${CX + 174} ${CY + 36}
+       C${CX + 175} ${CY + 50}, ${CX + 165} ${CY + 56}, ${CX + 155} ${CY + 50}
+       C${CX + 147} ${CY + 42}, ${CX + 152} ${CY + 30}, ${CX + 162} ${CY + 20}
+       L${CX + 158} ${CY + 6} L${CX + 145} ${CY - 4}
+       L${CX + 122} ${CY - 8} L${CX + 85} ${CY - 10} L${CX + 45} ${CY - 4}
+       L${CX + 6} ${CY + 4} Z`,
+    delay: 50,
+  },
+  // Right mid-upper
+  {
+    d: `M${CX} ${CY - 3}
+       L${CX + 38} ${CY - 16} L${CX + 76} ${CY - 32} L${CX + 112} ${CY - 38}
+       L${CX + 142} ${CY - 30} L${CX + 160} ${CY - 16} L${CX + 168} ${CY + 2}
+       C${CX + 172} ${CY + 16}, ${CX + 162} ${CY + 24}, ${CX + 152} ${CY + 18}
+       C${CX + 144} ${CY + 12}, ${CX + 148} ${CY}, ${CX + 155} ${CY - 8}
+       L${CX + 148} ${CY - 18} L${CX + 130} ${CY - 24}
+       L${CX + 106} ${CY - 28} L${CX + 74} ${CY - 22} L${CX + 40} ${CY - 8}
+       L${CX + 8} ${CY + 5} Z`,
+    delay: 140,
+  },
+  // Right low
+  {
+    d: `M${CX} ${CY + 3}
+       L${CX + 35} ${CY + 18} L${CX + 68} ${CY + 36} L${CX + 98} ${CY + 54}
+       L${CX + 118} ${CY + 70} L${CX + 128} ${CY + 86} L${CX + 130} ${CY + 102}
+       C${CX + 128} ${CY + 115}, ${CX + 118} ${CY + 118}, ${CX + 112} ${CY + 110}
+       C${CX + 106} ${CY + 100}, ${CX + 112} ${CY + 88}, ${CX + 120} ${CY + 80}
+       L${CX + 114} ${CY + 66} L${CX + 100} ${CY + 52}
+       L${CX + 76} ${CY + 38} L${CX + 48} ${CY + 22} L${CX + 20} ${CY + 10}
+       L${CX - 2} ${CY + 6} Z`,
+    delay: 230,
+  },
+
+  // ---- UPPER LEFT DIAGONAL ----
+  {
+    d: `M${CX - 2} ${CY}
+       L${CX - 20} ${CY - 22} L${CX - 42} ${CY - 52} L${CX - 62} ${CY - 78}
+       L${CX - 76} ${CY - 100} L${CX - 82} ${CY - 118} L${CX - 80} ${CY - 132}
+       C${CX - 76} ${CY - 144}, ${CX - 66} ${CY - 146}, ${CX - 60} ${CY - 138}
+       C${CX - 56} ${CY - 130}, ${CX - 62} ${CY - 120}, ${CX - 70} ${CY - 114}
+       L${CX - 68} ${CY - 98} L${CX - 58} ${CY - 78}
+       L${CX - 42} ${CY - 54} L${CX - 24} ${CY - 30} L${CX - 6} ${CY - 8}
+       L${CX + 3} ${CY + 5} Z`,
+    delay: 70,
+  },
+
+  // ---- UPPER RIGHT DIAGONAL ----
+  {
+    d: `M${CX + 2} ${CY}
+       L${CX + 22} ${CY - 24} L${CX + 46} ${CY - 56} L${CX + 68} ${CY - 82}
+       L${CX + 82} ${CY - 104} L${CX + 88} ${CY - 122} L${CX + 86} ${CY - 136}
+       C${CX + 82} ${CY - 148}, ${CX + 72} ${CY - 150}, ${CX + 66} ${CY - 142}
+       C${CX + 62} ${CY - 134}, ${CX + 68} ${CY - 124}, ${CX + 76} ${CY - 118}
+       L${CX + 74} ${CY - 102} L${CX + 64} ${CY - 82}
+       L${CX + 46} ${CY - 58} L${CX + 26} ${CY - 32} L${CX + 8} ${CY - 10}
+       L${CX - 2} ${CY + 4} Z`,
     delay: 160,
   },
 
-  // === FAR RIGHT — mirror-ish but irregular ===
+  // ---- TOP PETALS ----
+  // Top left-lean
   {
-    d: `M${CX} ${CY} C${CX + 18} ${CY - 4}, ${CX + 50} ${CY - 12}, ${CX + 85} ${CY - 10}
-       C${CX + 108} ${CY - 8}, ${CX + 130} ${CY - 2}, ${CX + 142} ${CY + 10}
-       C${CX + 150} ${CY + 20}, ${CX + 148} ${CY + 32}, ${CX + 138} ${CY + 30}
-       C${CX + 128} ${CY + 26}, ${CX + 130} ${CY + 14}, ${CX + 125} ${CY + 4}
-       C${CX + 112} ${CY - 4}, ${CX + 85} ${CY - 4}, ${CX + 58} ${CY}
-       C${CX + 32} ${CY + 3}, ${CX + 12} ${CY + 2}, ${CX} ${CY} Z`,
-    delay: 50,
+    d: `M${CX - 1} ${CY}
+       L${CX - 10} ${CY - 28} L${CX - 18} ${CY - 65} L${CX - 24} ${CY - 102}
+       L${CX - 26} ${CY - 132} L${CX - 22} ${CY - 155} L${CX - 14} ${CY - 170}
+       C${CX - 6} ${CY - 180}, ${CX + 2} ${CY - 176}, ${CX + 2} ${CY - 166}
+       C${CX + 2} ${CY - 156}, ${CX - 8} ${CY - 152}, ${CX - 16} ${CY - 148}
+       L${CX - 18} ${CY - 132} L${CX - 16} ${CY - 105}
+       L${CX - 12} ${CY - 68} L${CX - 4} ${CY - 32} L${CX + 4} ${CY - 4}
+       L${CX + 3} ${CY + 5} Z`,
+    delay: 40,
   },
-  // Right-upper with curl
+  // Top right-lean
   {
-    d: `M${CX} ${CY} C${CX + 14} ${CY - 10}, ${CX + 42} ${CY - 25}, ${CX + 72} ${CY - 35}
-       C${CX + 95} ${CY - 40}, ${CX + 118} ${CY - 36}, ${CX + 132} ${CY - 22}
-       C${CX + 142} ${CY - 12}, ${CX + 144} ${CY}, ${CX + 134} ${CY + 2}
-       C${CX + 124} ${CY + 2}, ${CX + 122} ${CY - 8}, ${CX + 115} ${CY - 18}
-       C${CX + 100} ${CY - 30}, ${CX + 75} ${CY - 28}, ${CX + 50} ${CY - 20}
-       C${CX + 28} ${CY - 12}, ${CX + 10} ${CY - 4}, ${CX} ${CY} Z`,
-    delay: 130,
+    d: `M${CX + 1} ${CY}
+       L${CX + 12} ${CY - 30} L${CX + 22} ${CY - 68} L${CX + 30} ${CY - 106}
+       L${CX + 34} ${CY - 138} L${CX + 30} ${CY - 160} L${CX + 22} ${CY - 175}
+       C${CX + 14} ${CY - 185}, ${CX + 4} ${CY - 182}, ${CX + 4} ${CY - 172}
+       C${CX + 4} ${CY - 162}, ${CX + 14} ${CY - 156}, ${CX + 22} ${CY - 152}
+       L${CX + 24} ${CY - 138} L${CX + 22} ${CY - 108}
+       L${CX + 16} ${CY - 72} L${CX + 8} ${CY - 34} L${CX} ${CY - 6}
+       L${CX - 2} ${CY + 4} Z`,
+    delay: 110,
   },
-  // Right-low curling under
+  // Top center-left narrow
   {
-    d: `M${CX} ${CY} C${CX + 12} ${CY + 5}, ${CX + 38} ${CY + 16}, ${CX + 65} ${CY + 25}
-       C${CX + 88} ${CY + 32}, ${CX + 108} ${CY + 40}, ${CX + 118} ${CY + 52}
-       C${CX + 124} ${CY + 62}, ${CX + 118} ${CY + 68}, ${CX + 108} ${CY + 62}
-       C${CX + 100} ${CY + 55}, ${CX + 102} ${CY + 45}, ${CX + 98} ${CY + 38}
-       C${CX + 88} ${CY + 25}, ${CX + 62} ${CY + 20}, ${CX + 40} ${CY + 14}
-       C${CX + 20} ${CY + 8}, ${CX + 6} ${CY + 3}, ${CX} ${CY} Z`,
+    d: `M${CX - 1} ${CY}
+       L${CX - 6} ${CY - 22} L${CX - 14} ${CY - 55} L${CX - 24} ${CY - 88}
+       L${CX - 36} ${CY - 115} L${CX - 42} ${CY - 135} L${CX - 42} ${CY - 150}
+       C${CX - 38} ${CY - 162}, ${CX - 28} ${CY - 164}, ${CX - 24} ${CY - 155}
+       C${CX - 20} ${CY - 146}, ${CX - 28} ${CY - 138}, ${CX - 35} ${CY - 132}
+       L${CX - 32} ${CY - 115} L${CX - 22} ${CY - 90}
+       L${CX - 12} ${CY - 58} L${CX - 4} ${CY - 26} L${CX + 4} ${CY - 2}
+       Z`,
     delay: 200,
   },
-
-  // === UPPER — rise and hook back ===
+  // Top center-right narrow
   {
-    d: `M${CX} ${CY} C${CX - 5} ${CY - 12}, ${CX - 15} ${CY - 38}, ${CX - 22} ${CY - 62}
-       C${CX - 28} ${CY - 82}, ${CX - 30} ${CY - 100}, ${CX - 25} ${CY - 110}
-       C${CX - 20} ${CY - 118}, ${CX - 12} ${CY - 115}, ${CX - 12} ${CY - 105}
-       C${CX - 12} ${CY - 95}, ${CX - 18} ${CY - 88}, ${CX - 18} ${CY - 72}
-       C${CX - 16} ${CY - 50}, ${CX - 8} ${CY - 28}, ${CX - 2} ${CY - 8}
-       L${CX} ${CY} Z`,
-    delay: 100,
-  },
-  {
-    d: `M${CX} ${CY} C${CX + 6} ${CY - 14}, ${CX + 18} ${CY - 42}, ${CX + 26} ${CY - 68}
-       C${CX + 32} ${CY - 88}, ${CX + 34} ${CY - 105}, ${CX + 28} ${CY - 115}
-       C${CX + 22} ${CY - 122}, ${CX + 14} ${CY - 118}, ${CX + 15} ${CY - 108}
-       C${CX + 16} ${CY - 98}, ${CX + 22} ${CY - 90}, ${CX + 22} ${CY - 75}
-       C${CX + 20} ${CY - 52}, ${CX + 12} ${CY - 30}, ${CX + 4} ${CY - 10}
-       L${CX} ${CY} Z`,
-    delay: 170,
+    d: `M${CX + 1} ${CY}
+       L${CX + 8} ${CY - 24} L${CX + 18} ${CY - 58} L${CX + 30} ${CY - 92}
+       L${CX + 42} ${CY - 118} L${CX + 48} ${CY - 138} L${CX + 48} ${CY - 152}
+       C${CX + 44} ${CY - 164}, ${CX + 34} ${CY - 166}, ${CX + 30} ${CY - 158}
+       C${CX + 26} ${CY - 148}, ${CX + 34} ${CY - 140}, ${CX + 42} ${CY - 135}
+       L${CX + 38} ${CY - 118} L${CX + 28} ${CY - 94}
+       L${CX + 16} ${CY - 62} L${CX + 6} ${CY - 28} L${CX - 2} ${CY - 4}
+       Z`,
+    delay: 260,
   },
 
-  // === UPPER-DIAGONAL — aggressive angular ===
+  // ---- EXTRA DENSITY PETALS ----
+  // Left far-upper — tighter angle
   {
-    d: `M${CX} ${CY} C${CX - 10} ${CY - 10}, ${CX - 30} ${CY - 35}, ${CX - 48} ${CY - 58}
-       C${CX - 62} ${CY - 75}, ${CX - 72} ${CY - 90}, ${CX - 70} ${CY - 100}
-       C${CX - 68} ${CY - 108}, ${CX - 60} ${CY - 108}, ${CX - 58} ${CY - 98}
-       C${CX - 56} ${CY - 88}, ${CX - 60} ${CY - 78}, ${CX - 52} ${CY - 65}
-       C${CX - 40} ${CY - 45}, ${CX - 22} ${CY - 25}, ${CX - 5} ${CY - 5}
-       L${CX} ${CY} Z`,
-    delay: 140,
+    d: `M${CX - 1} ${CY - 1}
+       L${CX - 28} ${CY - 18} L${CX - 58} ${CY - 42} L${CX - 85} ${CY - 58}
+       L${CX - 108} ${CY - 66} L${CX - 124} ${CY - 64} L${CX - 134} ${CY - 52}
+       C${CX - 140} ${CY - 40}, ${CX - 134} ${CY - 30}, ${CX - 124} ${CY - 32}
+       C${CX - 116} ${CY - 34}, ${CX - 118} ${CY - 44}, ${CX - 124} ${CY - 50}
+       L${CX - 114} ${CY - 54} L${CX - 98} ${CY - 52}
+       L${CX - 75} ${CY - 44} L${CX - 50} ${CY - 30} L${CX - 25} ${CY - 12}
+       L${CX + 2} ${CY + 5} Z`,
+    delay: 280,
   },
+  // Right far-upper
   {
-    d: `M${CX} ${CY} C${CX + 12} ${CY - 12}, ${CX + 35} ${CY - 38}, ${CX + 55} ${CY - 62}
-       C${CX + 68} ${CY - 78}, ${CX + 78} ${CY - 92}, ${CX + 75} ${CY - 102}
-       C${CX + 72} ${CY - 110}, ${CX + 64} ${CY - 108}, ${CX + 62} ${CY - 98}
-       C${CX + 60} ${CY - 88}, ${CX + 65} ${CY - 78}, ${CX + 58} ${CY - 65}
-       C${CX + 45} ${CY - 48}, ${CX + 25} ${CY - 28}, ${CX + 8} ${CY - 8}
-       L${CX} ${CY} Z`,
-    delay: 220,
+    d: `M${CX + 1} ${CY - 1}
+       L${CX + 30} ${CY - 20} L${CX + 62} ${CY - 46} L${CX + 90} ${CY - 62}
+       L${CX + 112} ${CY - 70} L${CX + 128} ${CY - 68} L${CX + 138} ${CY - 56}
+       C${CX + 144} ${CY - 44}, ${CX + 138} ${CY - 34}, ${CX + 128} ${CY - 36}
+       C${CX + 120} ${CY - 38}, ${CX + 122} ${CY - 48}, ${CX + 128} ${CY - 54}
+       L${CX + 118} ${CY - 58} L${CX + 102} ${CY - 56}
+       L${CX + 80} ${CY - 48} L${CX + 54} ${CY - 34} L${CX + 28} ${CY - 14}
+       L${CX - 1} ${CY + 4} Z`,
+    delay: 310,
   },
 ];
 
 const petalDelays = petals.map((p) => p.delay);
 
-// Stamens: graceful curves, not straight lines. Thin, elegant arcs.
+// Stamens: smooth graceful U-arcs — sweep outward then curve back up.
+// Single long cubic beziers for buttery smooth curves, no kinks.
 const stamens = [
-  { d: `M${CX} ${CY - 5} C${CX - 12} ${CY - 45}, ${CX - 30} ${CY - 100}, ${CX - 55} ${CY - 155} C${CX - 65} ${CY - 180}, ${CX - 72} ${CY - 200}, ${CX - 75} ${CY - 215}`, tipX: CX - 75, tipY: CY - 215, delay: 550 },
-  { d: `M${CX} ${CY - 5} C${CX + 10} ${CY - 48}, ${CX + 28} ${CY - 105}, ${CX + 50} ${CY - 158} C${CX + 60} ${CY - 182}, ${CX + 68} ${CY - 202}, ${CX + 72} ${CY - 218}`, tipX: CX + 72, tipY: CY - 218, delay: 620 },
-  { d: `M${CX} ${CY - 5} C${CX - 5} ${CY - 50}, ${CX - 12} ${CY - 110}, ${CX - 20} ${CY - 168} C${CX - 24} ${CY - 195}, ${CX - 26} ${CY - 215}, ${CX - 25} ${CY - 232}`, tipX: CX - 25, tipY: CY - 232, delay: 690 },
-  { d: `M${CX} ${CY - 5} C${CX + 5} ${CY - 52}, ${CX + 14} ${CY - 112}, ${CX + 22} ${CY - 170} C${CX + 26} ${CY - 198}, ${CX + 28} ${CY - 218}, ${CX + 28} ${CY - 235}`, tipX: CX + 28, tipY: CY - 235, delay: 760 },
-  { d: `M${CX} ${CY - 5} C${CX - 20} ${CY - 38}, ${CX - 52} ${CY - 82}, ${CX - 85} ${CY - 125} C${CX - 100} ${CY - 145}, ${CX - 112} ${CY - 160}, ${CX - 120} ${CY - 172}`, tipX: CX - 120, tipY: CY - 172, delay: 830 },
-  { d: `M${CX} ${CY - 5} C${CX + 18} ${CY - 40}, ${CX + 48} ${CY - 85}, ${CX + 80} ${CY - 128} C${CX + 95} ${CY - 148}, ${CX + 108} ${CY - 165}, ${CX + 115} ${CY - 175}`, tipX: CX + 115, tipY: CY - 175, delay: 900 },
+  // Far left — wide sweep out, gentle curve up
+  { d: `M${CX} ${CY - 10} C${CX - 80} ${CY - 15}, ${CX - 195} ${CY - 30}, ${CX - 205} ${CY - 150}`, tipX: CX - 205, tipY: CY - 150, delay: 580 },
+  // Far right
+  { d: `M${CX} ${CY - 10} C${CX + 78} ${CY - 18}, ${CX + 190} ${CY - 34}, ${CX + 202} ${CY - 155}`, tipX: CX + 202, tipY: CY - 155, delay: 650 },
+  // Left-upper — arcs out and up
+  { d: `M${CX} ${CY - 10} C${CX - 55} ${CY - 45}, ${CX - 155} ${CY - 105}, ${CX - 145} ${CY - 270}`, tipX: CX - 145, tipY: CY - 270, delay: 720 },
+  // Right-upper
+  { d: `M${CX} ${CY - 10} C${CX + 52} ${CY - 48}, ${CX + 150} ${CY - 110}, ${CX + 140} ${CY - 275}`, tipX: CX + 140, tipY: CY - 275, delay: 790 },
+  // Center-left — taller, gentle lean
+  { d: `M${CX} ${CY - 10} C${CX - 30} ${CY - 60}, ${CX - 80} ${CY - 180}, ${CX - 42} ${CY - 325}`, tipX: CX - 42, tipY: CY - 325, delay: 860 },
+  // Center-right
+  { d: `M${CX} ${CY - 10} C${CX + 28} ${CY - 62}, ${CX + 78} ${CY - 185}, ${CX + 45} ${CY - 328}`, tipX: CX + 45, tipY: CY - 328, delay: 930 },
 ];
 
 const SpiderLily = ({ className }: { className?: string }) => {
@@ -138,7 +221,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
   return (
     <svg
-      viewBox="10 -60 400 580"
+      viewBox="-10 -130 480 710"
       className={className}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -169,28 +252,28 @@ const SpiderLily = ({ className }: { className?: string }) => {
       </defs>
 
       <g filter="url(#ink-texture)">
-        {/* Stem — natural lean */}
+        {/* Stem */}
         <path
-          d={`M188 520 C190 475, 195 410, 200 350 C206 290, 214 245, ${CX} ${CY + 12}`}
+          d={`M195 580 C198 520, 205 445, 212 380 C218 320, 220 275, ${CX} ${CY + 15}`}
           className={`spider-lily-stem ${bloomed ? 'spider-lily-stem-active' : ''}`}
           pathLength={1}
         />
 
         {/* Bracts */}
         <path
-          d={`M${CX - 1} ${CY + 6} C${CX - 8} ${CY + 15}, ${CX - 14} ${CY + 28}, ${CX - 18} ${CY + 40}`}
+          d={`M${CX - 2} ${CY + 8} C${CX - 10} ${CY + 20}, ${CX - 16} ${CY + 35}, ${CX - 20} ${CY + 52}`}
           className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
           style={{ animationDelay: '120ms' }}
           pathLength={1}
         />
         <path
-          d={`M${CX + 1} ${CY + 6} C${CX + 6} ${CY + 15}, ${CX + 10} ${CY + 28}, ${CX + 12} ${CY + 40}`}
+          d={`M${CX + 2} ${CY + 8} C${CX + 8} ${CY + 20}, ${CX + 12} ${CY + 35}, ${CX + 14} ${CY + 52}`}
           className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
           style={{ animationDelay: '150ms' }}
           pathLength={1}
         />
 
-        {/* Petals — solid white filled shapes */}
+        {/* Petals */}
         {petals.map((p, i) => (
           <path
             key={`petal-${i}`}
@@ -201,7 +284,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
           />
         ))}
 
-        {/* Stamens — graceful curves */}
+        {/* Stamens */}
         {stamens.map((s, i) => (
           <g key={`stamen-${i}`}>
             <path

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -218,64 +218,67 @@ const SpiderLily = ({ className }: { className?: string }) => {
       </defs>
 
       <g filter="url(#ink-texture)">
-        {/* Stem — brush stroke: wide at flower head, trails to a wisp */}
+        {/* Stem — organic brush stroke with natural curve */}
         <path
-          d={`M${CX - 5} ${CY}
-              C${CX - 6} ${CY + 25}, ${CX - 7} 280, ${CX - 6} 330
-              C${CX - 4} 375, ${CX - 6} 420, ${CX - 7} 470
-              C${CX - 6} 515, ${CX - 4} 550, ${CX - 3} 580
-              Q${CX - 2} 594, ${CX} 598
-              Q${CX + 2} 594, ${CX + 2} 580
-              C${CX + 3} 550, ${CX + 1} 515, ${CX} 470
-              C${CX - 1} 420, ${CX + 2} 375, ${CX + 4} 330
-              C${CX + 5} 280, ${CX + 5} ${CY + 25}, ${CX + 5} ${CY}
+          d={`M${CX - 4} ${CY}
+              C${CX - 3} ${CY + 30}, ${CX + 2} 275, ${CX + 6} 320
+              C${CX + 10} 365, ${CX + 8} 410, ${CX + 4} 455
+              C${CX + 1} 500, ${CX - 3} 540, ${CX - 5} 575
+              Q${CX - 5} 592, ${CX - 3} 598
+              Q${CX - 1} 592, ${CX - 1} 575
+              C${CX + 1} 540, ${CX + 5} 500, ${CX + 8} 455
+              C${CX + 12} 410, ${CX + 14} 365, ${CX + 10} 320
+              C${CX + 6} 275, ${CX + 7} ${CY + 30}, ${CX + 6} ${CY}
               Z`}
           className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
         />
 
-        {/* Petals */}
-        {petals.map((p, i) => (
-          <path
-            key={`petal-${i}`}
-            d={p.d}
-            className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
-            style={{ animationDelay: `${petalDelays[i]}ms` }}
-            pathLength={1}
-          />
-        ))}
-
-        {/* Stamens */}
-        {stamens.map((s, i) => (
-          <g key={`stamen-${i}`}>
+        {/* Flower head — subtle lean */}
+        <g transform={`rotate(-4 ${CX} ${CY})`}>
+          {/* Petals */}
+          {petals.map((p, i) => (
             <path
-              d={s.d}
-              className={`spider-lily-stamen ${stamensActive ? 'spider-lily-stamen-active' : ''}`}
-              style={{ animationDelay: `${s.delay}ms` }}
-              filter="url(#stamen-glow)"
+              key={`petal-${i}`}
+              d={p.d}
+              className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
+              style={{ animationDelay: `${petalDelays[i]}ms` }}
               pathLength={1}
             />
-            {!s.noTip && (
-              <ellipse
-                cx={s.tipX}
-                cy={s.tipY}
-                rx={s.tipLen}
-                ry={s.tipW}
-                transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
-                className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
-                style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
-                filter="url(#stamen-glow)"
-              />
-            )}
-          </g>
-        ))}
+          ))}
 
-        {/* Center */}
-        <circle
-          cx={CX}
-          cy={CY}
-          r="3"
-          className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
-        />
+          {/* Stamens */}
+          {stamens.map((s, i) => (
+            <g key={`stamen-${i}`}>
+              <path
+                d={s.d}
+                className={`spider-lily-stamen ${stamensActive ? 'spider-lily-stamen-active' : ''}`}
+                style={{ animationDelay: `${s.delay}ms` }}
+                filter="url(#stamen-glow)"
+                pathLength={1}
+              />
+              {!s.noTip && (
+                <ellipse
+                  cx={s.tipX}
+                  cy={s.tipY}
+                  rx={s.tipLen}
+                  ry={s.tipW}
+                  transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
+                  className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
+                  style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
+                  filter="url(#stamen-glow)"
+                />
+              )}
+            </g>
+          ))}
+
+          {/* Center */}
+          <circle
+            cx={CX}
+            cy={CY}
+            r="3"
+            className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
+          />
+        </g>
       </g>
     </svg>
   );

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -9,183 +9,138 @@ import { useEffect, useState } from 'react';
 const CX = 220;
 const CY = 230;
 
-// Dense upper crown + few long swooping jellyfish tentacles below.
-// W = half-width of ribbon.
-const W = 4;
+// Hand-drawn ribbon petals — thin, organic, dome-shaped arrangement.
+// W = half-width of ribbon. Kept narrow for paper/ribbon feel.
+const W = 3;
 const petals: { d: string; delay: number }[] = [
-  // ==== DENSE UPPER CROWN — many petals radiating up and outward ====
+  // ==== UPPER DOME — organic ribbon petals, tips tracing a dome arc ====
 
   // Top center — straight up
   {
     d: `M${CX - W} ${CY}
-       C${CX - W} ${CY - 30}, ${CX - W - 2} ${CY - 70}, ${CX - W - 3} ${CY - 105}
-       C${CX - W - 4} ${CY - 128}, ${CX - W + 1} ${CY - 148}, ${CX + 2} ${CY - 155}
-       C${CX + W + 2} ${CY - 158}, ${CX + W + 4} ${CY - 148}, ${CX + W + 2} ${CY - 130}
-       C${CX + W} ${CY - 112}, ${CX + W - 1} ${CY - 100}, ${CX + W} ${CY - 80}
-       C${CX + W} ${CY - 52}, ${CX + W} ${CY - 28}, ${CX + W} ${CY} Z`,
+       C${CX - W - 1} ${CY - 40}, ${CX - W - 3} ${CY - 85}, ${CX - W - 2} ${CY - 125}
+       C${CX - W - 1} ${CY - 145}, ${CX} ${CY - 156}, ${CX} ${CY - 158}
+       C${CX} ${CY - 156}, ${CX + W + 1} ${CY - 145}, ${CX + W} ${CY - 125}
+       C${CX + W - 1} ${CY - 85}, ${CX + W + 1} ${CY - 40}, ${CX + W} ${CY} Z`,
     delay: 0,
   },
-  // Top slight left lean
+  // Left ~20°
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 5} ${CY - 28}, ${CX - W - 14} ${CY - 68}, ${CX - W - 20} ${CY - 105}
-       C${CX - W - 24} ${CY - 130}, ${CX - W - 16} ${CY - 150}, ${CX - 4} ${CY - 158}
-       C${CX + 6} ${CY - 162}, ${CX + 12} ${CY - 152}, ${CX + 8} ${CY - 138}
-       C${CX + 4} ${CY - 124}, ${CX - 4} ${CY - 118}, ${CX + W - 16} ${CY - 102}
-       C${CX + W - 10} ${CY - 68}, ${CX + W - 3} ${CY - 30}, ${CX + W} ${CY} Z`,
-    delay: 50,
+       C${CX - W - 6} ${CY - 35}, ${CX - W - 18} ${CY - 78}, ${CX - W - 30} ${CY - 118}
+       C${CX - W - 38} ${CY - 140}, ${CX - W - 24} ${CY - 154}, ${CX - W - 18} ${CY - 155}
+       L${CX + W - 24} ${CY - 152}
+       C${CX + W - 22} ${CY - 138}, ${CX + W - 18} ${CY - 112}, ${CX + W - 14} ${CY - 76}
+       C${CX + W - 4} ${CY - 35}, ${CX + W} ${CY - 10}, ${CX + W} ${CY} Z`,
+    delay: 60,
   },
-  // Top slight right lean
+  // Right ~20°
   {
     d: `M${CX + W} ${CY}
-       C${CX + W + 6} ${CY - 30}, ${CX + W + 16} ${CY - 72}, ${CX + W + 22} ${CY - 108}
-       C${CX + W + 26} ${CY - 132}, ${CX + W + 18} ${CY - 152}, ${CX + 5} ${CY - 160}
-       C${CX - 6} ${CY - 164}, ${CX - 10} ${CY - 154}, ${CX - 6} ${CY - 140}
-       C${CX - 2} ${CY - 126}, ${CX + 6} ${CY - 120}, ${CX - W + 18} ${CY - 105}
-       C${CX - W + 12} ${CY - 70}, ${CX - W + 4} ${CY - 32}, ${CX - W} ${CY} Z`,
-    delay: 80,
-  },
-  // Upper-left diagonal — ~45 degrees
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 12} ${CY - 22}, ${CX - W - 35} ${CY - 55}, ${CX - W - 55} ${CY - 85}
-       C${CX - W - 68} ${CY - 105}, ${CX - W - 62} ${CY - 128}, ${CX - W - 48} ${CY - 138}
-       C${CX - W - 35} ${CY - 145}, ${CX - W - 25} ${CY - 136}, ${CX - W - 30} ${CY - 122}
-       C${CX - W - 35} ${CY - 110}, ${CX - W - 42} ${CY - 105}, ${CX + W - 50} ${CY - 90}
-       C${CX + W - 32} ${CY - 58}, ${CX + W - 10} ${CY - 25}, ${CX + W} ${CY} Z`,
-    delay: 120,
-  },
-  // Upper-right diagonal — ~45 degrees
-  {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 14} ${CY - 24}, ${CX + W + 38} ${CY - 58}, ${CX + W + 60} ${CY - 88}
-       C${CX + W + 72} ${CY - 108}, ${CX + W + 66} ${CY - 132}, ${CX + W + 52} ${CY - 142}
-       C${CX + W + 38} ${CY - 148}, ${CX + W + 28} ${CY - 140}, ${CX + W + 34} ${CY - 125}
-       C${CX + W + 38} ${CY - 112}, ${CX + W + 46} ${CY - 108}, ${CX - W + 55} ${CY - 94}
-       C${CX - W + 36} ${CY - 60}, ${CX - W + 12} ${CY - 26}, ${CX - W} ${CY} Z`,
-    delay: 160,
-  },
-  // Far upper-left — ~60 degrees out, wide spread
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 18} ${CY - 16}, ${CX - W - 52} ${CY - 40}, ${CX - W - 88} ${CY - 58}
-       C${CX - W - 112} ${CY - 70}, ${CX - W - 128} ${CY - 65}, ${CX - W - 135} ${CY - 48}
-       C${CX - W - 140} ${CY - 34}, ${CX - W - 130} ${CY - 28}, ${CX - W - 120} ${CY - 38}
-       C${CX - W - 112} ${CY - 48}, ${CX - W - 116} ${CY - 55}, ${CX + W - 105} ${CY - 52}
-       C${CX + W - 68} ${CY - 38}, ${CX + W - 28} ${CY - 18}, ${CX + W} ${CY} Z`,
-    delay: 40,
-  },
-  // Far upper-right — ~60 degrees out
-  {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 20} ${CY - 18}, ${CX + W + 55} ${CY - 42}, ${CX + W + 92} ${CY - 62}
-       C${CX + W + 116} ${CY - 74}, ${CX + W + 132} ${CY - 68}, ${CX + W + 140} ${CY - 52}
-       C${CX + W + 145} ${CY - 38}, ${CX + W + 135} ${CY - 30}, ${CX + W + 124} ${CY - 40}
-       C${CX + W + 116} ${CY - 50}, ${CX + W + 120} ${CY - 58}, ${CX - W + 110} ${CY - 55}
-       C${CX - W + 72} ${CY - 40}, ${CX - W + 30} ${CY - 20}, ${CX - W} ${CY} Z`,
+       C${CX + W + 7} ${CY - 36}, ${CX + W + 20} ${CY - 80}, ${CX + W + 34} ${CY - 120}
+       C${CX + W + 42} ${CY - 142}, ${CX + W + 28} ${CY - 156}, ${CX + W + 22} ${CY - 158}
+       L${CX - W + 28} ${CY - 155}
+       C${CX - W + 26} ${CY - 140}, ${CX - W + 22} ${CY - 115}, ${CX - W + 18} ${CY - 78}
+       C${CX - W + 6} ${CY - 36}, ${CX - W} ${CY - 10}, ${CX - W} ${CY} Z`,
     delay: 100,
   },
-  // Upper-left between 45 and 60 — fills the gap
+  // Left ~42°
   {
     d: `M${CX - W} ${CY}
-       C${CX - W - 15} ${CY - 20}, ${CX - W - 42} ${CY - 48}, ${CX - W - 70} ${CY - 72}
-       C${CX - W - 88} ${CY - 88}, ${CX - W - 85} ${CY - 110}, ${CX - W - 72} ${CY - 118}
-       C${CX - W - 60} ${CY - 124}, ${CX - W - 50} ${CY - 115}, ${CX - W - 55} ${CY - 102}
-       C${CX - W - 58} ${CY - 90}, ${CX - W - 65} ${CY - 85}, ${CX + W - 62} ${CY - 75}
-       C${CX + W - 40} ${CY - 50}, ${CX + W - 15} ${CY - 22}, ${CX + W} ${CY} Z`,
-    delay: 200,
-  },
-  // Upper-right between 45 and 60
-  {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 16} ${CY - 22}, ${CX + W + 45} ${CY - 50}, ${CX + W + 74} ${CY - 76}
-       C${CX + W + 92} ${CY - 92}, ${CX + W + 90} ${CY - 114}, ${CX + W + 76} ${CY - 122}
-       C${CX + W + 64} ${CY - 128}, ${CX + W + 54} ${CY - 118}, ${CX + W + 58} ${CY - 105}
-       C${CX + W + 62} ${CY - 94}, ${CX + W + 68} ${CY - 88}, ${CX - W + 66} ${CY - 78}
-       C${CX - W + 44} ${CY - 52}, ${CX - W + 16} ${CY - 24}, ${CX - W} ${CY} Z`,
-    delay: 230,
-  },
-  // Near-horizontal left — wide spread at ~80 degrees
-  {
-    d: `M${CX} ${CY - W}
-       C${CX - 30} ${CY - W - 6}, ${CX - 75} ${CY - W - 12}, ${CX - 115} ${CY - W - 10}
-       C${CX - 142} ${CY - W - 8}, ${CX - 158} ${CY - 18}, ${CX - 160} ${CY - 32}
-       C${CX - 162} ${CY - 44}, ${CX - 152} ${CY - 48}, ${CX - 145} ${CY - 38}
-       C${CX - 138} ${CY - 28}, ${CX - 142} ${CY - 20}, ${CX - 125} ${CY + W - 14}
-       C${CX - 82} ${CY + W - 6}, ${CX - 35} ${CY + W - 2}, ${CX} ${CY + W} Z`,
+       C${CX - W - 14} ${CY - 26}, ${CX - W - 38} ${CY - 62}, ${CX - W - 62} ${CY - 98}
+       C${CX - W - 78} ${CY - 122}, ${CX - W - 64} ${CY - 140}, ${CX - W - 56} ${CY - 142}
+       L${CX + W - 62} ${CY - 139}
+       C${CX + W - 58} ${CY - 122}, ${CX + W - 50} ${CY - 95}, ${CX + W - 34} ${CY - 60}
+       C${CX + W - 12} ${CY - 26}, ${CX + W} ${CY - 8}, ${CX + W} ${CY} Z`,
     delay: 140,
   },
-  // Near-horizontal right
-  {
-    d: `M${CX} ${CY - W}
-       C${CX + 32} ${CY - W - 8}, ${CX + 78} ${CY - W - 14}, ${CX + 120} ${CY - W - 12}
-       C${CX + 148} ${CY - W - 10}, ${CX + 164} ${CY - 20}, ${CX + 166} ${CY - 35}
-       C${CX + 168} ${CY - 48}, ${CX + 158} ${CY - 52}, ${CX + 150} ${CY - 42}
-       C${CX + 142} ${CY - 32}, ${CX + 146} ${CY - 22}, ${CX + 130} ${CY + W - 16}
-       C${CX + 86} ${CY + W - 8}, ${CX + 38} ${CY + W - 2}, ${CX} ${CY + W} Z`,
-    delay: 180,
-  },
-  // Extra upper fill — between center and left lean
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 8} ${CY - 26}, ${CX - W - 22} ${CY - 62}, ${CX - W - 32} ${CY - 95}
-       C${CX - W - 38} ${CY - 118}, ${CX - W - 30} ${CY - 138}, ${CX - W - 18} ${CY - 145}
-       C${CX - W - 6} ${CY - 150}, ${CX + 2} ${CY - 142}, ${CX} ${CY - 128}
-       C${CX - 2} ${CY - 115}, ${CX - W - 8} ${CY - 110}, ${CX + W - 28} ${CY - 98}
-       C${CX + W - 18} ${CY - 64}, ${CX + W - 6} ${CY - 28}, ${CX + W} ${CY} Z`,
-    delay: 260,
-  },
-  // Extra upper fill — between center and right lean
+  // Right ~42°
   {
     d: `M${CX + W} ${CY}
-       C${CX + W + 10} ${CY - 28}, ${CX + W + 25} ${CY - 65}, ${CX + W + 36} ${CY - 98}
-       C${CX + W + 42} ${CY - 120}, ${CX + W + 34} ${CY - 140}, ${CX + W + 22} ${CY - 148}
-       C${CX + W + 10} ${CY - 152}, ${CX + 2} ${CY - 144}, ${CX + 4} ${CY - 130}
-       C${CX + 6} ${CY - 118}, ${CX + W + 10} ${CY - 112}, ${CX - W + 32} ${CY - 100}
-       C${CX - W + 22} ${CY - 66}, ${CX - W + 8} ${CY - 30}, ${CX - W} ${CY} Z`,
-    delay: 280,
+       C${CX + W + 16} ${CY - 28}, ${CX + W + 42} ${CY - 65}, ${CX + W + 66} ${CY - 100}
+       C${CX + W + 82} ${CY - 124}, ${CX + W + 68} ${CY - 142}, ${CX + W + 60} ${CY - 144}
+       L${CX - W + 66} ${CY - 141}
+       C${CX - W + 62} ${CY - 124}, ${CX - W + 54} ${CY - 98}, ${CX - W + 38} ${CY - 62}
+       C${CX - W + 14} ${CY - 28}, ${CX - W} ${CY - 8}, ${CX - W} ${CY} Z`,
+    delay: 180,
+  },
+  // Left ~62°
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 20} ${CY - 18}, ${CX - W - 55} ${CY - 42}, ${CX - W - 88} ${CY - 66}
+       C${CX - W - 108} ${CY - 82}, ${CX - W - 100} ${CY - 102}, ${CX - W - 95} ${CY - 105}
+       L${CX + W - 100} ${CY - 102}
+       C${CX + W - 95} ${CY - 85}, ${CX + W - 82} ${CY - 62}, ${CX + W - 50} ${CY - 40}
+       C${CX + W - 18} ${CY - 18}, ${CX + W} ${CY - 5}, ${CX + W} ${CY} Z`,
+    delay: 220,
+  },
+  // Right ~62°
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 22} ${CY - 20}, ${CX + W + 58} ${CY - 44}, ${CX + W + 92} ${CY - 68}
+       C${CX + W + 112} ${CY - 84}, ${CX + W + 104} ${CY - 104}, ${CX + W + 100} ${CY - 108}
+       L${CX - W + 104} ${CY - 105}
+       C${CX - W + 100} ${CY - 88}, ${CX - W + 86} ${CY - 65}, ${CX - W + 54} ${CY - 42}
+       C${CX - W + 20} ${CY - 20}, ${CX - W} ${CY - 5}, ${CX - W} ${CY} Z`,
+    delay: 250,
+  },
+  // Left ~80° — nearly horizontal
+  {
+    d: `M${CX} ${CY - W}
+       C${CX - 28} ${CY - W - 4}, ${CX - 72} ${CY - W - 10}, ${CX - 115} ${CY - W - 12}
+       C${CX - 142} ${CY - W - 12}, ${CX - 156} ${CY - 22}, ${CX - 158} ${CY - 28}
+       L${CX - 155} ${CY + W - 22}
+       C${CX - 142} ${CY + W - 12}, ${CX - 112} ${CY + W - 6}, ${CX - 72} ${CY + W - 2}
+       C${CX - 28} ${CY + W}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
+    delay: 40,
+  },
+  // Right ~80° — nearly horizontal
+  {
+    d: `M${CX} ${CY - W}
+       C${CX + 30} ${CY - W - 5}, ${CX + 76} ${CY - W - 12}, ${CX + 120} ${CY - W - 14}
+       C${CX + 148} ${CY - W - 13}, ${CX + 162} ${CY - 24}, ${CX + 164} ${CY - 30}
+       L${CX + 161} ${CY + W - 24}
+       C${CX + 148} ${CY + W - 13}, ${CX + 118} ${CY + W - 8}, ${CX + 76} ${CY + W - 3}
+       C${CX + 30} ${CY + W - 1}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
+    delay: 80,
   },
 
-  // ==== LOWER PETALS — four parenthesis-shaped curves framing the stem ====
+  // ==== LOWER PETALS — four parenthesis curves, sharp pointed tips ====
 
-  // Outer left "(" — arcs out left then curves down
+  // Outer left "("
   {
     d: `M${CX} ${CY + W}
        C${CX - 35} ${CY + W + 5}, ${CX - 70} ${CY + W + 18}, ${CX - 85} ${CY + W + 40}
-       C${CX - 95} ${CY + W + 58}, ${CX - 88} ${CY + W + 78}, ${CX - 72} ${CY + W + 88}
-       L${CX - 65} ${CY - W + 85}
-       C${CX - 80} ${CY - W + 72}, ${CX - 88} ${CY - W + 52}, ${CX - 78} ${CY - W + 35}
-       C${CX - 65} ${CY - W + 16}, ${CX - 32} ${CY - W + 4}, ${CX} ${CY - W} Z`,
+       C${CX - 95} ${CY + W + 58}, ${CX - 88} ${CY + W + 78}, ${CX - 68} ${CY + 86}
+       C${CX - 82} ${CY + 72}, ${CX - 88} ${CY + 52}, ${CX - 78} ${CY + 35}
+       C${CX - 65} ${CY + 16}, ${CX - 32} ${CY + 4}, ${CX} ${CY - W} Z`,
     delay: 280,
   },
-  // Outer right ")" — mirror
+  // Outer right ")"
   {
     d: `M${CX} ${CY + W}
        C${CX + 38} ${CY + W + 6}, ${CX + 72} ${CY + W + 20}, ${CX + 88} ${CY + W + 42}
-       C${CX + 98} ${CY + W + 60}, ${CX + 92} ${CY + W + 80}, ${CX + 76} ${CY + W + 90}
-       L${CX + 69} ${CY - W + 87}
-       C${CX + 84} ${CY - W + 74}, ${CX + 92} ${CY - W + 54}, ${CX + 82} ${CY - W + 37}
-       C${CX + 68} ${CY - W + 18}, ${CX + 35} ${CY - W + 5}, ${CX} ${CY - W} Z`,
+       C${CX + 98} ${CY + W + 60}, ${CX + 92} ${CY + W + 80}, ${CX + 72} ${CY + 88}
+       C${CX + 86} ${CY + 74}, ${CX + 92} ${CY + 54}, ${CX + 82} ${CY + 37}
+       C${CX + 68} ${CY + 18}, ${CX + 35} ${CY + 5}, ${CX} ${CY - W} Z`,
     delay: 320,
   },
-  // Inner left "(" — tighter, closer to stem
+  // Inner left "("
   {
     d: `M${CX} ${CY + W}
        C${CX - 20} ${CY + W + 6}, ${CX - 42} ${CY + W + 20}, ${CX - 52} ${CY + W + 38}
-       C${CX - 58} ${CY + W + 52}, ${CX - 52} ${CY + W + 68}, ${CX - 40} ${CY + W + 76}
-       L${CX - 34} ${CY - W + 73}
-       C${CX - 45} ${CY - W + 62}, ${CX - 50} ${CY - W + 46}, ${CX - 44} ${CY - W + 32}
-       C${CX - 36} ${CY - W + 18}, ${CX - 18} ${CY - W + 5}, ${CX} ${CY - W} Z`,
+       C${CX - 58} ${CY + W + 52}, ${CX - 52} ${CY + W + 68}, ${CX - 37} ${CY + 74}
+       C${CX - 48} ${CY + 62}, ${CX - 52} ${CY + 46}, ${CX - 44} ${CY + 32}
+       C${CX - 36} ${CY + 18}, ${CX - 18} ${CY + 5}, ${CX} ${CY - W} Z`,
     delay: 360,
   },
-  // Inner right ")" — mirror
+  // Inner right ")"
   {
     d: `M${CX} ${CY + W}
        C${CX + 22} ${CY + W + 8}, ${CX + 45} ${CY + W + 22}, ${CX + 55} ${CY + W + 40}
-       C${CX + 62} ${CY + W + 55}, ${CX + 56} ${CY + W + 70}, ${CX + 44} ${CY + W + 78}
-       L${CX + 38} ${CY - W + 75}
-       C${CX + 48} ${CY - W + 64}, ${CX + 54} ${CY - W + 48}, ${CX + 48} ${CY - W + 34}
-       C${CX + 40} ${CY - W + 20}, ${CX + 20} ${CY - W + 6}, ${CX} ${CY - W} Z`,
+       C${CX + 62} ${CY + W + 55}, ${CX + 56} ${CY + W + 70}, ${CX + 41} ${CY + 76}
+       C${CX + 52} ${CY + 64}, ${CX + 56} ${CY + 48}, ${CX + 48} ${CY + 34}
+       C${CX + 40} ${CY + 20}, ${CX + 20} ${CY + 6}, ${CX} ${CY - W} Z`,
     delay: 400,
   },
 ];
@@ -268,15 +223,15 @@ const SpiderLily = ({ className }: { className?: string }) => {
       <g filter="url(#ink-texture)">
         {/* Stem — brush stroke: wide at flower head, trails to a wisp */}
         <path
-          d={`M${CX - 7} ${CY}
-              C${CX - 9} ${CY + 25}, ${CX - 10} 280, ${CX - 8} 330
-              C${CX - 5} 375, ${CX - 8} 420, ${CX - 10} 470
-              C${CX - 9} 515, ${CX - 6} 550, ${CX - 4} 580
-              Q${CX - 3} 594, ${CX - 1} 598
-              Q${CX + 2} 594, ${CX + 3} 580
-              C${CX + 4} 550, ${CX + 1} 515, ${CX} 470
-              C${CX - 1} 420, ${CX + 3} 375, ${CX + 5} 330
-              C${CX + 7} 280, ${CX + 8} ${CY + 25}, ${CX + 7} ${CY}
+          d={`M${CX - 5} ${CY}
+              C${CX - 6} ${CY + 25}, ${CX - 7} 280, ${CX - 6} 330
+              C${CX - 4} 375, ${CX - 6} 420, ${CX - 7} 470
+              C${CX - 6} 515, ${CX - 4} 550, ${CX - 3} 580
+              Q${CX - 2} 594, ${CX} 598
+              Q${CX + 2} 594, ${CX + 2} 580
+              C${CX + 3} 550, ${CX + 1} 515, ${CX} 470
+              C${CX - 1} 420, ${CX + 2} 375, ${CX + 4} 330
+              C${CX + 5} 280, ${CX + 5} ${CY + 25}, ${CX + 5} ${CY}
               Z`}
           className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
         />

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -9,166 +9,164 @@ import { useEffect, useState } from 'react';
 const CX = 220;
 const CY = 230;
 
-// Reference analysis: most petal mass droops BELOW center, curling down
-// and outward like a skirt, with tips curling back up. Only 2-3 short
-// petals go upward. The shape is WIDE and DROOPING, not a vertical fan.
+// Dense upper crown + few long swooping jellyfish tentacles below.
 // W = half-width of ribbon.
 const W = 4;
 const petals: { d: string; delay: number }[] = [
-  // ==== DROOPING LEFT — the main visual mass ====
-  // Far left — drops down-left, sweeps wide, tip curls up
+  // ==== DENSE UPPER CROWN — many petals radiating up and outward ====
+
+  // Top center — straight up
   {
-    d: `M${CX} ${CY + W}
-       C${CX - 35} ${CY + W + 15}, ${CX - 80} ${CY + W + 45}, ${CX - 120} ${CY + W + 68}
-       C${CX - 145} ${CY + W + 80}, ${CX - 162} ${CY + 78}, ${CX - 165} ${CY + 62}
-       C${CX - 166} ${CY + 48}, ${CX - 155} ${CY + 45}, ${CX - 150} ${CY + 55}
-       C${CX - 145} ${CY + 65}, ${CX - 148} ${CY + 72}, ${CX - 130} ${CY - W + 65}
-       C${CX - 90} ${CY - W + 45}, ${CX - 40} ${CY - W + 18}, ${CX} ${CY - W} Z`,
+    d: `M${CX - W} ${CY}
+       C${CX - W} ${CY - 30}, ${CX - W - 2} ${CY - 70}, ${CX - W - 3} ${CY - 105}
+       C${CX - W - 4} ${CY - 128}, ${CX - W + 1} ${CY - 148}, ${CX + 2} ${CY - 155}
+       C${CX + W + 2} ${CY - 158}, ${CX + W + 4} ${CY - 148}, ${CX + W + 2} ${CY - 130}
+       C${CX + W} ${CY - 112}, ${CX + W - 1} ${CY - 100}, ${CX + W} ${CY - 80}
+       C${CX + W} ${CY - 52}, ${CX + W} ${CY - 28}, ${CX + W} ${CY} Z`,
     delay: 0,
   },
-  // Left mid-drop — slightly less steep
+  // Top slight left lean
   {
-    d: `M${CX} ${CY + W}
-       C${CX - 40} ${CY + W + 10}, ${CX - 90} ${CY + W + 30}, ${CX - 130} ${CY + W + 42}
-       C${CX - 155} ${CY + W + 48}, ${CX - 170} ${CY + 38}, ${CX - 172} ${CY + 22}
-       C${CX - 172} ${CY + 8}, ${CX - 162} ${CY + 5}, ${CX - 158} ${CY + 15}
-       C${CX - 154} ${CY + 25}, ${CX - 158} ${CY + 32}, ${CX - 140} ${CY - W + 38}
-       C${CX - 100} ${CY - W + 25}, ${CX - 45} ${CY - W + 8}, ${CX} ${CY - W} Z`,
+    d: `M${CX - W} ${CY}
+       C${CX - W - 5} ${CY - 28}, ${CX - W - 14} ${CY - 68}, ${CX - W - 20} ${CY - 105}
+       C${CX - W - 24} ${CY - 130}, ${CX - W - 16} ${CY - 150}, ${CX - 4} ${CY - 158}
+       C${CX + 6} ${CY - 162}, ${CX + 12} ${CY - 152}, ${CX + 8} ${CY - 138}
+       C${CX + 4} ${CY - 124}, ${CX - 4} ${CY - 118}, ${CX + W - 16} ${CY - 102}
+       C${CX + W - 10} ${CY - 68}, ${CX + W - 3} ${CY - 30}, ${CX + W} ${CY} Z`,
+    delay: 50,
+  },
+  // Top slight right lean
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 6} ${CY - 30}, ${CX + W + 16} ${CY - 72}, ${CX + W + 22} ${CY - 108}
+       C${CX + W + 26} ${CY - 132}, ${CX + W + 18} ${CY - 152}, ${CX + 5} ${CY - 160}
+       C${CX - 6} ${CY - 164}, ${CX - 10} ${CY - 154}, ${CX - 6} ${CY - 140}
+       C${CX - 2} ${CY - 126}, ${CX + 6} ${CY - 120}, ${CX - W + 18} ${CY - 105}
+       C${CX - W + 12} ${CY - 70}, ${CX - W + 4} ${CY - 32}, ${CX - W} ${CY} Z`,
     delay: 80,
   },
-  // Left upper-drop — goes out left, slight downward, curls back
+  // Upper-left diagonal — ~45 degrees
   {
-    d: `M${CX} ${CY - W}
-       C${CX - 42} ${CY - W - 2}, ${CX - 95} ${CY - W + 8}, ${CX - 135} ${CY - W + 18}
-       C${CX - 158} ${CY - W + 25}, ${CX - 170} ${CY + 15}, ${CX - 168} ${CY}
-       C${CX - 166} ${CY - 14}, ${CX - 156} ${CY - 18}, ${CX - 152} ${CY - 8}
-       C${CX - 148} ${CY + 2}, ${CX - 152} ${CY + 10}, ${CX - 135} ${CY + W + 10}
-       C${CX - 95} ${CY + W + 2}, ${CX - 42} ${CY + W - 2}, ${CX} ${CY + W} Z`,
-    delay: 160,
-  },
-  // Left steep drop — goes sharply down-left
-  {
-    d: `M${CX} ${CY + W}
-       C${CX - 25} ${CY + W + 20}, ${CX - 55} ${CY + W + 55}, ${CX - 80} ${CY + W + 85}
-       C${CX - 95} ${CY + W + 100}, ${CX - 108} ${CY + 102}, ${CX - 112} ${CY + 88}
-       C${CX - 115} ${CY + 75}, ${CX - 105} ${CY + 70}, ${CX - 100} ${CY + 80}
-       C${CX - 95} ${CY + 90}, ${CX - 98} ${CY + 95}, ${CX - 78} ${CY - W + 82}
-       C${CX - 52} ${CY - W + 55}, ${CX - 25} ${CY - W + 22}, ${CX} ${CY - W} Z`,
-    delay: 240,
-  },
-
-  // ==== DROOPING RIGHT — mirror mass ====
-  // Far right drop
-  {
-    d: `M${CX} ${CY + W}
-       C${CX + 38} ${CY + W + 16}, ${CX + 85} ${CY + W + 48}, ${CX + 125} ${CY + W + 72}
-       C${CX + 150} ${CY + W + 84}, ${CX + 168} ${CY + 80}, ${CX + 170} ${CY + 64}
-       C${CX + 172} ${CY + 50}, ${CX + 160} ${CY + 46}, ${CX + 155} ${CY + 56}
-       C${CX + 150} ${CY + 66}, ${CX + 152} ${CY + 74}, ${CX + 135} ${CY - W + 68}
-       C${CX + 95} ${CY - W + 48}, ${CX + 42} ${CY - W + 20}, ${CX} ${CY - W} Z`,
-    delay: 40,
-  },
-  // Right mid-drop
-  {
-    d: `M${CX} ${CY + W}
-       C${CX + 42} ${CY + W + 12}, ${CX + 95} ${CY + W + 32}, ${CX + 135} ${CY + W + 44}
-       C${CX + 160} ${CY + W + 50}, ${CX + 175} ${CY + 40}, ${CX + 178} ${CY + 24}
-       C${CX + 178} ${CY + 10}, ${CX + 168} ${CY + 6}, ${CX + 162} ${CY + 16}
-       C${CX + 158} ${CY + 26}, ${CX + 162} ${CY + 34}, ${CX + 145} ${CY - W + 40}
-       C${CX + 105} ${CY - W + 28}, ${CX + 48} ${CY - W + 10}, ${CX} ${CY - W} Z`,
+    d: `M${CX - W} ${CY}
+       C${CX - W - 12} ${CY - 22}, ${CX - W - 35} ${CY - 55}, ${CX - W - 55} ${CY - 85}
+       C${CX - W - 68} ${CY - 105}, ${CX - W - 62} ${CY - 128}, ${CX - W - 48} ${CY - 138}
+       C${CX - W - 35} ${CY - 145}, ${CX - W - 25} ${CY - 136}, ${CX - W - 30} ${CY - 122}
+       C${CX - W - 35} ${CY - 110}, ${CX - W - 42} ${CY - 105}, ${CX + W - 50} ${CY - 90}
+       C${CX + W - 32} ${CY - 58}, ${CX + W - 10} ${CY - 25}, ${CX + W} ${CY} Z`,
     delay: 120,
   },
-  // Right upper-drop
+  // Upper-right diagonal — ~45 degrees
   {
-    d: `M${CX} ${CY - W}
-       C${CX + 45} ${CY - W - 4}, ${CX + 100} ${CY - W + 5}, ${CX + 140} ${CY - W + 15}
-       C${CX + 162} ${CY - W + 22}, ${CX + 175} ${CY + 12}, ${CX + 172} ${CY - 2}
-       C${CX + 170} ${CY - 16}, ${CX + 160} ${CY - 20}, ${CX + 156} ${CY - 10}
-       C${CX + 152} ${CY}, ${CX + 156} ${CY + 8}, ${CX + 140} ${CY + W + 8}
-       C${CX + 100} ${CY + W}, ${CX + 45} ${CY + W - 4}, ${CX} ${CY + W} Z`,
+    d: `M${CX + W} ${CY}
+       C${CX + W + 14} ${CY - 24}, ${CX + W + 38} ${CY - 58}, ${CX + W + 60} ${CY - 88}
+       C${CX + W + 72} ${CY - 108}, ${CX + W + 66} ${CY - 132}, ${CX + W + 52} ${CY - 142}
+       C${CX + W + 38} ${CY - 148}, ${CX + W + 28} ${CY - 140}, ${CX + W + 34} ${CY - 125}
+       C${CX + W + 38} ${CY - 112}, ${CX + W + 46} ${CY - 108}, ${CX - W + 55} ${CY - 94}
+       C${CX - W + 36} ${CY - 60}, ${CX - W + 12} ${CY - 26}, ${CX - W} ${CY} Z`,
+    delay: 160,
+  },
+  // Far upper-left — ~60 degrees out, wide spread
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 18} ${CY - 16}, ${CX - W - 52} ${CY - 40}, ${CX - W - 88} ${CY - 58}
+       C${CX - W - 112} ${CY - 70}, ${CX - W - 128} ${CY - 65}, ${CX - W - 135} ${CY - 48}
+       C${CX - W - 140} ${CY - 34}, ${CX - W - 130} ${CY - 28}, ${CX - W - 120} ${CY - 38}
+       C${CX - W - 112} ${CY - 48}, ${CX - W - 116} ${CY - 55}, ${CX + W - 105} ${CY - 52}
+       C${CX + W - 68} ${CY - 38}, ${CX + W - 28} ${CY - 18}, ${CX + W} ${CY} Z`,
+    delay: 40,
+  },
+  // Far upper-right — ~60 degrees out
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 20} ${CY - 18}, ${CX + W + 55} ${CY - 42}, ${CX + W + 92} ${CY - 62}
+       C${CX + W + 116} ${CY - 74}, ${CX + W + 132} ${CY - 68}, ${CX + W + 140} ${CY - 52}
+       C${CX + W + 145} ${CY - 38}, ${CX + W + 135} ${CY - 30}, ${CX + W + 124} ${CY - 40}
+       C${CX + W + 116} ${CY - 50}, ${CX + W + 120} ${CY - 58}, ${CX - W + 110} ${CY - 55}
+       C${CX - W + 72} ${CY - 40}, ${CX - W + 30} ${CY - 20}, ${CX - W} ${CY} Z`,
+    delay: 100,
+  },
+  // Upper-left between 45 and 60 — fills the gap
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 15} ${CY - 20}, ${CX - W - 42} ${CY - 48}, ${CX - W - 70} ${CY - 72}
+       C${CX - W - 88} ${CY - 88}, ${CX - W - 85} ${CY - 110}, ${CX - W - 72} ${CY - 118}
+       C${CX - W - 60} ${CY - 124}, ${CX - W - 50} ${CY - 115}, ${CX - W - 55} ${CY - 102}
+       C${CX - W - 58} ${CY - 90}, ${CX - W - 65} ${CY - 85}, ${CX + W - 62} ${CY - 75}
+       C${CX + W - 40} ${CY - 50}, ${CX + W - 15} ${CY - 22}, ${CX + W} ${CY} Z`,
     delay: 200,
   },
-  // Right steep drop
+  // Upper-right between 45 and 60
   {
-    d: `M${CX} ${CY + W}
-       C${CX + 28} ${CY + W + 22}, ${CX + 58} ${CY + W + 58}, ${CX + 85} ${CY + W + 88}
-       C${CX + 100} ${CY + W + 104}, ${CX + 112} ${CY + 105}, ${CX + 116} ${CY + 90}
-       C${CX + 118} ${CY + 78}, ${CX + 108} ${CY + 72}, ${CX + 104} ${CY + 82}
-       C${CX + 100} ${CY + 92}, ${CX + 102} ${CY + 98}, ${CX + 82} ${CY - W + 85}
-       C${CX + 56} ${CY - W + 58}, ${CX + 28} ${CY - W + 24}, ${CX} ${CY - W} Z`,
+    d: `M${CX + W} ${CY}
+       C${CX + W + 16} ${CY - 22}, ${CX + W + 45} ${CY - 50}, ${CX + W + 74} ${CY - 76}
+       C${CX + W + 92} ${CY - 92}, ${CX + W + 90} ${CY - 114}, ${CX + W + 76} ${CY - 122}
+       C${CX + W + 64} ${CY - 128}, ${CX + W + 54} ${CY - 118}, ${CX + W + 58} ${CY - 105}
+       C${CX + W + 62} ${CY - 94}, ${CX + W + 68} ${CY - 88}, ${CX - W + 66} ${CY - 78}
+       C${CX - W + 44} ${CY - 52}, ${CX - W + 16} ${CY - 24}, ${CX - W} ${CY} Z`,
+    delay: 230,
+  },
+  // Near-horizontal left — wide spread at ~80 degrees
+  {
+    d: `M${CX} ${CY - W}
+       C${CX - 30} ${CY - W - 6}, ${CX - 75} ${CY - W - 12}, ${CX - 115} ${CY - W - 10}
+       C${CX - 142} ${CY - W - 8}, ${CX - 158} ${CY - 18}, ${CX - 160} ${CY - 32}
+       C${CX - 162} ${CY - 44}, ${CX - 152} ${CY - 48}, ${CX - 145} ${CY - 38}
+       C${CX - 138} ${CY - 28}, ${CX - 142} ${CY - 20}, ${CX - 125} ${CY + W - 14}
+       C${CX - 82} ${CY + W - 6}, ${CX - 35} ${CY + W - 2}, ${CX} ${CY + W} Z`,
+    delay: 140,
+  },
+  // Near-horizontal right
+  {
+    d: `M${CX} ${CY - W}
+       C${CX + 32} ${CY - W - 8}, ${CX + 78} ${CY - W - 14}, ${CX + 120} ${CY - W - 12}
+       C${CX + 148} ${CY - W - 10}, ${CX + 164} ${CY - 20}, ${CX + 166} ${CY - 35}
+       C${CX + 168} ${CY - 48}, ${CX + 158} ${CY - 52}, ${CX + 150} ${CY - 42}
+       C${CX + 142} ${CY - 32}, ${CX + 146} ${CY - 22}, ${CX + 130} ${CY + W - 16}
+       C${CX + 86} ${CY + W - 8}, ${CX + 38} ${CY + W - 2}, ${CX} ${CY + W} Z`,
+    delay: 180,
+  },
+  // Extra upper fill — between center and left lean
+  {
+    d: `M${CX - W} ${CY}
+       C${CX - W - 8} ${CY - 26}, ${CX - W - 22} ${CY - 62}, ${CX - W - 32} ${CY - 95}
+       C${CX - W - 38} ${CY - 118}, ${CX - W - 30} ${CY - 138}, ${CX - W - 18} ${CY - 145}
+       C${CX - W - 6} ${CY - 150}, ${CX + 2} ${CY - 142}, ${CX} ${CY - 128}
+       C${CX - 2} ${CY - 115}, ${CX - W - 8} ${CY - 110}, ${CX + W - 28} ${CY - 98}
+       C${CX + W - 18} ${CY - 64}, ${CX + W - 6} ${CY - 28}, ${CX + W} ${CY} Z`,
+    delay: 260,
+  },
+  // Extra upper fill — between center and right lean
+  {
+    d: `M${CX + W} ${CY}
+       C${CX + W + 10} ${CY - 28}, ${CX + W + 25} ${CY - 65}, ${CX + W + 36} ${CY - 98}
+       C${CX + W + 42} ${CY - 120}, ${CX + W + 34} ${CY - 140}, ${CX + W + 22} ${CY - 148}
+       C${CX + W + 10} ${CY - 152}, ${CX + 2} ${CY - 144}, ${CX + 4} ${CY - 130}
+       C${CX + 6} ${CY - 118}, ${CX + W + 10} ${CY - 112}, ${CX - W + 32} ${CY - 100}
+       C${CX - W + 22} ${CY - 66}, ${CX - W + 8} ${CY - 30}, ${CX - W} ${CY} Z`,
     delay: 280,
   },
 
-  // ==== UPPER — spreading out wide at various angles ====
-  // Upper far-left — goes up and out left, curls back
+  // ==== LOWER PETALS — two short, curving down then bending inward ====
+
+  // Left — gentle arc down-left, curves back toward center at mid-point
   {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 15} ${CY - 18}, ${CX - W - 45} ${CY - 45}, ${CX - W - 78} ${CY - 62}
-       C${CX - W - 100} ${CY - 72}, ${CX - W - 118} ${CY - 68}, ${CX - W - 125} ${CY - 52}
-       C${CX - W - 130} ${CY - 38}, ${CX - W - 120} ${CY - 32}, ${CX - W - 112} ${CY - 42}
-       C${CX - W - 105} ${CY - 52}, ${CX - W - 108} ${CY - 58}, ${CX + W - 95} ${CY - 55}
-       C${CX + W - 60} ${CY - 42}, ${CX + W - 25} ${CY - 20}, ${CX + W} ${CY} Z`,
-    delay: 60,
+    d: `M${CX} ${CY + W}
+       C${CX - 20} ${CY + W + 10}, ${CX - 45} ${CY + W + 25}, ${CX - 65} ${CY + W + 35}
+       C${CX - 78} ${CY + W + 42}, ${CX - 82} ${CY + W + 48}, ${CX - 76} ${CY + W + 52}
+       C${CX - 68} ${CY + W + 55}, ${CX - 60} ${CY + W + 48}, ${CX - 58} ${CY + W + 40}
+       C${CX - 55} ${CY + W + 32}, ${CX - 58} ${CY + 38}, ${CX - 50} ${CY + 28}
+       C${CX - 35} ${CY + 16}, ${CX - 18} ${CY + 6}, ${CX} ${CY - W} Z`,
+    delay: 300,
   },
-  // Upper far-right — mirror
+  // Right — mirror
   {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 18} ${CY - 20}, ${CX + W + 48} ${CY - 48}, ${CX + W + 82} ${CY - 66}
-       C${CX + W + 105} ${CY - 76}, ${CX + W + 122} ${CY - 72}, ${CX + W + 130} ${CY - 55}
-       C${CX + W + 135} ${CY - 42}, ${CX + W + 125} ${CY - 34}, ${CX + W + 116} ${CY - 44}
-       C${CX + W + 108} ${CY - 54}, ${CX + W + 112} ${CY - 62}, ${CX - W + 100} ${CY - 58}
-       C${CX - W + 65} ${CY - 45}, ${CX - W + 28} ${CY - 22}, ${CX - W} ${CY} Z`,
-    delay: 130,
-  },
-  // Upper-left diagonal — steeper
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 10} ${CY - 25}, ${CX - W - 28} ${CY - 62}, ${CX - W - 42} ${CY - 95}
-       C${CX - W - 52} ${CY - 118}, ${CX - W - 48} ${CY - 140}, ${CX - W - 35} ${CY - 148}
-       C${CX - W - 22} ${CY - 155}, ${CX - W - 12} ${CY - 145}, ${CX - W - 16} ${CY - 132}
-       C${CX - W - 20} ${CY - 120}, ${CX - W - 28} ${CY - 115}, ${CX + W - 38} ${CY - 100}
-       C${CX + W - 25} ${CY - 65}, ${CX + W - 8} ${CY - 28}, ${CX + W} ${CY} Z`,
-    delay: 100,
-  },
-  // Upper-right diagonal — steeper
-  {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 12} ${CY - 28}, ${CX + W + 32} ${CY - 65}, ${CX + W + 48} ${CY - 98}
-       C${CX + W + 58} ${CY - 122}, ${CX + W + 54} ${CY - 144}, ${CX + W + 40} ${CY - 152}
-       C${CX + W + 28} ${CY - 158}, ${CX + W + 16} ${CY - 148}, ${CX + W + 20} ${CY - 135}
-       C${CX + W + 24} ${CY - 122}, ${CX + W + 32} ${CY - 118}, ${CX - W + 42} ${CY - 104}
-       C${CX - W + 28} ${CY - 68}, ${CX - W + 10} ${CY - 30}, ${CX - W} ${CY} Z`,
-    delay: 190,
-  },
-  // Top left-lean
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W - 3} ${CY - 30}, ${CX - W - 10} ${CY - 72}, ${CX - W - 14} ${CY - 108}
-       C${CX - W - 16} ${CY - 132}, ${CX - W - 8} ${CY - 150}, ${CX + 2} ${CY - 155}
-       C${CX + 10} ${CY - 158}, ${CX + 14} ${CY - 148}, ${CX + 10} ${CY - 135}
-       C${CX + 6} ${CY - 122}, ${CX - 2} ${CY - 118}, ${CX + W - 10} ${CY - 105}
-       C${CX + W - 6} ${CY - 72}, ${CX + W - 1} ${CY - 30}, ${CX + W} ${CY} Z`,
-    delay: 50,
-  },
-  // Top right-lean
-  {
-    d: `M${CX + W} ${CY}
-       C${CX + W + 5} ${CY - 32}, ${CX + W + 14} ${CY - 75}, ${CX + W + 18} ${CY - 112}
-       C${CX + W + 20} ${CY - 135}, ${CX + W + 12} ${CY - 152}, ${CX + 2} ${CY - 158}
-       C${CX - 8} ${CY - 162}, ${CX - 12} ${CY - 152}, ${CX - 8} ${CY - 138}
-       C${CX - 4} ${CY - 125}, ${CX + 4} ${CY - 120}, ${CX - W + 14} ${CY - 108}
-       C${CX - W + 10} ${CY - 75}, ${CX - W + 3} ${CY - 32}, ${CX - W} ${CY} Z`,
-    delay: 150,
-  },
-  // Top center
-  {
-    d: `M${CX - W} ${CY}
-       C${CX - W} ${CY - 28}, ${CX - W - 3} ${CY - 65}, ${CX - W - 5} ${CY - 98}
-       C${CX - W - 6} ${CY - 120}, ${CX - W} ${CY - 138}, ${CX + 2} ${CY - 142}
-       C${CX + W + 2} ${CY - 145}, ${CX + W + 5} ${CY - 135}, ${CX + W + 3} ${CY - 122}
-       C${CX + W} ${CY - 108}, ${CX + W - 2} ${CY - 102}, ${CX + W} ${CY - 85}
-       C${CX + W} ${CY - 58}, ${CX + W} ${CY - 28}, ${CX + W} ${CY} Z`,
-    delay: 220,
+    d: `M${CX} ${CY + W}
+       C${CX + 22} ${CY + W + 12}, ${CX + 48} ${CY + W + 28}, ${CX + 68} ${CY + W + 38}
+       C${CX + 82} ${CY + W + 45}, ${CX + 86} ${CY + W + 52}, ${CX + 80} ${CY + W + 55}
+       C${CX + 72} ${CY + W + 58}, ${CX + 64} ${CY + W + 50}, ${CX + 62} ${CY + W + 42}
+       C${CX + 58} ${CY + W + 34}, ${CX + 62} ${CY + 40}, ${CX + 54} ${CY + 30}
+       C${CX + 38} ${CY + 18}, ${CX + 20} ${CY + 8}, ${CX} ${CY - W} Z`,
+    delay: 340,
   },
 ];
 
@@ -177,33 +175,44 @@ const petalDelays = petals.map((p) => p.delay);
 // Stamens: smooth wide U-arcs. All control points stay above CY (the center)
 // so nothing dips below the flower neck. Tips staggered naturally.
 const stamens = [
-  // ==== OUTERMOST — wide, shallow curve, control points above center ====
-  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 550 },
-  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 600 },
+  // ==== OUTERMOST — wide, shallow curve ====
+  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 18}, ${CX - 260} ${CY - 25}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 0 },
+  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 20}, ${CX + 256} ${CY - 28}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 40 },
 
   // ==== WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 650 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 700 },
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 22}, ${CX - 235} ${CY - 35}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 80 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 24}, ${CX + 232} ${CY - 38}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 120 },
 
   // ==== MID-WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 750 },
-  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 800 },
+  { d: `M${CX} ${CY - 12} C${CX - 65} ${CY - 38}, ${CX - 185} ${CY - 72}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 160 },
+  { d: `M${CX} ${CY - 12} C${CX + 62} ${CY - 40}, ${CX + 182} ${CY - 76}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 200 },
 
   // ==== UPPER ====
-  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 850 },
-  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 900 },
+  { d: `M${CX} ${CY - 12} C${CX - 40} ${CY - 55}, ${CX - 130} ${CY - 125}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 240 },
+  { d: `M${CX} ${CY - 12} C${CX + 38} ${CY - 58}, ${CX + 128} ${CY - 128}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 280 },
 
   // ==== CENTER ====
-  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 950 },
-  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 1000 },
+  { d: `M${CX} ${CY - 12} C${CX - 18} ${CY - 68}, ${CX - 58} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 320 },
+  { d: `M${CX} ${CY - 12} C${CX + 16} ${CY - 70}, ${CX + 56} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 360 },
 ];
 
+const STEM_DELAY = 150;
+const PETAL_DELAY = 650;
+const STAMEN_DELAY = 1000;
+const ANTHER_DELAY = STAMEN_DELAY + 550 + 360;
+
 const SpiderLily = ({ className }: { className?: string }) => {
-  const [bloomed, setBloomed] = useState(false);
+  const [stemActive, setStemActive] = useState(false);
+  const [petalsActive, setPetalsActive] = useState(false);
+  const [stamensActive, setStamensActive] = useState(false);
+  const [anthersActive, setAnthersActive] = useState(false);
 
   useEffect(() => {
-    const t = setTimeout(() => setBloomed(true), 300);
-    return () => clearTimeout(t);
+    const t1 = setTimeout(() => setStemActive(true), STEM_DELAY);
+    const t2 = setTimeout(() => setPetalsActive(true), PETAL_DELAY);
+    const t3 = setTimeout(() => setStamensActive(true), STAMEN_DELAY);
+    const t4 = setTimeout(() => setAnthersActive(true), ANTHER_DELAY);
+    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); clearTimeout(t4); };
   }, []);
 
   return (
@@ -251,7 +260,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
               C${CX - 1} 420, ${CX + 3} 375, ${CX + 5} 330
               C${CX + 7} 280, ${CX + 8} ${CY + 25}, ${CX + 7} ${CY}
               Z`}
-          className={`spider-lily-stem ${bloomed ? 'spider-lily-stem-active' : ''}`}
+          className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
         />
 
         {/* Petals */}
@@ -259,7 +268,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
           <path
             key={`petal-${i}`}
             d={p.d}
-            className={`spider-lily-petal ${bloomed ? 'spider-lily-petal-active' : ''}`}
+            className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
             style={{ animationDelay: `${petalDelays[i]}ms` }}
             pathLength={1}
           />
@@ -270,7 +279,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
           <g key={`stamen-${i}`}>
             <path
               d={s.d}
-              className={`spider-lily-stamen ${bloomed ? 'spider-lily-stamen-active' : ''}`}
+              className={`spider-lily-stamen ${stamensActive ? 'spider-lily-stamen-active' : ''}`}
               style={{ animationDelay: `${s.delay}ms` }}
               filter="url(#stamen-glow)"
               pathLength={1}
@@ -279,8 +288,8 @@ const SpiderLily = ({ className }: { className?: string }) => {
               cx={s.tipX}
               cy={s.tipY}
               r="2.2"
-              className={`spider-lily-anther ${bloomed ? 'spider-lily-anther-active' : ''}`}
-              style={{ animationDelay: `${s.delay + 180}ms` }}
+              className={`spider-lily-anther ${anthersActive ? 'spider-lily-anther-active' : ''}`}
+              style={{ animationDelay: `${s.delay}ms` }}
               filter="url(#stamen-glow)"
             />
           </g>
@@ -291,7 +300,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
           cx={CX}
           cy={CY}
           r="3"
-          className={`spider-lily-center ${bloomed ? 'spider-lily-center-active' : ''}`}
+          className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
         />
       </g>
     </svg>

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -194,21 +194,28 @@ const petals: { d: string; delay: number }[] = [
 
 const petalDelays = petals.map((p) => p.delay);
 
-// Stamens: smooth graceful U-arcs — sweep outward then curve back up.
-// Single long cubic beziers for buttery smooth curves, no kinks.
+// Stamens: smooth wide U-arcs. Tips staggered naturally around petal height.
+// Outer ones have a gentler, shallower curve. Inner ones arc higher.
 const stamens = [
-  // Far left — wide sweep out, gentle curve up
-  { d: `M${CX} ${CY - 10} C${CX - 80} ${CY - 15}, ${CX - 195} ${CY - 30}, ${CX - 205} ${CY - 150}`, tipX: CX - 205, tipY: CY - 150, delay: 580 },
-  // Far right
-  { d: `M${CX} ${CY - 10} C${CX + 78} ${CY - 18}, ${CX + 190} ${CY - 34}, ${CX + 202} ${CY - 155}`, tipX: CX + 202, tipY: CY - 155, delay: 650 },
-  // Left-upper — arcs out and up
-  { d: `M${CX} ${CY - 10} C${CX - 55} ${CY - 45}, ${CX - 155} ${CY - 105}, ${CX - 145} ${CY - 270}`, tipX: CX - 145, tipY: CY - 270, delay: 720 },
-  // Right-upper
-  { d: `M${CX} ${CY - 10} C${CX + 52} ${CY - 48}, ${CX + 150} ${CY - 110}, ${CX + 140} ${CY - 275}`, tipX: CX + 140, tipY: CY - 275, delay: 790 },
-  // Center-left — taller, gentle lean
-  { d: `M${CX} ${CY - 10} C${CX - 30} ${CY - 60}, ${CX - 80} ${CY - 180}, ${CX - 42} ${CY - 325}`, tipX: CX - 42, tipY: CY - 325, delay: 860 },
-  // Center-right
-  { d: `M${CX} ${CY - 10} C${CX + 28} ${CY - 62}, ${CX + 78} ${CY - 185}, ${CX + 45} ${CY - 328}`, tipX: CX + 45, tipY: CY - 328, delay: 930 },
+  // ==== OUTERMOST — very wide, shallow gentle curve, tips a bit lower ====
+  { d: `M${CX} ${CY - 8} C${CX - 140} ${CY + 10}, ${CX - 278} ${CY + 8}, ${CX - 280} ${CY - 120}`, tipX: CX - 280, tipY: CY - 120, delay: 550 },
+  { d: `M${CX} ${CY - 8} C${CX + 138} ${CY + 6}, ${CX + 274} ${CY + 5}, ${CX + 278} ${CY - 125}`, tipX: CX + 278, tipY: CY - 125, delay: 600 },
+
+  // ==== WIDE — slightly higher tips ====
+  { d: `M${CX} ${CY - 8} C${CX - 115} ${CY - 2}, ${CX - 250} ${CY - 8}, ${CX - 252} ${CY - 145}`, tipX: CX - 252, tipY: CY - 145, delay: 650 },
+  { d: `M${CX} ${CY - 8} C${CX + 112} ${CY - 5}, ${CX + 246} ${CY - 12}, ${CX + 250} ${CY - 140}`, tipX: CX + 250, tipY: CY - 140, delay: 700 },
+
+  // ==== MID-WIDE — tips near petal height ====
+  { d: `M${CX} ${CY - 8} C${CX - 72} ${CY - 28}, ${CX - 195} ${CY - 60}, ${CX - 205} ${CY - 165}`, tipX: CX - 205, tipY: CY - 165, delay: 750 },
+  { d: `M${CX} ${CY - 8} C${CX + 70} ${CY - 30}, ${CX + 192} ${CY - 65}, ${CX + 202} ${CY - 170}`, tipX: CX + 202, tipY: CY - 170, delay: 800 },
+
+  // ==== UPPER — tips at petal height ====
+  { d: `M${CX} ${CY - 8} C${CX - 45} ${CY - 50}, ${CX - 138} ${CY - 120}, ${CX - 142} ${CY - 180}`, tipX: CX - 142, tipY: CY - 180, delay: 850 },
+  { d: `M${CX} ${CY - 8} C${CX + 42} ${CY - 52}, ${CX + 135} ${CY - 125}, ${CX + 140} ${CY - 175}`, tipX: CX + 140, tipY: CY - 175, delay: 900 },
+
+  // ==== CENTER — tallest, just above petal height ====
+  { d: `M${CX} ${CY - 8} C${CX - 20} ${CY - 65}, ${CX - 62} ${CY - 155}, ${CX - 55} ${CY - 188}`, tipX: CX - 55, tipY: CY - 188, delay: 950 },
+  { d: `M${CX} ${CY - 8} C${CX + 18} ${CY - 68}, ${CX + 60} ${CY - 158}, ${CX + 52} ${CY - 185}`, tipX: CX + 52, tipY: CY - 185, delay: 1000 },
 ];
 
 const SpiderLily = ({ className }: { className?: string }) => {
@@ -221,7 +228,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
   return (
     <svg
-      viewBox="-10 -130 480 710"
+      viewBox="-120 10 680 590"
       className={className}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Side-view spider lily (彼岸花) — Japanese ink/anime aesthetic.
+ * Solid white filled petals with irregular widths and aggressive curling tips.
+ * Graceful curved stamens. Stem leans naturally.
+ */
+
+const CX = 218;
+const CY = 195;
+
+// Each petal is a closed filled shape — ribbon-like, wider in the middle,
+// tapering at base and tip, with a tight curl at the end.
+// Irregularity in widths and angles makes it feel hand-drawn.
+const petals: { d: string; delay: number }[] = [
+  // === FAR LEFT — wide sweep, aggressive curl down ===
+  {
+    d: `M${CX} ${CY} C${CX - 15} ${CY - 2}, ${CX - 45} ${CY - 8}, ${CX - 80} ${CY - 6}
+       C${CX - 105} ${CY - 4}, ${CX - 128} ${CY + 2}, ${CX - 140} ${CY + 15}
+       C${CX - 148} ${CY + 25}, ${CX - 145} ${CY + 35}, ${CX - 135} ${CY + 32}
+       C${CX - 125} ${CY + 28}, ${CX - 128} ${CY + 18}, ${CX - 122} ${CY + 8}
+       C${CX - 110} ${CY - 2}, ${CX - 82} ${CY - 2}, ${CX - 55} ${CY + 2}
+       C${CX - 30} ${CY + 5}, ${CX - 10} ${CY + 4}, ${CX} ${CY} Z`,
+    delay: 0,
+  },
+  // Left-upper sweep with tight hook
+  {
+    d: `M${CX} ${CY} C${CX - 12} ${CY - 8}, ${CX - 38} ${CY - 22}, ${CX - 68} ${CY - 30}
+       C${CX - 92} ${CY - 35}, ${CX - 115} ${CY - 32}, ${CX - 130} ${CY - 20}
+       C${CX - 140} ${CY - 10}, ${CX - 142} ${CY + 2}, ${CX - 132} ${CY + 5}
+       C${CX - 122} ${CY + 6}, ${CX - 120} ${CY - 5}, ${CX - 112} ${CY - 15}
+       C${CX - 98} ${CY - 28}, ${CX - 72} ${CY - 25}, ${CX - 48} ${CY - 18}
+       C${CX - 25} ${CY - 10}, ${CX - 8} ${CY - 3}, ${CX} ${CY} Z`,
+    delay: 80,
+  },
+  // Left-low sweep curling under
+  {
+    d: `M${CX} ${CY} C${CX - 10} ${CY + 4}, ${CX - 35} ${CY + 14}, ${CX - 62} ${CY + 22}
+       C${CX - 85} ${CY + 28}, ${CX - 105} ${CY + 35}, ${CX - 115} ${CY + 48}
+       C${CX - 120} ${CY + 58}, ${CX - 115} ${CY + 65}, ${CX - 105} ${CY + 60}
+       C${CX - 98} ${CY + 55}, ${CX - 100} ${CY + 45}, ${CX - 95} ${CY + 35}
+       C${CX - 85} ${CY + 22}, ${CX - 60} ${CY + 18}, ${CX - 38} ${CY + 12}
+       C${CX - 18} ${CY + 6}, ${CX - 5} ${CY + 2}, ${CX} ${CY} Z`,
+    delay: 160,
+  },
+
+  // === FAR RIGHT — mirror-ish but irregular ===
+  {
+    d: `M${CX} ${CY} C${CX + 18} ${CY - 4}, ${CX + 50} ${CY - 12}, ${CX + 85} ${CY - 10}
+       C${CX + 108} ${CY - 8}, ${CX + 130} ${CY - 2}, ${CX + 142} ${CY + 10}
+       C${CX + 150} ${CY + 20}, ${CX + 148} ${CY + 32}, ${CX + 138} ${CY + 30}
+       C${CX + 128} ${CY + 26}, ${CX + 130} ${CY + 14}, ${CX + 125} ${CY + 4}
+       C${CX + 112} ${CY - 4}, ${CX + 85} ${CY - 4}, ${CX + 58} ${CY}
+       C${CX + 32} ${CY + 3}, ${CX + 12} ${CY + 2}, ${CX} ${CY} Z`,
+    delay: 50,
+  },
+  // Right-upper with curl
+  {
+    d: `M${CX} ${CY} C${CX + 14} ${CY - 10}, ${CX + 42} ${CY - 25}, ${CX + 72} ${CY - 35}
+       C${CX + 95} ${CY - 40}, ${CX + 118} ${CY - 36}, ${CX + 132} ${CY - 22}
+       C${CX + 142} ${CY - 12}, ${CX + 144} ${CY}, ${CX + 134} ${CY + 2}
+       C${CX + 124} ${CY + 2}, ${CX + 122} ${CY - 8}, ${CX + 115} ${CY - 18}
+       C${CX + 100} ${CY - 30}, ${CX + 75} ${CY - 28}, ${CX + 50} ${CY - 20}
+       C${CX + 28} ${CY - 12}, ${CX + 10} ${CY - 4}, ${CX} ${CY} Z`,
+    delay: 130,
+  },
+  // Right-low curling under
+  {
+    d: `M${CX} ${CY} C${CX + 12} ${CY + 5}, ${CX + 38} ${CY + 16}, ${CX + 65} ${CY + 25}
+       C${CX + 88} ${CY + 32}, ${CX + 108} ${CY + 40}, ${CX + 118} ${CY + 52}
+       C${CX + 124} ${CY + 62}, ${CX + 118} ${CY + 68}, ${CX + 108} ${CY + 62}
+       C${CX + 100} ${CY + 55}, ${CX + 102} ${CY + 45}, ${CX + 98} ${CY + 38}
+       C${CX + 88} ${CY + 25}, ${CX + 62} ${CY + 20}, ${CX + 40} ${CY + 14}
+       C${CX + 20} ${CY + 8}, ${CX + 6} ${CY + 3}, ${CX} ${CY} Z`,
+    delay: 200,
+  },
+
+  // === UPPER — rise and hook back ===
+  {
+    d: `M${CX} ${CY} C${CX - 5} ${CY - 12}, ${CX - 15} ${CY - 38}, ${CX - 22} ${CY - 62}
+       C${CX - 28} ${CY - 82}, ${CX - 30} ${CY - 100}, ${CX - 25} ${CY - 110}
+       C${CX - 20} ${CY - 118}, ${CX - 12} ${CY - 115}, ${CX - 12} ${CY - 105}
+       C${CX - 12} ${CY - 95}, ${CX - 18} ${CY - 88}, ${CX - 18} ${CY - 72}
+       C${CX - 16} ${CY - 50}, ${CX - 8} ${CY - 28}, ${CX - 2} ${CY - 8}
+       L${CX} ${CY} Z`,
+    delay: 100,
+  },
+  {
+    d: `M${CX} ${CY} C${CX + 6} ${CY - 14}, ${CX + 18} ${CY - 42}, ${CX + 26} ${CY - 68}
+       C${CX + 32} ${CY - 88}, ${CX + 34} ${CY - 105}, ${CX + 28} ${CY - 115}
+       C${CX + 22} ${CY - 122}, ${CX + 14} ${CY - 118}, ${CX + 15} ${CY - 108}
+       C${CX + 16} ${CY - 98}, ${CX + 22} ${CY - 90}, ${CX + 22} ${CY - 75}
+       C${CX + 20} ${CY - 52}, ${CX + 12} ${CY - 30}, ${CX + 4} ${CY - 10}
+       L${CX} ${CY} Z`,
+    delay: 170,
+  },
+
+  // === UPPER-DIAGONAL — aggressive angular ===
+  {
+    d: `M${CX} ${CY} C${CX - 10} ${CY - 10}, ${CX - 30} ${CY - 35}, ${CX - 48} ${CY - 58}
+       C${CX - 62} ${CY - 75}, ${CX - 72} ${CY - 90}, ${CX - 70} ${CY - 100}
+       C${CX - 68} ${CY - 108}, ${CX - 60} ${CY - 108}, ${CX - 58} ${CY - 98}
+       C${CX - 56} ${CY - 88}, ${CX - 60} ${CY - 78}, ${CX - 52} ${CY - 65}
+       C${CX - 40} ${CY - 45}, ${CX - 22} ${CY - 25}, ${CX - 5} ${CY - 5}
+       L${CX} ${CY} Z`,
+    delay: 140,
+  },
+  {
+    d: `M${CX} ${CY} C${CX + 12} ${CY - 12}, ${CX + 35} ${CY - 38}, ${CX + 55} ${CY - 62}
+       C${CX + 68} ${CY - 78}, ${CX + 78} ${CY - 92}, ${CX + 75} ${CY - 102}
+       C${CX + 72} ${CY - 110}, ${CX + 64} ${CY - 108}, ${CX + 62} ${CY - 98}
+       C${CX + 60} ${CY - 88}, ${CX + 65} ${CY - 78}, ${CX + 58} ${CY - 65}
+       C${CX + 45} ${CY - 48}, ${CX + 25} ${CY - 28}, ${CX + 8} ${CY - 8}
+       L${CX} ${CY} Z`,
+    delay: 220,
+  },
+];
+
+const petalDelays = petals.map((p) => p.delay);
+
+// Stamens: graceful curves, not straight lines. Thin, elegant arcs.
+const stamens = [
+  { d: `M${CX} ${CY - 5} C${CX - 12} ${CY - 45}, ${CX - 30} ${CY - 100}, ${CX - 55} ${CY - 155} C${CX - 65} ${CY - 180}, ${CX - 72} ${CY - 200}, ${CX - 75} ${CY - 215}`, tipX: CX - 75, tipY: CY - 215, delay: 550 },
+  { d: `M${CX} ${CY - 5} C${CX + 10} ${CY - 48}, ${CX + 28} ${CY - 105}, ${CX + 50} ${CY - 158} C${CX + 60} ${CY - 182}, ${CX + 68} ${CY - 202}, ${CX + 72} ${CY - 218}`, tipX: CX + 72, tipY: CY - 218, delay: 620 },
+  { d: `M${CX} ${CY - 5} C${CX - 5} ${CY - 50}, ${CX - 12} ${CY - 110}, ${CX - 20} ${CY - 168} C${CX - 24} ${CY - 195}, ${CX - 26} ${CY - 215}, ${CX - 25} ${CY - 232}`, tipX: CX - 25, tipY: CY - 232, delay: 690 },
+  { d: `M${CX} ${CY - 5} C${CX + 5} ${CY - 52}, ${CX + 14} ${CY - 112}, ${CX + 22} ${CY - 170} C${CX + 26} ${CY - 198}, ${CX + 28} ${CY - 218}, ${CX + 28} ${CY - 235}`, tipX: CX + 28, tipY: CY - 235, delay: 760 },
+  { d: `M${CX} ${CY - 5} C${CX - 20} ${CY - 38}, ${CX - 52} ${CY - 82}, ${CX - 85} ${CY - 125} C${CX - 100} ${CY - 145}, ${CX - 112} ${CY - 160}, ${CX - 120} ${CY - 172}`, tipX: CX - 120, tipY: CY - 172, delay: 830 },
+  { d: `M${CX} ${CY - 5} C${CX + 18} ${CY - 40}, ${CX + 48} ${CY - 85}, ${CX + 80} ${CY - 128} C${CX + 95} ${CY - 148}, ${CX + 108} ${CY - 165}, ${CX + 115} ${CY - 175}`, tipX: CX + 115, tipY: CY - 175, delay: 900 },
+];
+
+const SpiderLily = ({ className }: { className?: string }) => {
+  const [bloomed, setBloomed] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setBloomed(true), 300);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <svg
+      viewBox="10 -60 400 580"
+      className={className}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <filter id="ink-texture">
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.04"
+            numOctaves="3"
+            result="noise"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="noise"
+            scale="1.2"
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+        <filter id="stamen-glow">
+          <feGaussianBlur stdDeviation="1.2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      <g filter="url(#ink-texture)">
+        {/* Stem — natural lean */}
+        <path
+          d={`M188 520 C190 475, 195 410, 200 350 C206 290, 214 245, ${CX} ${CY + 12}`}
+          className={`spider-lily-stem ${bloomed ? 'spider-lily-stem-active' : ''}`}
+          pathLength={1}
+        />
+
+        {/* Bracts */}
+        <path
+          d={`M${CX - 1} ${CY + 6} C${CX - 8} ${CY + 15}, ${CX - 14} ${CY + 28}, ${CX - 18} ${CY + 40}`}
+          className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
+          style={{ animationDelay: '120ms' }}
+          pathLength={1}
+        />
+        <path
+          d={`M${CX + 1} ${CY + 6} C${CX + 6} ${CY + 15}, ${CX + 10} ${CY + 28}, ${CX + 12} ${CY + 40}`}
+          className={`spider-lily-bract ${bloomed ? 'spider-lily-bract-active' : ''}`}
+          style={{ animationDelay: '150ms' }}
+          pathLength={1}
+        />
+
+        {/* Petals — solid white filled shapes */}
+        {petals.map((p, i) => (
+          <path
+            key={`petal-${i}`}
+            d={p.d}
+            className={`spider-lily-petal ${bloomed ? 'spider-lily-petal-active' : ''}`}
+            style={{ animationDelay: `${petalDelays[i]}ms` }}
+            pathLength={1}
+          />
+        ))}
+
+        {/* Stamens — graceful curves */}
+        {stamens.map((s, i) => (
+          <g key={`stamen-${i}`}>
+            <path
+              d={s.d}
+              className={`spider-lily-stamen ${bloomed ? 'spider-lily-stamen-active' : ''}`}
+              style={{ animationDelay: `${s.delay}ms` }}
+              filter="url(#stamen-glow)"
+              pathLength={1}
+            />
+            <circle
+              cx={s.tipX}
+              cy={s.tipY}
+              r="2.2"
+              className={`spider-lily-anther ${bloomed ? 'spider-lily-anther-active' : ''}`}
+              style={{ animationDelay: `${s.delay + 180}ms` }}
+              filter="url(#stamen-glow)"
+            />
+          </g>
+        ))}
+
+        {/* Center */}
+        <circle
+          cx={CX}
+          cy={CY}
+          r="3"
+          className={`spider-lily-center ${bloomed ? 'spider-lily-center-active' : ''}`}
+        />
+      </g>
+    </svg>
+  );
+};
+
+export { SpiderLily };

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -168,10 +168,11 @@ const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle:
   { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 4.7, tipW: 2.5 },
 ];
 
-const STEM_DELAY = 150;
-const PETAL_DELAY = 650;
-const STAMEN_DELAY = 1000;
-const STAMEN_DURATION = 550;
+const STEM_DELAY = 100;
+const STEM_DURATION = 800;
+const PETAL_DELAY = STEM_DELAY + STEM_DURATION;
+const STAMEN_DELAY = PETAL_DELAY + 300;
+const STAMEN_DURATION = 600;
 
 const SpiderLily = ({ className }: { className?: string }) => {
   const [stemActive, setStemActive] = useState(false);

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -1,28 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Side-view spider lily (彼岸花) — Japanese anime ink aesthetic.
  * Thin ribbon petals with tight spiral curls at the tips.
  * Dense, chaotic, overlapping. White on black.
+ * Petals and stamens react to hover — gently parting like fingers through a flower.
  */
 
 const CX = 220;
 const CY = 230;
 
-// Hand-drawn ribbon petals — thin, organic, dome-shaped arrangement.
-// W = half-width of ribbon. Kept narrow for paper/ribbon feel.
 const W = 4;
-const petals: { d: string; delay: number }[] = [
-  // ==== UPPER DOME — organic ribbon petals with natural irregularity ====
-
-  // Top center — leans very slightly left
+const petals: { d: string; delay: number; cx: number; cy: number }[] = [
+  // ==== UPPER DOME ====
+  // Top center
   {
     d: `M${CX - W} ${CY}
        C${CX - W - 2} ${CY - 38}, ${CX - W - 5} ${CY - 82}, ${CX - W - 4} ${CY - 122}
        C${CX - W - 3} ${CY - 144}, ${CX - 1} ${CY - 157}, ${CX - 1} ${CY - 160}
        C${CX} ${CY - 157}, ${CX + W} ${CY - 143}, ${CX + W - 1} ${CY - 124}
        C${CX + W} ${CY - 88}, ${CX + W + 2} ${CY - 42}, ${CX + W} ${CY} Z`,
-    delay: 0,
+    delay: 0, cx: CX, cy: CY - 80,
   },
   // Left ~18°
   {
@@ -32,7 +30,7 @@ const petals: { d: string; delay: number }[] = [
        L${CX + W - 22} ${CY - 153}
        C${CX + W - 20} ${CY - 136}, ${CX + W - 17} ${CY - 108}, ${CX + W - 12} ${CY - 74}
        C${CX + W - 3} ${CY - 37}, ${CX + W + 1} ${CY - 12}, ${CX + W} ${CY} Z`,
-    delay: 60,
+    delay: 60, cx: CX - 20, cy: CY - 78,
   },
   // Right ~22°
   {
@@ -42,7 +40,7 @@ const petals: { d: string; delay: number }[] = [
        L${CX - W + 29} ${CY - 153}
        C${CX - W + 27} ${CY - 139}, ${CX - W + 23} ${CY - 113}, ${CX - W + 19} ${CY - 76}
        C${CX - W + 7} ${CY - 38}, ${CX - W + 1} ${CY - 11}, ${CX - W} ${CY} Z`,
-    delay: 100,
+    delay: 100, cx: CX + 30, cy: CY - 78,
   },
   // Left ~40°
   {
@@ -52,7 +50,7 @@ const petals: { d: string; delay: number }[] = [
        L${CX + W - 60} ${CY - 140}
        C${CX + W - 57} ${CY - 120}, ${CX + W - 48} ${CY - 92}, ${CX + W - 33} ${CY - 58}
        C${CX + W - 11} ${CY - 25}, ${CX + W + 1} ${CY - 9}, ${CX + W} ${CY} Z`,
-    delay: 140,
+    delay: 140, cx: CX - 50, cy: CY - 70,
   },
   // Right ~44°
   {
@@ -62,7 +60,7 @@ const petals: { d: string; delay: number }[] = [
        L${CX - W + 68} ${CY - 142}
        C${CX - W + 64} ${CY - 123}, ${CX - W + 56} ${CY - 96}, ${CX - W + 40} ${CY - 61}
        C${CX - W + 15} ${CY - 27}, ${CX - W + 1} ${CY - 9}, ${CX - W} ${CY} Z`,
-    delay: 180,
+    delay: 180, cx: CX + 60, cy: CY - 70,
   },
   // Left ~60°
   {
@@ -72,7 +70,7 @@ const petals: { d: string; delay: number }[] = [
        L${CX + W - 97} ${CY - 100}
        C${CX + W - 93} ${CY - 83}, ${CX + W - 80} ${CY - 60}, ${CX + W - 48} ${CY - 38}
        C${CX + W - 17} ${CY - 17}, ${CX + W + 1} ${CY - 5}, ${CX + W} ${CY} Z`,
-    delay: 220,
+    delay: 220, cx: CX - 80, cy: CY - 50,
   },
   // Right ~64°
   {
@@ -82,9 +80,9 @@ const petals: { d: string; delay: number }[] = [
        L${CX - W + 106} ${CY - 103}
        C${CX - W + 102} ${CY - 87}, ${CX - W + 88} ${CY - 64}, ${CX - W + 56} ${CY - 41}
        C${CX - W + 22} ${CY - 19}, ${CX - W + 1} ${CY - 6}, ${CX - W} ${CY} Z`,
-    delay: 250,
+    delay: 250, cx: CX + 90, cy: CY - 50,
   },
-  // Left ~78° — nearly horizontal, slight droop
+  // Left ~78°
   {
     d: `M${CX} ${CY - W}
        C${CX - 26} ${CY - W - 3}, ${CX - 68} ${CY - W - 8}, ${CX - 112} ${CY - W - 10}
@@ -92,9 +90,9 @@ const petals: { d: string; delay: number }[] = [
        L${CX - 154} ${CY + W - 21}
        C${CX - 140} ${CY + W - 11}, ${CX - 108} ${CY + W - 4}, ${CX - 70} ${CY + W}
        C${CX - 30} ${CY + W + 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
-    delay: 40,
+    delay: 40, cx: CX - 100, cy: CY - 14,
   },
-  // Right ~82° — nearly horizontal, slight lift
+  // Right ~82°
   {
     d: `M${CX} ${CY - W}
        C${CX + 32} ${CY - W - 6}, ${CX + 78} ${CY - W - 13}, ${CX + 122} ${CY - W - 16}
@@ -102,70 +100,65 @@ const petals: { d: string; delay: number }[] = [
        L${CX + 163} ${CY + W - 26}
        C${CX + 150} ${CY + W - 14}, ${CX + 120} ${CY + W - 9}, ${CX + 78} ${CY + W - 4}
        C${CX + 32} ${CY + W - 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
-    delay: 80,
+    delay: 80, cx: CX + 110, cy: CY - 14,
   },
 
-  // ==== LOWER PETALS — parenthesis curves with organic asymmetry ====
-
-  // Outer left "(" — wider arc, tip curls slightly inward
+  // ==== LOWER PETALS ====
+  // Outer left "("
   {
     d: `M${CX} ${CY + W}
        C${CX - 33} ${CY + W + 4}, ${CX - 68} ${CY + W + 16}, ${CX - 84} ${CY + W + 38}
        C${CX - 96} ${CY + W + 57}, ${CX - 90} ${CY + W + 78}, ${CX - 70} ${CY + 87}
        C${CX - 84} ${CY + 73}, ${CX - 89} ${CY + 53}, ${CX - 79} ${CY + 36}
        C${CX - 66} ${CY + 17}, ${CX - 34} ${CY + 5}, ${CX} ${CY - W} Z`,
-    delay: 280,
+    delay: 280, cx: CX - 60, cy: CY + 50,
   },
-  // Outer right ")" — slightly tighter than left
+  // Outer right ")"
   {
     d: `M${CX} ${CY + W}
        C${CX + 36} ${CY + W + 5}, ${CX + 70} ${CY + W + 19}, ${CX + 86} ${CY + W + 40}
        C${CX + 97} ${CY + W + 59}, ${CX + 91} ${CY + W + 79}, ${CX + 70} ${CY + 86}
        C${CX + 85} ${CY + 72}, ${CX + 90} ${CY + 52}, ${CX + 80} ${CY + 35}
        C${CX + 66} ${CY + 17}, ${CX + 33} ${CY + 4}, ${CX} ${CY - W} Z`,
-    delay: 320,
+    delay: 320, cx: CX + 65, cy: CY + 50,
   },
-  // Inner left "(" — shorter, tighter curl
+  // Inner left "("
   {
     d: `M${CX} ${CY + W}
        C${CX - 18} ${CY + W + 5}, ${CX - 40} ${CY + W + 18}, ${CX - 50} ${CY + W + 36}
        C${CX - 57} ${CY + W + 51}, ${CX - 51} ${CY + W + 67}, ${CX - 36} ${CY + 73}
        C${CX - 47} ${CY + 61}, ${CX - 51} ${CY + 45}, ${CX - 43} ${CY + 31}
        C${CX - 34} ${CY + 17}, ${CX - 17} ${CY + 5}, ${CX} ${CY - W} Z`,
-    delay: 360,
+    delay: 360, cx: CX - 30, cy: CY + 40,
   },
-  // Inner right ")" — slightly longer than inner left
+  // Inner right ")"
   {
     d: `M${CX} ${CY + W}
        C${CX + 24} ${CY + W + 7}, ${CX + 47} ${CY + W + 21}, ${CX + 57} ${CY + W + 39}
        C${CX + 64} ${CY + W + 54}, ${CX + 58} ${CY + W + 70}, ${CX + 43} ${CY + 77}
        C${CX + 54} ${CY + 65}, ${CX + 58} ${CY + 49}, ${CX + 50} ${CY + 35}
        C${CX + 42} ${CY + 21}, ${CX + 22} ${CY + 7}, ${CX} ${CY - W} Z`,
-    delay: 400,
+    delay: 400, cx: CX + 35, cy: CY + 40,
   },
 ];
 
 const petalDelays = petals.map((p) => p.delay);
 
-// Stamens: smooth wide U-arcs. All control points stay above CY (the center)
-// so nothing dips below the flower neck. Tips staggered naturally.
-const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean }[] = [
-  // ==== OUTER cluster (dense, wide fan) ====
-  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 5.2, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 5.0, tipW: 2.5 },
-  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 4.8, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 4.6, tipW: 2.6 },
+const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean; cx: number; cy: number }[] = [
+  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 5.2, tipW: 2.4, cx: CX - 170, cy: CY - 60 },
+  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 5.0, tipW: 2.5, cx: CX - 155, cy: CY - 72 },
+  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 4.8, tipW: 2.4, cx: CX - 140, cy: CY - 82 },
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 4.6, tipW: 2.6, cx: CX - 120, cy: CY - 90 },
 
-  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 4.9, tipW: 2.5 },
-  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 5.1, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 5.0, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 5.3, tipW: 2.3 },
+  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 4.9, tipW: 2.5, cx: CX + 170, cy: CY - 62 },
+  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 5.1, tipW: 2.4, cx: CX + 155, cy: CY - 74 },
+  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 5.0, tipW: 2.2, cx: CX + 140, cy: CY - 84 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 5.3, tipW: 2.3, cx: CX + 120, cy: CY - 92 },
 
-  // ==== MIDDLE (sparse) ====
-  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 4.8, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 4.6, tipW: 2.6 },
-  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 5.1, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 4.7, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 4.8, tipW: 2.4, cx: CX - 90, cy: CY - 95 },
+  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 4.6, tipW: 2.6, cx: CX + 90, cy: CY - 95 },
+  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 5.1, tipW: 2.2, cx: CX - 45, cy: CY - 100 },
+  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 4.7, tipW: 2.5, cx: CX + 45, cy: CY - 100 },
 ];
 
 const STEM_DELAY = 100;
@@ -174,10 +167,45 @@ const PETAL_DELAY = STEM_DELAY + STEM_DURATION;
 const STAMEN_DELAY = PETAL_DELAY + 300;
 const STAMEN_DURATION = 600;
 
+const HOVER_RADIUS = 120;
+const HOVER_STRENGTH = 12;
+const LERP_SPEED = 0.08;
+const RETURN_SPEED = 0.06;
+
+const WIND_SPEED = 0.0006;
+const WIND_STRENGTH_X = 2.5;
+const WIND_STRENGTH_Y = 1.0;
+
+type Vec2 = { x: number; y: number };
+
+function computeDisplacement(
+  elCx: number,
+  elCy: number,
+  mouseX: number,
+  mouseY: number,
+): Vec2 {
+  const dx = elCx - mouseX;
+  const dy = elCy - mouseY;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist > HOVER_RADIUS || dist < 0.1) return { x: 0, y: 0 };
+  const factor = (1 - dist / HOVER_RADIUS) ** 2;
+  const norm = HOVER_STRENGTH * factor;
+  return { x: (dx / dist) * norm, y: (dy / dist) * norm };
+}
+
 const SpiderLily = ({ className }: { className?: string }) => {
   const [stemActive, setStemActive] = useState(false);
   const [petalsActive, setPetalsActive] = useState(false);
   const [stamensActive, setStamensActive] = useState(false);
+
+  const svgRef = useRef<SVGSVGElement>(null);
+  const mouseRef = useRef<{ x: number; y: number; active: boolean }>({ x: 0, y: 0, active: false });
+  const petalOffsetsRef = useRef<Vec2[]>(petals.map(() => ({ x: 0, y: 0 })));
+  const stamenOffsetsRef = useRef<Vec2[]>(stamens.map(() => ({ x: 0, y: 0 })));
+  const petalElsRef = useRef<(SVGPathElement | null)[]>([]);
+  const stamenGroupElsRef = useRef<(SVGGElement | null)[]>([]);
+  const wholeFlowerRef = useRef<SVGGElement>(null);
+  const rafRef = useRef<number>(0);
 
   useEffect(() => {
     const t1 = setTimeout(() => setStemActive(true), STEM_DELAY);
@@ -186,12 +214,120 @@ const SpiderLily = ({ className }: { className?: string }) => {
     return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
   }, []);
 
+  const toSVGCoords = useCallback((clientX: number, clientY: number): Vec2 => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return { x: 0, y: 0 };
+    const svgPt = pt.matrixTransform(ctm.inverse());
+    return { x: svgPt.x, y: svgPt.y };
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    const coords = toSVGCoords(e.clientX, e.clientY);
+    mouseRef.current = { x: coords.x, y: coords.y, active: true };
+  }, [toSVGCoords]);
+
+  const handleMouseLeave = useCallback(() => {
+    mouseRef.current.active = false;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    const coords = toSVGCoords(touch.clientX, touch.clientY);
+    mouseRef.current = { x: coords.x, y: coords.y, active: true };
+  }, [toSVGCoords]);
+
+  const handleTouchEnd = useCallback(() => {
+    mouseRef.current.active = false;
+  }, []);
+
+  useEffect(() => {
+    const t0 = performance.now();
+    const petalPhases = petals.map((_, i) => i * 0.7 + Math.sin(i * 2.3) * 0.5);
+    const stamenPhases = stamens.map((_, i) => i * 0.9 + Math.cos(i * 1.7) * 0.6);
+
+    const animate = () => {
+      const now = performance.now();
+      const t = (now - t0) * WIND_SPEED;
+      const mouse = mouseRef.current;
+      const petalOffsets = petalOffsetsRef.current;
+      const stamenOffsets = stamenOffsetsRef.current;
+
+      for (let i = 0; i < petals.length; i++) {
+        const phase = petalPhases[i];
+        const windX = Math.sin(t + phase) * WIND_STRENGTH_X + Math.sin(t * 1.7 + phase * 0.6) * WIND_STRENGTH_X * 0.3;
+        const windY = Math.cos(t * 0.8 + phase * 1.3) * WIND_STRENGTH_Y;
+
+        const hover = mouse.active
+          ? computeDisplacement(petals[i].cx, petals[i].cy, mouse.x, mouse.y)
+          : { x: 0, y: 0 };
+
+        const targetX = windX + hover.x;
+        const targetY = windY + hover.y;
+        const speed = mouse.active ? LERP_SPEED : RETURN_SPEED;
+
+        petalOffsets[i] = {
+          x: petalOffsets[i].x + (targetX - petalOffsets[i].x) * speed,
+          y: petalOffsets[i].y + (targetY - petalOffsets[i].y) * speed,
+        };
+        const el = petalElsRef.current[i];
+        if (el) {
+          el.setAttribute('transform', `translate(${petalOffsets[i].x.toFixed(2)} ${petalOffsets[i].y.toFixed(2)})`);
+        }
+      }
+
+      for (let i = 0; i < stamens.length; i++) {
+        const phase = stamenPhases[i];
+        const windX = Math.sin(t + phase) * WIND_STRENGTH_X * 1.2 + Math.sin(t * 1.4 + phase * 0.8) * WIND_STRENGTH_X * 0.4;
+        const windY = Math.cos(t * 0.7 + phase * 1.1) * WIND_STRENGTH_Y * 0.8;
+
+        const hover = mouse.active
+          ? computeDisplacement(stamens[i].cx, stamens[i].cy, mouse.x, mouse.y)
+          : { x: 0, y: 0 };
+
+        const targetX = windX + hover.x;
+        const targetY = windY + hover.y;
+        const speed = mouse.active ? LERP_SPEED : RETURN_SPEED;
+
+        stamenOffsets[i] = {
+          x: stamenOffsets[i].x + (targetX - stamenOffsets[i].x) * speed,
+          y: stamenOffsets[i].y + (targetY - stamenOffsets[i].y) * speed,
+        };
+        const el = stamenGroupElsRef.current[i];
+        if (el) {
+          el.setAttribute('transform', `translate(${stamenOffsets[i].x.toFixed(2)} ${stamenOffsets[i].y.toFixed(2)})`);
+        }
+      }
+
+      const flowerEl = wholeFlowerRef.current;
+      if (flowerEl) {
+        const swayAngle = Math.sin(t * 0.8) * 0.6 + Math.sin(t * 1.3) * 0.25;
+        flowerEl.setAttribute('transform', `rotate(${swayAngle.toFixed(3)} ${CX} 598)`);
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
   return (
     <svg
+      ref={svgRef}
       viewBox="-180 10 800 590"
       className={className}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
     >
       <defs>
         <filter id="ink-texture">
@@ -227,8 +363,9 @@ const SpiderLily = ({ className }: { className?: string }) => {
         </filter>
       </defs>
 
+      <g ref={wholeFlowerRef}>
       <g filter="url(#ink-texture)">
-        {/* Stem — organic brush stroke with natural curve */}
+        {/* Stem */}
         <path
           d={`M${CX - 4} ${CY}
               C${CX - 3} ${CY + 30}, ${CX + 2} 275, ${CX + 6} 320
@@ -243,12 +380,13 @@ const SpiderLily = ({ className }: { className?: string }) => {
           className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
         />
 
-        {/* Flower head — subtle lean + ethereal glow */}
+        {/* Flower head */}
         <g transform={`rotate(-4 ${CX} ${CY})`} filter="url(#petal-glow)">
           {/* Petals */}
           {petals.map((p, i) => (
             <path
               key={`petal-${i}`}
+              ref={(el) => { petalElsRef.current[i] = el; }}
               d={p.d}
               className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
               style={{ animationDelay: `${petalDelays[i]}ms` }}
@@ -258,7 +396,10 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
           {/* Stamens */}
           {stamens.map((s, i) => (
-            <g key={`stamen-${i}`}>
+            <g
+              key={`stamen-${i}`}
+              ref={(el) => { stamenGroupElsRef.current[i] = el; }}
+            >
               <path
                 d={s.d}
                 className={`spider-lily-stamen ${stamensActive ? 'spider-lily-stamen-active' : ''}`}
@@ -289,6 +430,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
             className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
           />
         </g>
+      </g>
       </g>
     </svg>
   );

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -150,25 +150,22 @@ const petalDelays = petals.map((p) => p.delay);
 // Stamens: smooth wide U-arcs. All control points stay above CY (the center)
 // so nothing dips below the flower neck. Tips staggered naturally.
 const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean }[] = [
-  // ==== OUTERMOST — wide, shallow curve ====
-  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 16}, ${CX - 310} ${CY - 20}, ${CX - 335} ${CY - 110}`, tipX: CX - 335, tipY: CY - 110, delay: 0, tipAngle: -15, tipLen: 3.8, tipW: 2.4, noTip: true },
-  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 18}, ${CX + 306} ${CY - 24}, ${CX + 332} ${CY - 115}`, tipX: CX + 332, tipY: CY - 115, delay: 40, tipAngle: 20, tipLen: 3.5, tipW: 2.6 },
+  // ==== OUTER cluster (dense, wide fan) ====
+  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 3.8, tipW: 2.4, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 3.7, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 3.6, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 3.4, tipW: 2.6, noTip: true },
 
-  // ==== WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 120} ${CY - 20}, ${CX - 280} ${CY - 30}, ${CX - 305} ${CY - 135}`, tipX: CX - 305, tipY: CY - 135, delay: 80, tipAngle: -35, tipLen: 4, tipW: 2.3 },
-  { d: `M${CX} ${CY - 12} C${CX + 118} ${CY - 22}, ${CX + 276} ${CY - 34}, ${CX + 302} ${CY - 130}`, tipX: CX + 302, tipY: CY - 130, delay: 120, tipAngle: 40, tipLen: 3.4, tipW: 2.7, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 3.6, tipW: 2.5 },
+  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 3.8, tipW: 2.4, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 3.7, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 3.9, tipW: 2.3 },
 
-  // ==== MID-WIDE ====
-  { d: `M${CX} ${CY - 12} C${CX - 80} ${CY - 35}, ${CX - 225} ${CY - 65}, ${CX - 255} ${CY - 158}`, tipX: CX - 255, tipY: CY - 158, delay: 160, tipAngle: -50, tipLen: 3.8, tipW: 2.2 },
-  { d: `M${CX} ${CY - 12} C${CX + 78} ${CY - 38}, ${CX + 222} ${CY - 70}, ${CX + 252} ${CY - 162}`, tipX: CX + 252, tipY: CY - 162, delay: 200, tipAngle: 55, tipLen: 3.6, tipW: 2.5 },
-
-  // ==== UPPER ====
-  { d: `M${CX} ${CY - 12} C${CX - 52} ${CY - 50}, ${CX - 165} ${CY - 118}, ${CX - 182} ${CY - 178}`, tipX: CX - 182, tipY: CY - 178, delay: 240, tipAngle: -70, tipLen: 3.9, tipW: 2.2, noTip: true },
-  { d: `M${CX} ${CY - 12} C${CX + 50} ${CY - 52}, ${CX + 162} ${CY - 122}, ${CX + 180} ${CY - 174}`, tipX: CX + 180, tipY: CY - 174, delay: 280, tipAngle: 65, tipLen: 3.4, tipW: 2.6 },
-
-  // ==== CENTER ====
-  { d: `M${CX} ${CY - 12} C${CX - 25} ${CY - 65}, ${CX - 78} ${CY - 150}, ${CX - 75} ${CY - 190}`, tipX: CX - 75, tipY: CY - 190, delay: 320, tipAngle: -80, tipLen: 3.6, tipW: 2.4 },
-  { d: `M${CX} ${CY - 12} C${CX + 22} ${CY - 68}, ${CX + 75} ${CY - 154}, ${CX + 72} ${CY - 188}`, tipX: CX + 72, tipY: CY - 188, delay: 360, tipAngle: 75, tipLen: 3.8, tipW: 2.3, noTip: true },
+  // ==== MIDDLE (sparse) ====
+  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 3.6, tipW: 2.4 },
+  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 3.4, tipW: 2.6, noTip: true },
+  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 3.8, tipW: 2.2 },
+  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 3.5, tipW: 2.5 },
 ];
 
 const STEM_DELAY = 150;
@@ -257,16 +254,18 @@ const SpiderLily = ({ className }: { className?: string }) => {
               filter="url(#stamen-glow)"
               pathLength={1}
             />
-            <ellipse
-              cx={s.tipX}
-              cy={s.tipY}
-              rx={s.tipLen}
-              ry={s.tipW}
-              transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
-              className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
-              style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
-              filter="url(#stamen-glow)"
-            />
+            {!s.noTip && (
+              <ellipse
+                cx={s.tipX}
+                cy={s.tipY}
+                rx={s.tipLen}
+                ry={s.tipW}
+                transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
+                className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
+                style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
+                filter="url(#stamen-glow)"
+              />
+            )}
           </g>
         ))}
 

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -239,11 +239,19 @@ const SpiderLily = ({ className }: { className?: string }) => {
       </defs>
 
       <g filter="url(#ink-texture)">
-        {/* Stem */}
+        {/* Stem — brush stroke: wide at flower head, trails to a wisp */}
         <path
-          d={`M195 580 C198 520, 205 445, 212 380 C218 320, 220 275, ${CX} ${CY + 15}`}
+          d={`M${CX - 7} ${CY}
+              C${CX - 9} ${CY + 25}, ${CX - 10} 280, ${CX - 8} 330
+              C${CX - 5} 375, ${CX - 8} 420, ${CX - 10} 470
+              C${CX - 9} 515, ${CX - 6} 550, ${CX - 4} 580
+              Q${CX - 3} 594, ${CX - 1} 598
+              Q${CX + 2} 594, ${CX + 3} 580
+              C${CX + 4} 550, ${CX + 1} 515, ${CX} 470
+              C${CX - 1} 420, ${CX + 3} 375, ${CX + 5} 330
+              C${CX + 7} 280, ${CX + 8} ${CY + 25}, ${CX + 7} ${CY}
+              Z`}
           className={`spider-lily-stem ${bloomed ? 'spider-lily-stem-active' : ''}`}
-          pathLength={1}
         />
 
         {/* Petals */}

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -12,7 +12,7 @@ const MainBanner = () => {
   return (
     <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>
-        <div className='bio-glitch w-48 sm:w-56 md:w-64 lg:w-72' style={jitter()}>
+        <div className='bio-glitch w-64 sm:w-72 md:w-80 lg:w-96' style={jitter()}>
           <SpiderLily className='spider-lily-container w-full h-auto' />
         </div>
         <div className='flex flex-col gap-4'>

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -12,7 +12,7 @@ const MainBanner = () => {
   return (
     <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>
-        <div className='bio-glitch w-64 sm:w-72 md:w-80 lg:w-96' style={jitter()}>
+        <div className='bio-glitch w-80 sm:w-88 md:w-[26rem] lg:w-[30rem]' style={jitter()}>
           <SpiderLily className='spider-lily-container w-full h-auto' />
         </div>
         <div className='flex flex-col gap-4'>

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { SpiderLily } from '../../SpiderLily';
 
 const linkClass =
   'font-mono text-xs uppercase tracking-widest text-white/50 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300';
@@ -9,26 +9,11 @@ const bioClass =
 const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
 
 const MainBanner = () => {
-  const [loaded, setLoaded] = useState(false);
-
   return (
     <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>
-        <div
-          className='bio-glitch relative w-52 sm:w-52 md:w-64 lg:w-80 aspect-square opacity-80 grayscale rotate-25'
-          style={jitter()}
-        >
-          <img
-            src='/images/mirror-placeholder.webp'
-            alt=''
-            className={`w-full ${loaded ? 'opacity-0' : 'opacity-100'} blur-md transition-opacity duration-500`}
-          />
-          <img
-            src='/images/mirror.webp'
-            alt=''
-            className={`absolute inset-0 w-full ${loaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-500`}
-            onLoad={() => setLoaded(true)}
-          />
+        <div className='bio-glitch w-48 sm:w-56 md:w-64 lg:w-72' style={jitter()}>
+          <SpiderLily className='spider-lily-container w-full h-auto' />
         </div>
         <div className='flex flex-col gap-4'>
           <p


### PR DESCRIPTION
## Summary
Replaces the circular photo on the homepage with an animated SVG spider lily (彼岸花) rendered in a Japanese ink/anime aesthetic. The flower features hand-drawn ribbon petals, organically fanned stamens with oval anther tips, a brush-stroke stem, and a layered ethereal glow — all animated with a sequential bloom sequence (stem rise → petal unfurl → stamen growth → anther appearance).

## Commentary
- Built as a self-contained `SpiderLily` React component using pure SVG with no external assets
- Petals and stamens have unique center-of-mass coordinates enabling two interactive behaviors: hover displacement (elements part away from the cursor like fingers through silk) and ambient wind simulation (layered sine waves with per-element phase offsets)
- The whole flower sways gently from the stem base, with individual petal/stamen flutter on top, creating three layers of organic motion
- Glow system uses both SVG filters (Gaussian blur on the flower head) and CSS `drop-shadow` animations (fade-in + breathing pulse) for the ethereal Tokyo Ghoul-inspired aura
- Animation sequencing ensures the stem reaches full height before petals bloom, with overlapping phases for natural flow