### PR TITLE
fix: remove light-mode glow on mobile menu flower

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -930,6 +930,13 @@ html[data-theme-flash-reset] .nav-glitch-active {
   filter: none;
 }
 
+/* Same story for the mobile menu flower: the breathing drop-shadow reads as a
+   smudge around the black petals on white. Kill the animation in light mode. */
+[data-theme='light'] .menu-flower-glow {
+  animation: none;
+  filter: none;
+}
+
 /*
  * Inline arbitrary text-shadow utilities used throughout the codebase
  * (`[text-shadow:0_0_Npx_rgba(255,255,255,…)]`). In light mode these become


### PR DESCRIPTION
## Summary
Disables the breathing `lunar-tear-glow` drop-shadow on the mobile menu flower icon under `[data-theme='light']`, where it was reading as a muddy halo around the black petals on white.

## Commentary
Mirrors the existing light-mode override for `.scroll-to-top` in `src/index.css` — same pattern, same rationale. Dark mode is untouched.