### PR TITLE
perf: drop heavy SVG filters + bio-glitch on mobile / reduced-motion

### DIFF
--- a/docs/wu-json/specs/archived/2026-04-21-mobile-lily-and-glitch-perf.md
+++ b/docs/wu-json/specs/archived/2026-04-21-mobile-lily-and-glitch-perf.md
@@ -1,0 +1,188 @@
+---
+status: implemented
+---
+
+# Mobile performance for spider lily + bio-glitch
+
+## Goal
+
+The spider lily on the home banner (`src/screens/Home/SpiderLily.tsx`) and the
+`.bio-glitch` text effect (`src/index.css`) are visibly laggy on iOS Safari —
+the bloom stutters, the wind/sway animation hitches, and theme-flip glitch
+replays on text compete with the lily for frame budget.
+
+Make the home page feel smooth on an iPhone without losing the ink-texture,
+glow, and wind aesthetic on desktop.
+
+## Non-goals
+
+- Redesigning the lily or glitch visuals. Desktop should look identical.
+- Dropping `feTurbulence` / `feGaussianBlur` entirely on desktop.
+- A full `prefers-reduced-motion` pass across the whole site — only the two
+  surfaces in this spec (lily + bio-glitch), because the rest (gallery,
+  fragment lightbox, etc.) is already acceptable.
+- Per-frame performance tuning of the Gallery screen. Out of scope.
+
+## Current state
+
+### Lily (`src/screens/Home/SpiderLily.tsx` + `src/index.css`)
+
+The flower renders inside a chain of SVG filters applied to a subtree that
+changes every rAF:
+
+1. `#ink-texture` — `feTurbulence` (fractalNoise, 3 octaves) + `feDisplacementMap`,
+   wrapping the entire flower group (`<g filter='url(#ink-texture)'>`).
+2. `#petal-glow` — two `feGaussianBlur` passes (stdDeviation 6 and 2.5) + `feMerge`,
+   wrapping all 14 petals + 12 stamens (`<g filter='url(#petal-glow)'>`).
+3. `#stamen-glow` — `feGaussianBlur` applied **per stamen `<path>` and per
+   anther `<ellipse>`**, so ~24 individually filtered nodes.
+
+On top of that, the component runs a `requestAnimationFrame` loop that writes
+`transform='translate(x y)'` on 14 petal paths, 12 stamen groups, and the
+outer flower group for wind + sway — every frame, forever, while the page is
+mounted. Safari does not GPU-accelerate SVG filters the way desktop Chromium
+does; `feTurbulence` in particular recomputes on the CPU, and any transform
+change inside the filtered subtree re-rasterizes the turbulence + both blur
+passes.
+
+The entrance bloom (`lily-petal-bloom`, `lily-stamen-grow`, etc.) stacks on
+top of all this, and `lily-breathe` drives a 7s infinite `drop-shadow`
+animation on the wrapping container. The lily has no reduced-motion or mobile
+fallback.
+
+### `.bio-glitch`
+
+Light on its own (`opacity` + `translateX` with `steps(1, end)` over 350ms),
+but it's applied to **every heading, bio paragraph, and link group** on the
+home banner and on Memories / Signals / Constructs / Heroes index + detail
+screens. It also replays on every theme toggle via `data-theme-flash-reset`.
+On iOS, while the lily is saturating the compositor, the concurrent glitch
+replays on a dozen nodes stutter visibly. There is no reduced-motion guard.
+
+## Design
+
+Two orthogonal levers: **capability detection** and **animation density**.
+Neither changes the desktop experience.
+
+### 1. Capability detection helper
+
+Add a tiny module `src/lib/motion.ts` (or inline constant inside `SpiderLily`
+if we don't need reuse) that exposes two booleans, computed once at module
+load:
+
+- `prefersReducedMotion` — `window.matchMedia('(prefers-reduced-motion: reduce)').matches`
+- `isCoarsePointer` — `window.matchMedia('(pointer: coarse)').matches`
+
+Convention used elsewhere (`src/screens/Gallery/index.tsx`) already treats
+`pointer: coarse` as "mobile-ish". We'll reuse that rather than parsing UA.
+
+A derived `heavyEffectsEnabled` boolean = `!prefersReducedMotion && !isCoarsePointer`
+is what the lily and glitch will consult. SSR-safe: fall back to `true`
+(desktop) when `window` is undefined.
+
+Live updates (e.g. user enables reduced motion mid-session) are not a goal —
+re-reading on component mount is sufficient.
+
+### 2. Lily: conditional filter chain + rAF gating
+
+In `SpiderLily.tsx`:
+
+- When `heavyEffectsEnabled` is `false`:
+  - **Omit `#ink-texture`.** Render the flower subtree without the outer
+    `<g filter='url(#ink-texture)'>` wrapper. Turbulence + displacement map
+    is the single biggest mobile cost and is cosmetic.
+  - **Omit `#petal-glow`.** Replace with a single CSS `filter: drop-shadow(...)`
+    applied on the rotated flower `<g>` (composited by Safari) — keeps a
+    soft bloom without two `feGaussianBlur` passes on 26 children.
+  - **Drop per-stamen `#stamen-glow`.** The per-node Gaussian blur on 24
+    elements is what makes pan/sway hitch. Remove the `filter=` attribute
+    on each `<path className='spider-lily-stamen'>` and each anther
+    `<ellipse>` in the reduced branch.
+  - **Skip the wind/sway rAF loop entirely.** The sub-pixel wind offsets
+    and ±1° sway are imperceptible at phone viewport sizes and carry the
+    full cost of re-rasterizing the filtered subtree. Leave the entrance
+    bloom keyframes on (they're cheap without the filters), skip the rAF.
+  - **Disable `lily-breathe`.** The infinite `drop-shadow` pulse on the
+    container is layered on top of the now-removed filters and adds
+    nothing without them. Gate the class or override with a reduced-motion
+    rule.
+  - **Touch-push reaction on `<path>` transforms is dropped** as a
+    consequence of not running the rAF loop. Tap still fires `toggle()` —
+    that's the important interaction.
+
+- When `heavyEffectsEnabled` is `true`: behavior is unchanged. Desktop gets
+  the full filter chain, wind, sway, and breathe.
+
+Implementation shape: branch on the constant at render time and return two
+slightly different JSX trees, sharing the same petal/stamen data arrays.
+Gate the `useEffect` that starts the rAF loop behind the same flag
+(early-return if disabled). The entrance `setTimeout` chain that toggles
+`stemActive` / `petalsActive` / `activeStamens` stays the same in both
+branches.
+
+### 3. `.bio-glitch`: reduced-motion + mobile opt-out
+
+In `src/index.css`:
+
+- Add a media-query override:
+  ```css
+  @media (prefers-reduced-motion: reduce), (pointer: coarse) {
+    .bio-glitch,
+    .nav-glitch-active {
+      animation: none;
+      opacity: 1;
+    }
+    html[data-theme-flash-reset] .bio-glitch,
+    html[data-theme-flash-reset] .nav-glitch-active {
+      animation: none;
+    }
+  }
+  ```
+- This leaves the element fully visible on mobile (no entrance jitter, no
+  theme-flip replay) and preserves desktop behavior verbatim.
+
+We intentionally keep the `nav-glitch` keyframes defined — they just don't
+run on mobile.
+
+## Files touched
+
+- `src/screens/Home/SpiderLily.tsx` — branch on `heavyEffectsEnabled`,
+  conditionally render filter wrappers, conditionally register the rAF
+  wind/sway effect, drop per-node `filter='url(#stamen-glow)'` in the
+  reduced branch.
+- `src/index.css` — add the `@media (prefers-reduced-motion: reduce),
+(pointer: coarse)` block for `.bio-glitch` / `.nav-glitch-active`, and
+  a companion rule to suppress `lily-breathe` on the `.spider-lily-container`
+  under the same media query.
+- _(optional)_ `src/lib/motion.ts` — small helper if we end up wanting the
+  flag in other places; otherwise inline in `SpiderLily.tsx`.
+
+## Verification
+
+1. Desktop Chromium + desktop Safari: home banner looks identical — ink
+   texture, petal glow, per-stamen glow, wind, sway, breathe all intact.
+2. iOS Safari (or DevTools device emulation with `pointer: coarse` forced):
+   lily blooms smoothly, no ink-texture, subtle CSS drop-shadow in place of
+   petal glow, no wind loop, no breathing pulse. Tap still toggles theme
+   and the ripple still plays (ripple is owned by `ThemeContext` / outer
+   overlay, not this component).
+3. macOS with **System Settings → Accessibility → Reduce Motion** on:
+   same reduced render as mobile.
+4. `.bio-glitch` text on mobile is static (no shift, no flicker); on
+   desktop the entrance glitch and theme-flip replay behave as before.
+5. `bun run lint` and `bun run format` clean.
+
+## Risks / open questions
+
+- **Aesthetic regression on mobile.** We lose the inky displacement and the
+  wide petal halo. Acceptable trade: the flower still reads as a spider
+  lily, the bloom still plays, and the page is usable. If we miss the glow
+  we can reintroduce a single `drop-shadow` at a modest radius on mobile
+  (included in the design above).
+- **`pointer: coarse` is an imperfect proxy for "slow device".** A large
+  Android tablet with coarse pointer will also get the reduced render even
+  if it could handle the full one. Acceptable: the reduced render still
+  looks intentional, and this is strictly a perf safety net.
+- **No live media-query listener.** If a user toggles Reduce Motion without
+  reloading, they keep whatever mode was captured at mount. Revisit only
+  if this becomes a real complaint.

--- a/src/index.css
+++ b/src/index.css
@@ -464,6 +464,37 @@ html[data-theme-flash-reset] .nav-glitch-active {
     lily-breathe 7s ease-in-out 4s infinite;
 }
 
+/* Mobile / reduced-motion fallback.
+   iOS Safari can't composite the stacked SVG filters (feTurbulence + two
+   Gaussian blurs + per-stamen glow) at 60fps while the lily is animating.
+   SpiderLily.tsx drops those filters and the wind/sway rAF loop on coarse
+   pointers; here we also skip the infinite breathing drop-shadow (which
+   layers on top of those filters) and stop the bio-glitch text animation
+   across the site. Desktop behavior is unchanged. */
+@media (prefers-reduced-motion: reduce), (pointer: coarse) {
+  .spider-lily-container {
+    animation: lily-glow-in 2.5s ease-out 1.2s forwards;
+  }
+
+  /* Soft CSS drop-shadow to replace the removed #petal-glow SVG filter.
+     Composited by the browser, so it doesn't re-rasterize on any transform. */
+  .spider-lily-head-lite {
+    filter: drop-shadow(0 0 4px var(--color-glow-soft));
+  }
+
+  .bio-glitch,
+  .nav-glitch-active {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  html[data-theme-flash-reset] .bio-glitch,
+  html[data-theme-flash-reset] .nav-glitch-active {
+    animation: none;
+  }
+}
+
 @keyframes lily-glitch {
   0% {
     translate: 0 0;

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -346,6 +346,18 @@ const WIND_SPEED = 0.0008;
 const WIND_STRENGTH_X = 4.5;
 const WIND_STRENGTH_Y = 2.0;
 
+// Capability flags captured once at module load. iOS Safari chokes on the
+// stacked SVG filters (feTurbulence + two Gaussian blurs + per-stamen glow)
+// re-rasterizing every rAF, so on coarse-pointer devices and under Reduce
+// Motion we skip the filter chain and the wind/sway loop entirely. Desktop
+// behavior is unchanged.
+const heavyEffectsEnabled = (() => {
+  if (typeof window === 'undefined') return true;
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const coarse = window.matchMedia('(pointer: coarse)').matches;
+  return !reduce && !coarse;
+})();
+
 type Vec2 = { x: number; y: number };
 
 const SpiderLily = ({ className }: { className?: string }) => {
@@ -447,6 +459,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
   );
 
   useEffect(() => {
+    if (!heavyEffectsEnabled) return;
     const t0 = performance.now();
     const petalPhases = petals.map((_, i) => i * 0.7 + Math.sin(i * 2.3) * 0.5);
     const stamenPhases = stamens.map(
@@ -569,50 +582,52 @@ const SpiderLily = ({ className }: { className?: string }) => {
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
-      <defs>
-        <filter id='ink-texture'>
-          <feTurbulence
-            type='fractalNoise'
-            baseFrequency='0.04'
-            numOctaves='3'
-            result='noise'
-          />
-          <feDisplacementMap
-            in='SourceGraphic'
-            in2='noise'
-            scale='1.2'
-            xChannelSelector='R'
-            yChannelSelector='G'
-          />
-        </filter>
-        <filter id='stamen-glow'>
-          <feGaussianBlur stdDeviation='1.2' result='blur' />
-          <feMerge>
-            <feMergeNode in='blur' />
-            <feMergeNode in='SourceGraphic' />
-          </feMerge>
-        </filter>
-        <filter id='petal-glow' x='-30%' y='-30%' width='160%' height='160%'>
-          <feGaussianBlur
-            in='SourceGraphic'
-            stdDeviation='6'
-            result='wideGlow'
-          />
-          <feGaussianBlur
-            in='SourceGraphic'
-            stdDeviation='2.5'
-            result='tightGlow'
-          />
-          <feMerge>
-            <feMergeNode in='wideGlow' />
-            <feMergeNode in='tightGlow' />
-            <feMergeNode in='SourceGraphic' />
-          </feMerge>
-        </filter>
-      </defs>
+      {heavyEffectsEnabled && (
+        <defs>
+          <filter id='ink-texture'>
+            <feTurbulence
+              type='fractalNoise'
+              baseFrequency='0.04'
+              numOctaves='3'
+              result='noise'
+            />
+            <feDisplacementMap
+              in='SourceGraphic'
+              in2='noise'
+              scale='1.2'
+              xChannelSelector='R'
+              yChannelSelector='G'
+            />
+          </filter>
+          <filter id='stamen-glow'>
+            <feGaussianBlur stdDeviation='1.2' result='blur' />
+            <feMerge>
+              <feMergeNode in='blur' />
+              <feMergeNode in='SourceGraphic' />
+            </feMerge>
+          </filter>
+          <filter id='petal-glow' x='-30%' y='-30%' width='160%' height='160%'>
+            <feGaussianBlur
+              in='SourceGraphic'
+              stdDeviation='6'
+              result='wideGlow'
+            />
+            <feGaussianBlur
+              in='SourceGraphic'
+              stdDeviation='2.5'
+              result='tightGlow'
+            />
+            <feMerge>
+              <feMergeNode in='wideGlow' />
+              <feMergeNode in='tightGlow' />
+              <feMergeNode in='SourceGraphic' />
+            </feMerge>
+          </filter>
+        </defs>
+      )}
 
       <g ref={wholeFlowerRef}>
-        <g filter='url(#ink-texture)'>
+        <g filter={heavyEffectsEnabled ? 'url(#ink-texture)' : undefined}>
           {/* Stem */}
           <path
             d={`M${CX - 4} ${CY}
@@ -625,7 +640,13 @@ const SpiderLily = ({ className }: { className?: string }) => {
           />
 
           {/* Flower head */}
-          <g transform={`rotate(-4 ${CX} ${CY})`} filter='url(#petal-glow)'>
+          <g
+            transform={`rotate(-4 ${CX} ${CY})`}
+            filter={heavyEffectsEnabled ? 'url(#petal-glow)' : undefined}
+            className={
+              heavyEffectsEnabled ? undefined : 'spider-lily-head-lite'
+            }
+          >
             {/* Petals */}
             {petals.map((p, i) => (
               <path
@@ -651,7 +672,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
                 <path
                   d={s.d}
                   className={`spider-lily-stamen ${activeStamens[i] ? 'spider-lily-stamen-active' : ''}`}
-                  filter='url(#stamen-glow)'
+                  filter={heavyEffectsEnabled ? 'url(#stamen-glow)' : undefined}
                   pathLength={1}
                 />
                 {!s.noTip && (
@@ -663,7 +684,9 @@ const SpiderLily = ({ className }: { className?: string }) => {
                     transform={`rotate(${s.tipAngle} ${s.tipX} ${s.tipY})`}
                     className={`spider-lily-anther ${activeStamens[i] ? 'spider-lily-anther-active' : ''}`}
                     style={{ animationDelay: `${STAMEN_DURATION}ms` }}
-                    filter='url(#stamen-glow)'
+                    filter={
+                      heavyEffectsEnabled ? 'url(#stamen-glow)' : undefined
+                    }
                   />
                 )}
               </g>


### PR DESCRIPTION
## Summary
Skips the spider lily's stacked SVG filter chain (`feTurbulence` + two `feGaussianBlur` passes + per-stamen glow), the wind/sway `requestAnimationFrame` loop, the infinite `lily-breathe` pulse, and the site-wide `.bio-glitch` / `.nav-glitch-active` animations on coarse-pointer devices and under `prefers-reduced-motion`. Desktop behavior is unchanged.

## Commentary
iOS Safari doesn't GPU-accelerate SVG filters like desktop Chromium, so the bloom + per-frame transform writes inside the filtered subtree were re-rasterizing turbulence and both blur passes every frame. The lite branch also adds a composited CSS `drop-shadow` on the flower head as a cheap stand-in for `#petal-glow`. See `docs/wu-json/specs/archived/2026-04-21-mobile-lily-and-glitch-perf.md`.