### PR TITLE
fix: restore flower center glow on mobile Safari

### DIFF
--- a/docs/wu-json/bugs/archived/2026-04-21-mobile-safari-flower-center-no-glow.md
+++ b/docs/wu-json/bugs/archived/2026-04-21-mobile-safari-flower-center-no-glow.md
@@ -1,0 +1,176 @@
+---
+status: implemented
+---
+
+# Mobile Safari: no glow at flower center
+
+## Bug
+
+On iOS Safari (and anywhere the coarse-pointer / reduced-motion fallback
+branch in `SpiderLily.tsx` is active), the spider lily renders flat —
+there is no visible halo around the dense petal / stamen / center
+region, where desktop has a strong luminous bloom.
+
+The `lily-breathe` / `lily-glow-in` **outer** drop-shadow on the
+`.spider-lily-container` HTML wrapper still fires (that was fixed in
+#56), but the _inner_ petal-glow replacement never produces visible
+output on mobile.
+
+## Current state
+
+Desktop uses `#petal-glow` — a two-pass `feGaussianBlur`
+(stdDeviation 6 + 2.5) + `feMerge`, applied to the flower `<g>`. The
+glow is self-colored (the petals are white ink, blurred into a white
+halo).
+
+Mobile / reduced-motion uses `#petal-glow-lite`:
+
+```
+<filter id='petal-glow-lite' ...>
+  <feDropShadow
+    className='spider-lily-petal-glow'
+    dx='0' dy='0' stdDeviation='3'
+  />
+</filter>
+```
+
+and a CSS rule tries to theme the shadow color:
+
+```
+.spider-lily-petal-glow {
+  flood-color: var(--color-glow-soft);
+  flood-opacity: 1;
+}
+```
+
+Two independent problems stack:
+
+1. **`flood-color` set via a CSS class on `<feDropShadow>` is not
+   honored by iOS Safari.** WebKit supports the `flood-color` and
+   `flood-opacity` _presentation attributes_ on filter primitives, but
+   does not reliably resolve them when they arrive as CSS declarations
+   targeting the `<feDropShadow>` element. The shadow falls back to
+   opaque black, which is invisible on the black dark-mode surface
+   (and produces an unexpected black smudge under the light-mode
+   flower).
+
+2. **Even if `flood-color` resolved, `stdDeviation=3` with dx/dy=0 is
+   much tighter than the desktop halo.** The desktop petal-glow is a
+   _merge_ of a wide blur (stdDev 6) and a tight blur (stdDev 2.5)
+   composited behind the source graphic — not a colored drop shadow.
+   The single-pass lite filter can't reproduce the "light is radiating
+   out of the center" look even when it's colored correctly.
+
+## Goal
+
+Restore a visible, luminous halo around the flower on mobile Safari
+(and anywhere the reduced-motion branch runs), concentrated at the
+dense center where the petals and stamens converge — without
+reintroducing `feTurbulence` or per-stamen filters, and without
+breaking desktop.
+
+## Non-goals
+
+- Matching the desktop halo pixel-for-pixel. Mobile can be slightly
+  softer so long as the center clearly glows.
+- Bringing back the wind/sway rAF loop, per-stamen `#stamen-glow`, or
+  `#ink-texture` on mobile. Those remain opted out (see the prior
+  spec, `2026-04-21-mobile-lily-and-glitch-perf.md`).
+- Fixing any other iOS Safari glow regressions outside the lily.
+
+## Design
+
+Rebuild `#petal-glow-lite` so it uses the same pattern as the desktop
+filter — a **self-colored** multi-pass Gaussian blur of the source
+graphic — but with fewer passes and a tighter region so it stays cheap
+on mobile Safari. This eliminates the dependence on `flood-color`
+entirely: the halo inherits whatever color the petals/stamens are
+already painted in, which is driven by the existing `--color-ink`
+token and already tracks the light/dark theme correctly.
+
+Concrete shape:
+
+```xml
+<filter id='petal-glow-lite' x='-30%' y='-30%' width='160%' height='160%'>
+  <feGaussianBlur in='SourceGraphic' stdDeviation='5' result='wide' />
+  <feGaussianBlur in='SourceGraphic' stdDeviation='2' result='tight' />
+  <feMerge>
+    <feMergeNode in='wide' />
+    <feMergeNode in='tight' />
+    <feMergeNode in='SourceGraphic' />
+  </feMerge>
+</filter>
+```
+
+- Two `feGaussianBlur` passes instead of desktop's two stacked on top
+  of a wrapping `feTurbulence`. On a **static** subtree (no rAF loop
+  on mobile) Safari rasterizes this **once at paint time** and caches
+  it, which is the whole reason we removed the per-frame writes. A
+  single static two-pass blur is well within iOS's budget.
+- No `flood-color`, no CSS rule on the primitive — the halo picks up
+  the petals' existing ink color, so dark mode glows white and light
+  mode glows black (matching desktop behavior).
+- Dimensions (`x`, `y`, `width`, `height`) already give the halo room
+  to bleed past the flower bounds.
+
+Since there is no `flood-color` dependency anymore, the
+`.spider-lily-petal-glow` CSS rule and the `className` on
+`<feDropShadow>` are both removed.
+
+### Why not keep `feDropShadow` with a presentation attribute?
+
+A `flood-color="white"` attribute would work, but it would bake in the
+wrong dark-mode color for light mode (the shadow would always be white
+regardless of theme). Self-colored blur of `SourceGraphic` is theme-
+agnostic by construction.
+
+### Why two passes instead of one
+
+With one pass at stdDev ~4 the halo looks tight and waxy; the flower
+still reads flat. Desktop's distinctive "soft wide ring + tight inner
+bloom" comes specifically from the _merge_ of two different blur
+radii. Matching that shape (at slightly smaller stdDeviations, 5 and 2) preserves the aesthetic without the cost.
+
+## Files touched
+
+- `src/screens/Home/SpiderLily.tsx`
+  - Rewrite the `else` branch of the `<defs>` block: replace the
+    single `<feDropShadow>` with the two-pass `feGaussianBlur` +
+    `feMerge` structure above.
+  - Remove the `className='spider-lily-petal-glow'` attribute (it has
+    no remaining consumer).
+  - Update the accompanying comment to describe the new approach and
+    drop the WebKit bug 261806 reference (that bug was about CSS
+    `filter: drop-shadow` on inline SVG roots; it's still relevant to
+    the `.spider-lily-container` wrapper discussion but not to this
+    inline SVG filter).
+- `src/index.css`
+  - Delete the `.spider-lily-petal-glow` rule (`flood-color` /
+    `flood-opacity`). Nothing else references it.
+
+## Verification
+
+1. iOS Safari (or DevTools with `pointer: coarse` forced + hard
+   reload): the flower has a visible white halo concentrated at the
+   center, clearly readable against the black surface.
+2. iOS Safari in light mode (after tapping the flower): halo is a
+   subtle dark bloom that matches the desktop light-mode glow color.
+3. Desktop Chromium + desktop Safari: unchanged (`heavyEffectsEnabled`
+   still true → still uses `#petal-glow`, not `#petal-glow-lite`).
+4. macOS with Reduce Motion on: sees the new mobile-style glow
+   consistently.
+5. `bun run lint` and `bun run format` clean.
+
+## Risks
+
+- **Two-pass blur on mobile is still heavier than a drop-shadow.**
+  Mitigated by: (a) the subtree is static on mobile (no rAF writes
+  inside the filtered group, so it rasterizes once), and (b) the
+  entrance bloom keyframes are on individual petal/stamen ink paths
+  inside the filtered group — they animate `opacity` and
+  `stroke-dashoffset` but _not_ geometry. If they turn out to trigger
+  re-rasterization, we can further downgrade to a single-pass blur
+  (stdDev ~4) and accept a slightly softer halo.
+- **Dropping `flood-color` theming removes a seam for future
+  multi-color glow experimentation** — acceptable; we can reintroduce
+  a themed filter later behind its own id if we ever need it.

--- a/src/index.css
+++ b/src/index.css
@@ -464,21 +464,14 @@ html[data-theme-flash-reset] .nav-glitch-active {
     lily-breathe 7s ease-in-out 4s infinite;
 }
 
-/* Theme color for the mobile/reduced-motion petal glow (SVG <feDropShadow>
-   in SpiderLily.tsx). We theme via a CSS `flood-color` rule instead of an
-   SVG presentation attribute so the light/dark tokens resolve correctly. */
-.spider-lily-petal-glow {
-  flood-color: var(--color-glow-soft);
-  flood-opacity: 1;
-}
-
 /* Mobile / reduced-motion fallback for the spider lily.
    iOS Safari can't composite the stacked SVG filters (feTurbulence + two
    Gaussian blurs + per-stamen glow) at 60fps while the lily is animating.
    SpiderLily.tsx drops those filters and the wind/sway rAF loop on coarse
-   pointers, and swaps the heavy #petal-glow for a single-pass
-   <feDropShadow> (#petal-glow-lite). Here we also skip the infinite
-   breathing drop-shadow on the container. Desktop behavior is unchanged. */
+   pointers, and swaps the heavy #petal-glow for a slimmer two-pass
+   Gaussian blur merge (#petal-glow-lite) that self-colors from
+   SourceGraphic. Here we also skip the infinite breathing drop-shadow on
+   the container. Desktop behavior is unchanged. */
 @media (prefers-reduced-motion: reduce), (pointer: coarse) {
   .spider-lily-container {
     animation: lily-glow-in 2.5s ease-out 1.2s forwards;

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -625,12 +625,15 @@ const SpiderLily = ({ className }: { className?: string }) => {
           </filter>
         </defs>
       ) : (
-        /* Mobile / reduced-motion path. A single `<feDropShadow>` is cheap
-           for Safari to composite (one pass, no per-frame rasterization)
-           and — unlike CSS `filter: drop-shadow(...)` on an inline SVG
-           subtree — actually renders on iOS (WebKit bug 261806). This
-           replaces the removed #petal-glow so the flower still reads as
-           luminous on mobile. */
+        /* Mobile / reduced-motion path. Mirrors the desktop #petal-glow
+           (wide blur + tight blur + SourceGraphic merge) at smaller radii.
+           On this branch the flower subtree is static — no rAF transform
+           writes inside the filtered group — so iOS Safari rasterizes the
+           filter once at paint time instead of every frame, which keeps
+           it cheap. Self-coloring via SourceGraphic avoids a `flood-color`
+           CSS theming seam that iOS ignores on `<feDropShadow>`; the halo
+           inherits the petals' ink color and tracks the active theme
+           automatically. */
         <defs>
           <filter
             id='petal-glow-lite'
@@ -639,14 +642,21 @@ const SpiderLily = ({ className }: { className?: string }) => {
             width='160%'
             height='160%'
           >
-            {/* flood-color is themed via CSS (see .spider-lily-petal-glow
-                rule in index.css) so the glow tracks the active palette. */}
-            <feDropShadow
-              className='spider-lily-petal-glow'
-              dx='0'
-              dy='0'
-              stdDeviation='3'
+            <feGaussianBlur
+              in='SourceGraphic'
+              stdDeviation='5'
+              result='wideGlow'
             />
+            <feGaussianBlur
+              in='SourceGraphic'
+              stdDeviation='2'
+              result='tightGlow'
+            />
+            <feMerge>
+              <feMergeNode in='wideGlow' />
+              <feMergeNode in='tightGlow' />
+              <feMergeNode in='SourceGraphic' />
+            </feMerge>
           </filter>
         </defs>
       )}


### PR DESCRIPTION
## Summary
The mobile / reduced-motion `#petal-glow-lite` filter used a CSS `flood-color` rule to theme a `<feDropShadow>`, but iOS Safari does not apply CSS-sourced `flood-color` to filter primitives — the shadow fell back to black and was invisible against the dark surface, leaving the flower center flat on mobile.

Replace it with a two-pass `feGaussianBlur` + `feMerge` that mirrors the desktop `#petal-glow` at smaller radii and self-colors from `SourceGraphic`, so the halo inherits the petals' ink and tracks the light/dark theme automatically.

## Commentary
- The subtree stays static on mobile (no rAF writes inside the filtered group, per #55 / #56), so Safari rasterizes the blur once at paint time — cheap enough to keep.
- Removes the now-unused `.spider-lily-petal-glow` CSS rule.
- Bug spec archived under `docs/wu-json/bugs/archived/2026-04-21-mobile-safari-flower-center-no-glow.md`.