### PR TITLE
feat: stagger spider lily stamen growth for natural center-out animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -408,7 +408,8 @@
 
 /* Ethereal glow — fades in during bloom, then breathes */
 .spider-lily-container {
-  animation: lily-glow-in 2.5s ease-out 1.2s forwards,
+  animation:
+    lily-glow-in 2.5s ease-out 1.2s forwards,
     lily-breathe 7s ease-in-out 4s infinite;
 }
 

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -20,7 +20,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        C${CX - W - 3} ${CY - 144}, ${CX - 1} ${CY - 157}, ${CX - 1} ${CY - 160}
        C${CX} ${CY - 157}, ${CX + W} ${CY - 143}, ${CX + W - 1} ${CY - 124}
        C${CX + W} ${CY - 88}, ${CX + W + 2} ${CY - 42}, ${CX + W} ${CY} Z`,
-    delay: 0, cx: CX, cy: CY - 80,
+    delay: 0,
+    cx: CX,
+    cy: CY - 80,
   },
   // Left ~18°
   {
@@ -30,7 +32,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX + W - 22} ${CY - 153}
        C${CX + W - 20} ${CY - 136}, ${CX + W - 17} ${CY - 108}, ${CX + W - 12} ${CY - 74}
        C${CX + W - 3} ${CY - 37}, ${CX + W + 1} ${CY - 12}, ${CX + W} ${CY} Z`,
-    delay: 60, cx: CX - 20, cy: CY - 78,
+    delay: 60,
+    cx: CX - 20,
+    cy: CY - 78,
   },
   // Right ~22°
   {
@@ -40,7 +44,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX - W + 29} ${CY - 153}
        C${CX - W + 27} ${CY - 139}, ${CX - W + 23} ${CY - 113}, ${CX - W + 19} ${CY - 76}
        C${CX - W + 7} ${CY - 38}, ${CX - W + 1} ${CY - 11}, ${CX - W} ${CY} Z`,
-    delay: 100, cx: CX + 30, cy: CY - 78,
+    delay: 100,
+    cx: CX + 30,
+    cy: CY - 78,
   },
   // Left ~40°
   {
@@ -50,7 +56,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX + W - 60} ${CY - 140}
        C${CX + W - 57} ${CY - 120}, ${CX + W - 48} ${CY - 92}, ${CX + W - 33} ${CY - 58}
        C${CX + W - 11} ${CY - 25}, ${CX + W + 1} ${CY - 9}, ${CX + W} ${CY} Z`,
-    delay: 140, cx: CX - 50, cy: CY - 70,
+    delay: 140,
+    cx: CX - 50,
+    cy: CY - 70,
   },
   // Right ~44°
   {
@@ -60,7 +68,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX - W + 68} ${CY - 142}
        C${CX - W + 64} ${CY - 123}, ${CX - W + 56} ${CY - 96}, ${CX - W + 40} ${CY - 61}
        C${CX - W + 15} ${CY - 27}, ${CX - W + 1} ${CY - 9}, ${CX - W} ${CY} Z`,
-    delay: 180, cx: CX + 60, cy: CY - 70,
+    delay: 180,
+    cx: CX + 60,
+    cy: CY - 70,
   },
   // Left ~60°
   {
@@ -70,7 +80,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX + W - 97} ${CY - 100}
        C${CX + W - 93} ${CY - 83}, ${CX + W - 80} ${CY - 60}, ${CX + W - 48} ${CY - 38}
        C${CX + W - 17} ${CY - 17}, ${CX + W + 1} ${CY - 5}, ${CX + W} ${CY} Z`,
