### PR TITLE
fix: gate signal list hover tint behind (hover: hover)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -793,6 +793,16 @@ html[data-theme-flash-reset] .nav-glitch-active {
   filter: drop-shadow(0 0 6px var(--color-glow-strong));
 }
 
+/* Signal list item hover. Gated behind `(hover: hover)` so iOS Safari
+   doesn't strand the tint on the last-tapped card while scrolling — most
+   noticeable in light mode where the hair-line tint reads as a real
+   highlight. */
+@media (hover: hover) {
+  .signal-list-item:hover {
+    background-color: var(--color-ink-hair);
+  }
+}
+
 @keyframes gallery-hint-in {
   from {
     opacity: 0;
@@ -902,9 +912,6 @@ html[data-theme-flash-reset] .nav-glitch-active {
   background-color: var(--color-ink-hair);
 }
 [data-theme='light'] .bg-white\/5 {
-  background-color: var(--color-ink-hair);
-}
-[data-theme='light'] .hover\:bg-white\/\[0\.03\]:hover {
   background-color: var(--color-ink-hair);
 }
 

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -96,7 +96,7 @@ const SignalsScreen = () => {
                 <div
                   tabIndex={0}
                   aria-label={`View full signal${s.title ? `: ${s.title}` : ` ${s.id}`}`}
-                  className='cursor-pointer rounded-sm -mx-2 px-2 py-1 -my-1 transition-colors hover:bg-white/[0.03] outline-none focus-visible:ring-1 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+                  className='signal-list-item cursor-pointer rounded-sm -mx-2 px-2 py-1 -my-1 transition-colors outline-none focus-visible:ring-1 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
                   onClick={onPreviewClick}
                   onKeyDown={onPreviewKeyDown}
                 >


### PR DESCRIPTION
## Summary

On mobile Safari, scrolling through `/signals` would leave a faint highlight on seemingly random cards. Tapping triggers `:hover` on iOS and the state strands on the last-tapped element until you tap elsewhere — very visible in light mode where the hair-line tint reads as a real highlight, barely noticeable in dark mode.

- Replace `hover:bg-white/[0.03]` on the signal list item with a dedicated `.signal-list-item` class whose `:hover` rule is wrapped in `@media (hover: hover)`, so the tint only applies on devices that actually support hover.
- Drop the now-orphaned `[data-theme='light'] .hover\:bg-white\/\[0\.03\]:hover` override (no remaining callers).