### PR TITLE
fix: restore bio/nav glitch entrance and flower glow on mobile Safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -464,21 +464,24 @@ html[data-theme-flash-reset] .nav-glitch-active {
     lily-breathe 7s ease-in-out 4s infinite;
 }
 
+/* Theme color for the mobile/reduced-motion petal glow (SVG <feDropShadow>
+   in SpiderLily.tsx). We theme via a CSS `flood-color` rule instead of an
+   SVG presentation attribute so the light/dark tokens resolve correctly. */
+.spider-lily-petal-glow {
+  flood-color: var(--color-glow-soft);
+  flood-opacity: 1;
+}
+
 /* Mobile / reduced-motion fallback for the spider lily.
    iOS Safari can't composite the stacked SVG filters (feTurbulence + two
    Gaussian blurs + per-stamen glow) at 60fps while the lily is animating.
    SpiderLily.tsx drops those filters and the wind/sway rAF loop on coarse
-   pointers; here we also skip the infinite breathing drop-shadow (which
-   layers on top of those filters). Desktop behavior is unchanged. */
+   pointers, and swaps the heavy #petal-glow for a single-pass
+   <feDropShadow> (#petal-glow-lite). Here we also skip the infinite
+   breathing drop-shadow on the container. Desktop behavior is unchanged. */
 @media (prefers-reduced-motion: reduce), (pointer: coarse) {
   .spider-lily-container {
     animation: lily-glow-in 2.5s ease-out 1.2s forwards;
-  }
-
-  /* Soft CSS drop-shadow to replace the removed #petal-glow SVG filter.
-     Composited by the browser, so it doesn't re-rasterize on any transform. */
-  .spider-lily-head-lite {
-    filter: drop-shadow(0 0 4px var(--color-glow-soft));
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -464,13 +464,12 @@ html[data-theme-flash-reset] .nav-glitch-active {
     lily-breathe 7s ease-in-out 4s infinite;
 }
 
-/* Mobile / reduced-motion fallback.
+/* Mobile / reduced-motion fallback for the spider lily.
    iOS Safari can't composite the stacked SVG filters (feTurbulence + two
    Gaussian blurs + per-stamen glow) at 60fps while the lily is animating.
    SpiderLily.tsx drops those filters and the wind/sway rAF loop on coarse
    pointers; here we also skip the infinite breathing drop-shadow (which
-   layers on top of those filters) and stop the bio-glitch text animation
-   across the site. Desktop behavior is unchanged. */
+   layers on top of those filters). Desktop behavior is unchanged. */
 @media (prefers-reduced-motion: reduce), (pointer: coarse) {
   .spider-lily-container {
     animation: lily-glow-in 2.5s ease-out 1.2s forwards;
@@ -481,7 +480,15 @@ html[data-theme-flash-reset] .nav-glitch-active {
   .spider-lily-head-lite {
     filter: drop-shadow(0 0 4px var(--color-glow-soft));
   }
+}
 
+/* The bio/nav glitch entrance is opacity + translateX only (cheap on its
+   own). It was originally bundled into the coarse-pointer opt-out above
+   because it ran concurrently with the heavy lily filters on mobile — now
+   that the lily drops those on coarse pointers, the glitch itself plays
+   fine on iOS Safari and gives the page load its intended cadence. We
+   still honor `prefers-reduced-motion` for accessibility. */
+@media (prefers-reduced-motion: reduce) {
   .bio-glitch,
   .nav-glitch-active {
     animation: none;

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -582,7 +582,7 @@ const SpiderLily = ({ className }: { className?: string }) => {
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
-      {heavyEffectsEnabled && (
+      {heavyEffectsEnabled ? (
         <defs>
           <filter id='ink-texture'>
             <feTurbulence
@@ -624,6 +624,31 @@ const SpiderLily = ({ className }: { className?: string }) => {
             </feMerge>
           </filter>
         </defs>
+      ) : (
+        /* Mobile / reduced-motion path. A single `<feDropShadow>` is cheap
+           for Safari to composite (one pass, no per-frame rasterization)
+           and — unlike CSS `filter: drop-shadow(...)` on an inline SVG
+           subtree — actually renders on iOS (WebKit bug 261806). This
+           replaces the removed #petal-glow so the flower still reads as
+           luminous on mobile. */
+        <defs>
+          <filter
+            id='petal-glow-lite'
+            x='-30%'
+            y='-30%'
+            width='160%'
+            height='160%'
+          >
+            {/* flood-color is themed via CSS (see .spider-lily-petal-glow
+                rule in index.css) so the glow tracks the active palette. */}
+            <feDropShadow
+              className='spider-lily-petal-glow'
+              dx='0'
+              dy='0'
+              stdDeviation='3'
+            />
+          </filter>
+        </defs>
       )}
 
       <g ref={wholeFlowerRef}>
@@ -642,9 +667,8 @@ const SpiderLily = ({ className }: { className?: string }) => {
           {/* Flower head */}
           <g
             transform={`rotate(-4 ${CX} ${CY})`}
-            filter={heavyEffectsEnabled ? 'url(#petal-glow)' : undefined}
-            className={
-              heavyEffectsEnabled ? undefined : 'spider-lily-head-lite'
+            filter={
+              heavyEffectsEnabled ? 'url(#petal-glow)' : 'url(#petal-glow-lite)'
             }
           >
             {/* Petals */}

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -16,7 +16,14 @@ const MainBanner = () => {
           className='bio-glitch w-80 sm:w-88 md:w-[26rem] lg:w-[30rem]'
           style={jitter()}
         >
-          <SpiderLily className='spider-lily-container w-full h-auto' />
+          {/* spider-lily-container lives on a wrapping HTML element rather
+              than the <svg> itself because iOS Safari doesn't apply CSS
+              `filter: drop-shadow(...)` to inline SVG roots (WebKit bug
+              261806). Wrapping in a div lets the glow animation render on
+              mobile Safari while keeping desktop behavior identical. */}
+          <div className='spider-lily-container w-full h-auto'>
+            <SpiderLily className='w-full h-auto' />
+          </div>
         </div>
         <div className='flex flex-col gap-4'>
           <p


### PR DESCRIPTION
## Summary

Fix two mobile-Safari regressions on the home banner: the `.bio-glitch` / `.nav-glitch-active` entrance doesn't play, and the spider lily's ambient glow doesn't render.

## Commentary

**Glitch entrance** was bundled into the `(pointer: coarse)` opt-out in #55 alongside the heavy lily filters, but the glitch itself is just `opacity` + `translateX` steps — cheap on its own. It only stuttered because it ran concurrently with the lily's `feTurbulence` + stacked blurs, which are already dropped on coarse pointers. Scope the glitch opt-out to `prefers-reduced-motion: reduce` only so iOS Safari plays it while accessibility contracts hold.

**Flower glow** was invisible on iOS because CSS `filter: drop-shadow(...)` doesn't apply to inline SVG roots or inner SVG subtrees ([WebKit 261806](https://bugs.webkit.org/show_bug.cgi?id=261806) / [246106](https://bugs.webkit.org/show_bug.cgi?id=246106)). Two fixes:

- Move `.spider-lily-container` onto a wrapping `<div>` so the `lily-glow-in` drop-shadow animation composites on an HTML element.
- Swap the inner `spider-lily-head-lite` CSS filter for a single-pass SVG `<feDropShadow>` (`#petal-glow-lite`) — rendered reliably by iOS, cheap enough to avoid regressing mobile perf. Flood color is themed via CSS so light/dark tokens resolve.

Desktop behavior is unchanged in both cases.