-    delay: 220, cx: CX - 80, cy: CY - 50,
+    delay: 220,
+    cx: CX - 80,
+    cy: CY - 50,
   },
   // Right ~64°
   {
@@ -80,7 +92,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX - W + 106} ${CY - 103}
        C${CX - W + 102} ${CY - 87}, ${CX - W + 88} ${CY - 64}, ${CX - W + 56} ${CY - 41}
        C${CX - W + 22} ${CY - 19}, ${CX - W + 1} ${CY - 6}, ${CX - W} ${CY} Z`,
-    delay: 250, cx: CX + 90, cy: CY - 50,
+    delay: 250,
+    cx: CX + 90,
+    cy: CY - 50,
   },
   // Left ~78°
   {
@@ -90,7 +104,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX - 154} ${CY + W - 21}
        C${CX - 140} ${CY + W - 11}, ${CX - 108} ${CY + W - 4}, ${CX - 70} ${CY + W}
        C${CX - 30} ${CY + W + 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
-    delay: 40, cx: CX - 100, cy: CY - 14,
+    delay: 40,
+    cx: CX - 100,
+    cy: CY - 14,
   },
   // Right ~82°
   {
@@ -100,7 +116,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        L${CX + 163} ${CY + W - 26}
        C${CX + 150} ${CY + W - 14}, ${CX + 120} ${CY + W - 9}, ${CX + 78} ${CY + W - 4}
        C${CX + 32} ${CY + W - 2}, ${CX} ${CY + W}, ${CX} ${CY + W} Z`,
-    delay: 80, cx: CX + 110, cy: CY - 14,
+    delay: 80,
+    cx: CX + 110,
+    cy: CY - 14,
   },
 
   // ==== LOWER PETALS ====
@@ -111,7 +129,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        C${CX - 96} ${CY + W + 57}, ${CX - 90} ${CY + W + 78}, ${CX - 70} ${CY + 87}
        C${CX - 84} ${CY + 73}, ${CX - 89} ${CY + 53}, ${CX - 79} ${CY + 36}
        C${CX - 66} ${CY + 17}, ${CX - 34} ${CY + 5}, ${CX} ${CY - W} Z`,
-    delay: 280, cx: CX - 60, cy: CY + 50,
+    delay: 280,
+    cx: CX - 60,
+    cy: CY + 50,
   },
   // Outer right ")"
   {
@@ -120,7 +140,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        C${CX + 97} ${CY + W + 59}, ${CX + 91} ${CY + W + 79}, ${CX + 70} ${CY + 86}
        C${CX + 85} ${CY + 72}, ${CX + 90} ${CY + 52}, ${CX + 80} ${CY + 35}
        C${CX + 66} ${CY + 17}, ${CX + 33} ${CY + 4}, ${CX} ${CY - W} Z`,
-    delay: 320, cx: CX + 65, cy: CY + 50,
+    delay: 320,
+    cx: CX + 65,
+    cy: CY + 50,
   },
   // Inner left "("
   {
@@ -129,7 +151,9 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        C${CX - 57} ${CY + W + 51}, ${CX - 51} ${CY + W + 67}, ${CX - 36} ${CY + 73}
        C${CX - 47} ${CY + 61}, ${CX - 51} ${CY + 45}, ${CX - 43} ${CY + 31}
        C${CX - 34} ${CY + 17}, ${CX - 17} ${CY + 5}, ${CX} ${CY - W} Z`,
-    delay: 360, cx: CX - 30, cy: CY + 40,
+    delay: 360,
+    cx: CX - 30,
+    cy: CY + 40,
   },
   // Inner right ")"
   {
@@ -138,34 +162,179 @@ const petals: { d: string; delay: number; cx: number; cy: number }[] = [
        C${CX + 64} ${CY + W + 54}, ${CX + 58} ${CY + W + 70}, ${CX + 43} ${CY + 77}
        C${CX + 54} ${CY + 65}, ${CX + 58} ${CY + 49}, ${CX + 50} ${CY + 35}
        C${CX + 42} ${CY + 21}, ${CX + 22} ${CY + 7}, ${CX} ${CY - W} Z`,
-    delay: 400, cx: CX + 35, cy: CY + 40,
+    delay: 400,
+    cx: CX + 35,
+    cy: CY + 40,
   },
 ];
 
-const petalDelays = petals.map((p) => p.delay);
+const petalDelays = petals.map(p => p.delay);
 
