### PR TITLE
feat: add transmission 005 and soften footnotes in feed view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -519,6 +519,11 @@
 .transmission-prose.transmission-entry section[data-footnotes] {
   margin-top: 2.5rem;
 }
+.transmission-prose.transmission-list section[data-footnotes] {
+  margin-top: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: none;
+}
 .transmission-prose.transmission-entry pre {
   margin: 1.35em 0;
 }

--- a/src/screens/Transmissions/entries/005-david.md
+++ b/src/screens/Transmissions/entries/005-david.md
@@ -6,6 +6,6 @@ expanded: false
 location: 'San Francisco, US'
 ---
 
-"Finding David in the marble"[^a] is the only description of vibe-coding that has actually made sense to me. It recognizes the non-additive nature of the process while not completely demeriting the difficulty of painfully picking at the model.
+"Finding David in the marble"[^a] is the only representative description of vibe-coding. It recognizes the non-additive nature of the process while not demeriting the difficulty of picking at the model.
 
 [^a]: [Cursor's Ryo Lu on Soulful Design](https://jdahl.substack.com/p/cursors-ryo-lu-on-soulful-design)

--- a/src/screens/Transmissions/entries/005-david.md
+++ b/src/screens/Transmissions/entries/005-david.md
@@ -1,0 +1,11 @@
+---
+id: '005'
+timestamp: '2026.04.12 // 12:11:00'
+title: 'David'
+expanded: false
+location: 'San Francisco, US'
+---
+
+"Finding David in the marble"[^a] is the only description of vibe-coding that has actually made sense to me. It recognizes the non-additive nature of the process while not completely demeriting the difficulty of painfully picking at the model.
+
+[^a]: [Cursor's Ryo Lu on Soulful Design](https://jdahl.substack.com/p/cursors-ryo-lu-on-soulful-design)

--- a/src/screens/Transmissions/index.tsx
+++ b/src/screens/Transmissions/index.tsx
@@ -117,7 +117,7 @@ const TransmissionsScreen = () => {
                     {t.title}
                   </h2>
 
-                  <div className='transmission-prose transmission-entry text-white/60 text-xs sm:text-sm font-mono'>
+                  <div className='transmission-prose transmission-entry transmission-list text-white/60 text-xs sm:text-sm font-mono'>
                     {collapsed ? (
                       <>
                         {hero && (


### PR DESCRIPTION
## Summary
Adds transmission 005 ("David") and reduces the visual separation of the footnotes/ref-nodes section in the transmissions feed so it reads as part of the entry rather than a disjoint block.

## Commentary
A new `transmission-list` CSS modifier class is applied to the feed view wrapper. It removes the `border-top` and tightens spacing on `section[data-footnotes]`, while leaving the full separator intact on the detail page.

Made with [Cursor](https://cursor.com)