-const stamens: { d: string; tipX: number; tipY: number; delay: number; tipAngle: number; tipLen: number; tipW: number; noTip?: boolean; cx: number; cy: number }[] = [
-  { d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`, tipX: CX - 340, tipY: CY - 115, delay: 0, tipAngle: -12, tipLen: 5.2, tipW: 2.4, cx: CX - 170, cy: CY - 60 },
-  { d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`, tipX: CX - 315, tipY: CY - 135, delay: 40, tipAngle: -25, tipLen: 5.0, tipW: 2.5, cx: CX - 155, cy: CY - 72 },
-  { d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`, tipX: CX - 285, tipY: CY - 155, delay: 80, tipAngle: -38, tipLen: 4.8, tipW: 2.4, cx: CX - 140, cy: CY - 82 },
-  { d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`, tipX: CX - 252, tipY: CY - 170, delay: 120, tipAngle: -50, tipLen: 4.6, tipW: 2.6, cx: CX - 120, cy: CY - 90 },
+const stamens: {
+  d: string;
+  tipX: number;
+  tipY: number;
+  delay: number;
+  tipAngle: number;
+  tipLen: number;
+  tipW: number;
+  noTip?: boolean;
+  cx: number;
+  cy: number;
+}[] = [
+  {
+    d: `M${CX} ${CY - 12} C${CX - 160} ${CY - 12}, ${CX - 320} ${CY - 14}, ${CX - 340} ${CY - 115}`,
+    tipX: CX - 340,
+    tipY: CY - 115,
+    delay: 0,
+    tipAngle: -12,
+    tipLen: 5.2,
+    tipW: 2.4,
+    cx: CX - 170,
+    cy: CY - 60,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX - 145} ${CY - 14}, ${CX - 298} ${CY - 20}, ${CX - 315} ${CY - 135}`,
+    tipX: CX - 315,
+    tipY: CY - 135,
+    delay: 40,
+    tipAngle: -25,
+    tipLen: 5.0,
+    tipW: 2.5,
+    cx: CX - 155,
+    cy: CY - 72,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX - 125} ${CY - 16}, ${CX - 268} ${CY - 28}, ${CX - 285} ${CY - 155}`,
+    tipX: CX - 285,
+    tipY: CY - 155,
+    delay: 80,
+    tipAngle: -38,
+    tipLen: 4.8,
+    tipW: 2.4,
+    cx: CX - 140,
+    cy: CY - 82,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX - 100} ${CY - 20}, ${CX - 232} ${CY - 42}, ${CX - 252} ${CY - 170}`,
+    tipX: CX - 252,
+    tipY: CY - 170,
+    delay: 120,
+    tipAngle: -50,
+    tipLen: 4.6,
+    tipW: 2.6,
+    cx: CX - 120,
+    cy: CY - 90,
+  },
 
-  { d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`, tipX: CX + 338, tipY: CY - 118, delay: 20, tipAngle: 14, tipLen: 4.9, tipW: 2.5, cx: CX + 170, cy: CY - 62 },
-  { d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`, tipX: CX + 312, tipY: CY - 138, delay: 60, tipAngle: 28, tipLen: 5.1, tipW: 2.4, cx: CX + 155, cy: CY - 74 },
-  { d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`, tipX: CX + 282, tipY: CY - 158, delay: 100, tipAngle: 42, tipLen: 5.0, tipW: 2.2, cx: CX + 140, cy: CY - 84 },
-  { d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`, tipX: CX + 248, tipY: CY - 172, delay: 140, tipAngle: 54, tipLen: 5.3, tipW: 2.3, cx: CX + 120, cy: CY - 92 },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 158} ${CY - 12}, ${CX + 318} ${CY - 16}, ${CX + 338} ${CY - 118}`,
+    tipX: CX + 338,
+    tipY: CY - 118,
+    delay: 20,
+    tipAngle: 14,
+    tipLen: 4.9,
+    tipW: 2.5,
+    cx: CX + 170,
+    cy: CY - 62,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 142} ${CY - 15}, ${CX + 295} ${CY - 22}, ${CX + 312} ${CY - 138}`,
+    tipX: CX + 312,
+    tipY: CY - 138,
+    delay: 60,
+    tipAngle: 28,
+    tipLen: 5.1,
+    tipW: 2.4,
+    cx: CX + 155,
+    cy: CY - 74,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 122} ${CY - 18}, ${CX + 265} ${CY - 32}, ${CX + 282} ${CY - 158}`,
+    tipX: CX + 282,
+    tipY: CY - 158,
+    delay: 100,
+    tipAngle: 42,
+    tipLen: 5.0,
+    tipW: 2.2,
+    cx: CX + 140,
+    cy: CY - 84,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 98} ${CY - 22}, ${CX + 230} ${CY - 46}, ${CX + 248} ${CY - 172}`,
+    tipX: CX + 248,
+    tipY: CY - 172,
+    delay: 140,
+    tipAngle: 54,
+    tipLen: 5.3,
+    tipW: 2.3,
+    cx: CX + 120,
+    cy: CY - 92,
+  },
 
-  { d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`, tipX: CX - 185, tipY: CY - 178, delay: 200, tipAngle: -65, tipLen: 4.8, tipW: 2.4, cx: CX - 90, cy: CY - 95 },
-  { d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`, tipX: CX + 182, tipY: CY - 175, delay: 240, tipAngle: 62, tipLen: 4.6, tipW: 2.6, cx: CX + 90, cy: CY - 95 },
-  { d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`, tipX: CX - 90, tipY: CY - 190, delay: 280, tipAngle: -78, tipLen: 5.1, tipW: 2.2, cx: CX - 45, cy: CY - 100 },
-  { d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`, tipX: CX + 88, tipY: CY - 188, delay: 320, tipAngle: 75, tipLen: 4.7, tipW: 2.5, cx: CX + 45, cy: CY - 100 },
+  {
+    d: `M${CX} ${CY - 12} C${CX - 55} ${CY - 48}, ${CX - 168} ${CY - 115}, ${CX - 185} ${CY - 178}`,
+    tipX: CX - 185,
+    tipY: CY - 178,
+    delay: 200,
+    tipAngle: -65,
+    tipLen: 4.8,
+    tipW: 2.4,
+    cx: CX - 90,
+    cy: CY - 95,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 52} ${CY - 50}, ${CX + 165} ${CY - 118}, ${CX + 182} ${CY - 175}`,
+    tipX: CX + 182,
+    tipY: CY - 175,
+    delay: 240,
+    tipAngle: 62,
+    tipLen: 4.6,
+    tipW: 2.6,
+    cx: CX + 90,
+    cy: CY - 95,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX - 30} ${CY - 62}, ${CX - 95} ${CY - 148}, ${CX - 90} ${CY - 190}`,
+    tipX: CX - 90,
+    tipY: CY - 190,
+    delay: 280,
+    tipAngle: -78,
+    tipLen: 5.1,
+    tipW: 2.2,
+    cx: CX - 45,
+    cy: CY - 100,
+  },
+  {
+    d: `M${CX} ${CY - 12} C${CX + 28} ${CY - 64}, ${CX + 92} ${CY - 150}, ${CX + 88} ${CY - 188}`,
+    tipX: CX + 88,
+    tipY: CY - 188,
+    delay: 320,
+    tipAngle: 75,
+    tipLen: 4.7,
+    tipW: 2.5,
+    cx: CX + 45,
+    cy: CY - 100,
+  },
 ];
 
 const STEM_DELAY = 100;
 const STEM_DURATION = 800;
 const PETAL_DELAY = STEM_DELAY + STEM_DURATION;
-const STAMEN_DELAY = PETAL_DELAY + 300;
+const STAMEN_BASE_DELAY = PETAL_DELAY + 300;
 const STAMEN_DURATION = 600;
+const STAMEN_STAGGER = 50;
+
+const stamenDistances = stamens.map(s =>
+  Math.sqrt((s.cx - CX) ** 2 + (s.cy - CY) ** 2),
+);
+const stamenActivationOrder = stamens
+  .map((_, i) => i)
+  .sort((a, b) => stamenDistances[a] - stamenDistances[b]);
+const stamenRank = new Array<number>(stamens.length);
+for (let rank = 0; rank < stamenActivationOrder.length; rank++) {
+  stamenRank[stamenActivationOrder[rank]] = rank;
+}
 
 const HOVER_RADIUS = 140;
 const HOVER_STRENGTH = 8;
@@ -184,10 +353,17 @@ type Vec2 = { x: number; y: number };
 const SpiderLily = ({ className }: { className?: string }) => {
   const [stemActive, setStemActive] = useState(false);
   const [petalsActive, setPetalsActive] = useState(false);
-  const [stamensActive, setStamensActive] = useState(false);
+  const [activeStamens, setActiveStamens] = useState<boolean[]>(() =>
+    stamens.map(() => false),
+  );
 
   const svgRef = useRef<SVGSVGElement>(null);
-  const mouseRef = useRef<{ x: number; y: number; active: boolean; pressed: boolean }>({ x: 0, y: 0, active: false, pressed: false });
+  const mouseRef = useRef<{
+    x: number;
+    y: number;
+    active: boolean;
+    pressed: boolean;
+  }>({ x: 0, y: 0, active: false, pressed: false });
   const petalOffsetsRef = useRef<Vec2[]>(petals.map(() => ({ x: 0, y: 0 })));
   const stamenOffsetsRef = useRef<Vec2[]>(stamens.map(() => ({ x: 0, y: 0 })));
   const petalElsRef = useRef<(SVGPathElement | null)[]>([]);
@@ -199,8 +375,23 @@ const SpiderLily = ({ className }: { className?: string }) => {
   useEffect(() => {
     const t1 = setTimeout(() => setStemActive(true), STEM_DELAY);
     const t2 = setTimeout(() => setPetalsActive(true), PETAL_DELAY);
-    const t3 = setTimeout(() => setStamensActive(true), STAMEN_DELAY);
-    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
+    const stamenTimers = stamens.map((_, i) =>
+      setTimeout(
+        () => {
+          setActiveStamens(prev => {
+            const next = [...prev];
+            next[i] = true;
+            return next;
+          });
+        },
+        STAMEN_BASE_DELAY + stamenRank[i] * STAMEN_STAGGER,
+      ),
+    );
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      for (const t of stamenTimers) clearTimeout(t);
+    };
   }, []);
 
   const toSVGCoords = useCallback((clientX: number, clientY: number): Vec2 => {
@@ -215,20 +406,26 @@ const SpiderLily = ({ className }: { className?: string }) => {
     return { x: svgPt.x, y: svgPt.y };
   }, []);
 
-  const handleMouseMove = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
-    const coords = toSVGCoords(e.clientX, e.clientY);
-    mouseRef.current.x = coords.x;
-    mouseRef.current.y = coords.y;
-    mouseRef.current.active = true;
-  }, [toSVGCoords]);
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const coords = toSVGCoords(e.clientX, e.clientY);
+      mouseRef.current.x = coords.x;
+      mouseRef.current.y = coords.y;
+      mouseRef.current.active = true;
+    },
+    [toSVGCoords],
+  );
 
-  const handleMouseDown = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
-    const coords = toSVGCoords(e.clientX, e.clientY);
-    mouseRef.current.x = coords.x;
-    mouseRef.current.y = coords.y;
-    mouseRef.current.active = true;
-    mouseRef.current.pressed = true;
-  }, [toSVGCoords]);
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const coords = toSVGCoords(e.clientX, e.clientY);
+      mouseRef.current.x = coords.x;
+      mouseRef.current.y = coords.y;
+      mouseRef.current.active = true;
+      mouseRef.current.pressed = true;
+    },
+    [toSVGCoords],
+  );
 
   const handleMouseUp = useCallback(() => {
     mouseRef.current.pressed = false;
@@ -239,24 +436,30 @@ const SpiderLily = ({ className }: { className?: string }) => {
     mouseRef.current.pressed = false;
   }, []);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
-    const touch = e.touches[0];
-    if (!touch) return;
-    const coords = toSVGCoords(touch.clientX, touch.clientY);
-    mouseRef.current.x = coords.x;
-    mouseRef.current.y = coords.y;
-    mouseRef.current.active = true;
-    mouseRef.current.pressed = true;
-  }, [toSVGCoords]);
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent<SVGSVGElement>) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      const coords = toSVGCoords(touch.clientX, touch.clientY);
+      mouseRef.current.x = coords.x;
+      mouseRef.current.y = coords.y;
+      mouseRef.current.active = true;
+      mouseRef.current.pressed = true;
+    },
+    [toSVGCoords],
+  );
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
-    const touch = e.touches[0];
-    if (!touch) return;
-    const coords = toSVGCoords(touch.clientX, touch.clientY);
-    mouseRef.current.x = coords.x;
-    mouseRef.current.y = coords.y;
-    mouseRef.current.active = true;
-  }, [toSVGCoords]);
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent<SVGSVGElement>) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      const coords = toSVGCoords(touch.clientX, touch.clientY);
+      mouseRef.current.x = coords.x;
+      mouseRef.current.y = coords.y;
+      mouseRef.current.active = true;
+    },
+    [toSVGCoords],
+  );
 
   const handleTouchEnd = useCallback(() => {
     mouseRef.current.active = false;
@@ -266,7 +469,9 @@ const SpiderLily = ({ className }: { className?: string }) => {
   useEffect(() => {
     const t0 = performance.now();
     const petalPhases = petals.map((_, i) => i * 0.7 + Math.sin(i * 2.3) * 0.5);
-    const stamenPhases = stamens.map((_, i) => i * 0.9 + Math.cos(i * 1.7) * 0.6);
+    const stamenPhases = stamens.map(
+      (_, i) => i * 0.9 + Math.cos(i * 1.7) * 0.6,
+    );
 
     const animate = () => {
       const now = performance.now();
@@ -279,10 +484,13 @@ const SpiderLily = ({ className }: { className?: string }) => {
 
       for (let i = 0; i < petals.length; i++) {
         const phase = petalPhases[i];
-        const windX = Math.sin(t + phase) * WIND_STRENGTH_X + Math.sin(t * 1.7 + phase * 0.6) * WIND_STRENGTH_X * 0.3;
+        const windX =
+          Math.sin(t + phase) * WIND_STRENGTH_X +
+          Math.sin(t * 1.7 + phase * 0.6) * WIND_STRENGTH_X * 0.3;
         const windY = Math.cos(t * 0.8 + phase * 1.3) * WIND_STRENGTH_Y;
 
-        let pushX = 0, pushY = 0;
+        let pushX = 0,
+          pushY = 0;
         if (mouse.active) {
           const dx = petals[i].cx - mouse.x;
           const dy = petals[i].cy - mouse.y;
@@ -304,16 +512,22 @@ const SpiderLily = ({ className }: { className?: string }) => {
         };
         const el = petalElsRef.current[i];
         if (el) {
-          el.setAttribute('transform', `translate(${petalOffsets[i].x.toFixed(2)} ${petalOffsets[i].y.toFixed(2)})`);
+          el.setAttribute(
+            'transform',
+            `translate(${petalOffsets[i].x.toFixed(2)} ${petalOffsets[i].y.toFixed(2)})`,
+          );
         }
       }
 
       for (let i = 0; i < stamens.length; i++) {
         const phase = stamenPhases[i];
-        const windX = Math.sin(t + phase) * WIND_STRENGTH_X * 1.2 + Math.sin(t * 1.4 + phase * 0.8) * WIND_STRENGTH_X * 0.4;
+        const windX =
+          Math.sin(t + phase) * WIND_STRENGTH_X * 1.2 +
+          Math.sin(t * 1.4 + phase * 0.8) * WIND_STRENGTH_X * 0.4;
         const windY = Math.cos(t * 0.7 + phase * 1.1) * WIND_STRENGTH_Y * 0.8;
 
-        let pushX = 0, pushY = 0;
+        let pushX = 0,
+          pushY = 0;
         if (mouse.active) {
           const dx = stamens[i].cx - mouse.x;
           const dy = stamens[i].cy - mouse.y;
@@ -335,7 +549,10 @@ const SpiderLily = ({ className }: { className?: string }) => {
         };
         const el = stamenGroupElsRef.current[i];
         if (el) {
-          el.setAttribute('transform', `translate(${stamenOffsets[i].x.toFixed(2)} ${stamenOffsets[i].y.toFixed(2)})`);
+          el.setAttribute(
+            'transform',
+            `translate(${stamenOffsets[i].x.toFixed(2)} ${stamenOffsets[i].y.toFixed(2)})`,
+          );
         }
       }
 
@@ -344,15 +561,23 @@ const SpiderLily = ({ className }: { className?: string }) => {
         const side = mouse.x < CX ? -1 : 1;
         const dx = Math.abs(mouse.x - CX);
         const dy = Math.abs(mouse.y - CY);
-        const proximity = Math.max(0, 1 - Math.sqrt(dx * dx + dy * dy) / PRESS_RADIUS);
+        const proximity = Math.max(
+          0,
+          1 - Math.sqrt(dx * dx + dy * dy) / PRESS_RADIUS,
+        );
         leanTarget = side * proximity * 3.5;
       }
-      leanRef.current += (leanTarget - leanRef.current) * (mouse.active ? 0.03 : 0.015);
+      leanRef.current +=
+        (leanTarget - leanRef.current) * (mouse.active ? 0.03 : 0.015);
 
       const flowerEl = wholeFlowerRef.current;
       if (flowerEl) {
-        const swayAngle = Math.sin(t * 0.8) * 0.8 + Math.sin(t * 1.3) * 0.35 + leanRef.current;
-        flowerEl.setAttribute('transform', `rotate(${swayAngle.toFixed(3)} ${CX} 465)`);
+        const swayAngle =
+          Math.sin(t * 0.8) * 0.8 + Math.sin(t * 1.3) * 0.35 + leanRef.current;
+        flowerEl.setAttribute(
+          'transform',
+          `rotate(${swayAngle.toFixed(3)} ${CX} 465)`,
+        );
       }
 
       rafRef.current = requestAnimationFrame(animate);
@@ -365,10 +590,10 @@ const SpiderLily = ({ className }: { className?: string }) => {
   return (
     <svg
       ref={svgRef}
-      viewBox="-180 10 800 470"
+      viewBox='-180 10 800 470'
       className={className}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
       onMouseMove={handleMouseMove}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
@@ -378,103 +603,114 @@ const SpiderLily = ({ className }: { className?: string }) => {
       onTouchEnd={handleTouchEnd}
     >
       <defs>
-        <filter id="ink-texture">
+        <filter id='ink-texture'>
           <feTurbulence
-            type="fractalNoise"
-            baseFrequency="0.04"
-            numOctaves="3"
-            result="noise"
+            type='fractalNoise'
+            baseFrequency='0.04'
+            numOctaves='3'
+            result='noise'
           />
           <feDisplacementMap
-            in="SourceGraphic"
-            in2="noise"
-            scale="1.2"
-            xChannelSelector="R"
-            yChannelSelector="G"
+            in='SourceGraphic'
+            in2='noise'
+            scale='1.2'
+            xChannelSelector='R'
+            yChannelSelector='G'
           />
         </filter>
-        <filter id="stamen-glow">
-          <feGaussianBlur stdDeviation="1.2" result="blur" />
+        <filter id='stamen-glow'>
+          <feGaussianBlur stdDeviation='1.2' result='blur' />
           <feMerge>
-            <feMergeNode in="blur" />
-            <feMergeNode in="SourceGraphic" />
+            <feMergeNode in='blur' />
+            <feMergeNode in='SourceGraphic' />
           </feMerge>
         </filter>
-        <filter id="petal-glow" x="-30%" y="-30%" width="160%" height="160%">
-          <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="wideGlow" />
-          <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="tightGlow" />
+        <filter id='petal-glow' x='-30%' y='-30%' width='160%' height='160%'>
+          <feGaussianBlur
+            in='SourceGraphic'
+            stdDeviation='6'
+            result='wideGlow'
+          />
+          <feGaussianBlur
+            in='SourceGraphic'
+            stdDeviation='2.5'
+            result='tightGlow'
+          />
           <feMerge>
-            <feMergeNode in="wideGlow" />
-            <feMergeNode in="tightGlow" />
-            <feMergeNode in="SourceGraphic" />
+            <feMergeNode in='wideGlow' />
+            <feMergeNode in='tightGlow' />
+            <feMergeNode in='SourceGraphic' />
           </feMerge>
         </filter>
       </defs>
 
       <g ref={wholeFlowerRef}>
-      <g filter="url(#ink-texture)">
-        {/* Stem */}
-        <path
-          d={`M${CX - 4} ${CY}
+        <g filter='url(#ink-texture)'>
+          {/* Stem */}
+          <path
+            d={`M${CX - 4} ${CY}
               C${CX - 3} ${CY + 30}, ${CX + 2} 275, ${CX + 4} 320
               C${CX + 6} 365, ${CX + 4} 410, ${CX + 1} 465
               C${CX + 6} 410, ${CX + 8} 365, ${CX + 10} 320
               C${CX + 8} 275, ${CX + 7} ${CY + 30}, ${CX + 6} ${CY}
               Z`}
-          className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
-        />
+            className={`spider-lily-stem ${stemActive ? 'spider-lily-stem-active' : ''}`}
+          />
 
-        {/* Flower head */}
-        <g transform={`rotate(-4 ${CX} ${CY})`} filter="url(#petal-glow)">
-          {/* Petals */}
-          {petals.map((p, i) => (
-            <path
-              key={`petal-${i}`}
-              ref={(el) => { petalElsRef.current[i] = el; }}
-              d={p.d}
-              className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
-              style={{ animationDelay: `${petalDelays[i]}ms` }}
-              pathLength={1}
-            />
-          ))}
-
-          {/* Stamens */}
-          {stamens.map((s, i) => (
-            <g
-              key={`stamen-${i}`}
-              ref={(el) => { stamenGroupElsRef.current[i] = el; }}
-            >
+          {/* Flower head */}
+          <g transform={`rotate(-4 ${CX} ${CY})`} filter='url(#petal-glow)'>
+            {/* Petals */}
+            {petals.map((p, i) => (
               <path
-                d={s.d}
-                className={`spider-lily-stamen ${stamensActive ? 'spider-lily-stamen-active' : ''}`}
-                style={{ animationDelay: `${s.delay}ms` }}
-                filter="url(#stamen-glow)"
+                key={`petal-${i}`}
+                ref={el => {
+                  petalElsRef.current[i] = el;
+                }}
+                d={p.d}
+                className={`spider-lily-petal ${petalsActive ? 'spider-lily-petal-active' : ''}`}
+                style={{ animationDelay: `${petalDelays[i]}ms` }}
                 pathLength={1}
               />
-              {!s.noTip && (
-                <ellipse
-                  cx={s.tipX}
-                  cy={s.tipY}
-                  rx={s.tipLen}
-                  ry={s.tipW}
-                  transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
-                  className={`spider-lily-anther ${stamensActive ? 'spider-lily-anther-active' : ''}`}
-                  style={{ animationDelay: `${s.delay + STAMEN_DURATION}ms` }}
-                  filter="url(#stamen-glow)"
-                />
-              )}
-            </g>
-          ))}
+            ))}
 
-          {/* Center */}
-          <circle
-            cx={CX}
-            cy={CY}
-            r="3"
-            className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
-          />
+            {/* Stamens */}
+            {stamens.map((s, i) => (
+              <g
+                key={`stamen-${i}`}
+                ref={el => {
+                  stamenGroupElsRef.current[i] = el;
+                }}
+              >
+                <path
+                  d={s.d}
+                  className={`spider-lily-stamen ${activeStamens[i] ? 'spider-lily-stamen-active' : ''}`}
+                  filter='url(#stamen-glow)'
+                  pathLength={1}
+                />
+                {!s.noTip && (
+                  <ellipse
+                    cx={s.tipX}
+                    cy={s.tipY}
+                    rx={s.tipLen}
+                    ry={s.tipW}
+                    transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
+                    className={`spider-lily-anther ${activeStamens[i] ? 'spider-lily-anther-active' : ''}`}
+                    style={{ animationDelay: `${STAMEN_DURATION}ms` }}
+                    filter='url(#stamen-glow)'
+                  />
+                )}
+              </g>
+            ))}
+
+            {/* Center */}
+            <circle
+              cx={CX}
+              cy={CY}
+              r='3'
+              className={`spider-lily-center ${petalsActive ? 'spider-lily-center-active' : ''}`}
+            />
+          </g>
         </g>
-      </g>
       </g>
     </svg>
   );

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -12,7 +12,10 @@ const MainBanner = () => {
   return (
     <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>
-        <div className='bio-glitch w-80 sm:w-88 md:w-[26rem] lg:w-[30rem]' style={jitter()}>
+        <div
+          className='bio-glitch w-80 sm:w-88 md:w-[26rem] lg:w-[30rem]'
+          style={jitter()}
+        >
           <SpiderLily className='spider-lily-container w-full h-auto' />
         </div>
         <div className='flex flex-col gap-4'>


### PR DESCRIPTION
## Summary
Refactors the spider lily stamen animation so each stamen grows its line and tip independently, with inner stamens emerging before outer ones — matching how a real Lycoris radiata blooms from the center outward.

## Commentary
Previously all stamens activated via a single boolean flag, causing every stamen line to start drawing at once and all anther tips to appear in a batch. Now each stamen has its own activation timeout, ordered by distance from the flower center. Each stamen independently grows its line and then reveals its tip, producing a more organic, staggered growth effect.

Made with [Cursor](https://cursor.com)