### PR TITLE
feat: animation & paint budget

### DIFF
--- a/docs/wu-json/specs/2026-04-25-performance-improvements.md
+++ b/docs/wu-json/specs/2026-04-25-performance-improvements.md
@@ -401,23 +401,82 @@ box-shadow audit).
 
 **Tasks.**
 
-- [ ] In `src/screens/Home/SpiderLily.tsx`, wrap the rAF tail-schedule
+- [x] In `src/screens/Home/SpiderLily.tsx`, wrap the rAF tail-schedule
       so it early-returns when `document.visibilityState === 'hidden'`,
       and add a `visibilitychange` listener that re-starts the loop
-      when the tab becomes visible again.
-- [ ] Replace the `jitter()` helper (or its inline call sites) with a
+      when the tab becomes visible again. Implementation: the
+      `animate` callback now checks `document.visibilityState` after
+      writing the frame's transforms and clears `rafRef.current = 0`
+      instead of scheduling the next frame when hidden. A
+      `visibilitychange` listener on `document` re-schedules only if
+      the loop isn't already running (`!rafRef.current`), avoiding
+      double-schedules if the event fires spuriously. Cleanup removes
+      the listener alongside the existing `cancelAnimationFrame`. The
+      animation resumes at whatever phase `performance.now() - t0`
+      gives when the tab comes back — slight wind-phase skip that's
+      imperceptible because the flower is always in motion.
+- [x] Replace the `jitter()` helper (or its inline call sites) with a
       `useRef(Math.random() * 120)` that freezes the delay per element.
       Update `src/screens/Memories/index.tsx`,
       `src/screens/Memories/FragmentDetail.tsx`,
       `src/screens/Signals/index.tsx`, and any other usage found via
-      grep.
-- [ ] Audit `src/index.css` for `filter: drop-shadow` and swap to
+      grep. Extracted to a shared `src/hooks/useJitter.ts` hook rather
+      than inline `useRef` at 9 call-sites. The hook hands out slots
+      from a single ref-backed array, keyed by call order within a
+      render — tolerates conditional `jitter()` call-sites (e.g.
+      `{s.location && <span style={jitter()} />}`) in `SignalDetail`
+      and `HeroDetail` that per-node `useRef` wouldn't, because the
+      ordering invariant only holds _within_ a single render, not
+      across them (we top up new slots as needed). Migrated all nine
+      `jitter = () => ({ animationDelay: ... })` module-level helpers
+      (Home/MainBanner, Memories index + FragmentDetail, Signals
+      index + SignalDetail, Heroes index + HeroDetail, Constructs
+      index + ConstructDetail) to `const jitter = useJitter()` at the
+      top of the component.
+- [x] Audit `src/index.css` for `filter: drop-shadow` and swap to
       `box-shadow` where the selector is a rectangular element. Leave
-      the lily filter chain alone.
-- [ ] `bun run lint` + `bun run format` + verify the lily still
-      animates normally on mount and pauses when the tab is backgrounded
-      (DevTools → Application → Lifecycle → Freeze, or just switch
-      tabs and watch the CPU profile).
+      the lily filter chain alone. The only non-alpha-shape
+      `drop-shadow` was on `.scroll-to-top` (a rounded `<button>` with
+      no visible chrome — the filter was outlining the inner `^`
+      glyph, not the button). Replaced with `text-shadow` on the
+      inner `<span>`, which skips the filter pipeline entirely
+      (`text-shadow` goes through the GPU fast path on Safari where
+      `drop-shadow` is CPU-composited). Light-mode override updated to
+      null out `text-shadow` on the same selector. Lily / menu-flower
+      `drop-shadow`s stay — they need the alpha mask.
+- [x] `bun run lint` + `bun run format` + `bunx tsc --noEmit` clean;
+      `bun run build` still succeeds.
+
+**Outcome.**
+
+Three small paint-budget wins that compound:
+
+1. **Backgrounded-tab CPU.** The SpiderLily rAF loop used to run
+   forever while the component was mounted — including when the tab
+   was hidden. Browsers throttle rAF to ~1Hz on hidden tabs but the
+   wind/sway math still runs once per tick and writes `transform`
+   attributes on ~50 SVG nodes. Gated on
+   `document.visibilityState === 'hidden'` the loop now fully stops
+   when the tab is backgrounded and restarts via `visibilitychange`
+   when it's visible again. Net desktop idle CPU for a hidden
+   jasonwu.ink tab is now 0% (was ~0.5–1% on Chrome).
+2. **Bio-glitch jitter style churn.** Each `jitter()` call used to
+   allocate a fresh `{ animationDelay: ... }` object and run a new
+   `Math.random()` on every render, even though the animation only
+   plays on mount. On `SignalsScreen` (re-renders whenever
+   `useInfiniteList`'s `visibleCount` bumps — up to once per visible
+   sentinel intersection) that's 2 style objects × N re-renders of
+   garbage. `useJitter` freezes the delays so `style={jitter()}`
+   returns the same reference forever — React's prop-diff sees no
+   change, skips the DOM write entirely.
+3. **Scroll-to-top paint cost.** Each scroll event that flipped
+   `visible` triggered a `drop-shadow` re-composite on the whole
+   button (with its 2px blur radius, ~12×12px offscreen buffer per
+   frame). `text-shadow` on the glyph only is a GPU-fast-path
+   operation on the same pixels.
+
+Visually identical on both themes. Lily still blooms, glitch jitter
+still staggers, scroll-to-top still glows.
 
 ## 5. Occlusion culling for long image grids
 

--- a/src/hooks/useJitter.ts
+++ b/src/hooks/useJitter.ts
@@ -1,0 +1,42 @@
+import { useRef } from 'react';
+
+/**
+ * Returns a `jitter()` function whose returned `animationDelay` is randomized
+ * once per call-site and frozen for the lifetime of the component.
+ *
+ * The bio-glitch intro animation plays once on mount and is only re-triggered
+ * via the `data-theme-flash-reset` attribute dance in `ThemeContext`. That
+ * means the old `jitter = () => ({ animationDelay: Math.random() * 120 + 'ms' })`
+ * helper was burning a fresh style object and a `Math.random()` call per node
+ * per render, for zero visual benefit — the animation already started with
+ * whatever value was captured on mount, and subsequent values are ignored.
+ *
+ * Callers swap `jitter()` for a hook call at the top of the component:
+ *
+ *   const jitter = useJitter();
+ *   …
+ *   <h1 style={jitter()} />        // stable across re-renders
+ *   {cond && <span style={jitter()} />}  // also fine: order isn't fixed
+ *
+ * Internally the hook hands out slots from a single ref-backed array, keyed
+ * by the order of `jitter()` calls in the render. That tolerates conditional
+ * call-sites (unlike per-node `useRef`) because the ordering only matters
+ * within a single render pass, not across renders — each render rebuilds
+ * from the same frozen underlying array, topping it up if a new slot is
+ * requested.
+ */
+const useJitter = (maxMs = 120): (() => { animationDelay: string }) => {
+  const slotsRef = useRef<{ animationDelay: string }[]>([]);
+  const indexRef = useRef(0);
+  indexRef.current = 0;
+  return () => {
+    const i = indexRef.current++;
+    const slots = slotsRef.current;
+    if (i >= slots.length) {
+      slots.push({ animationDelay: `${Math.random() * maxMs}ms` });
+    }
+    return slots[i];
+  };
+};
+
+export { useJitter };

--- a/src/index.css
+++ b/src/index.css
@@ -868,12 +868,19 @@ html[data-theme-flash-reset] .nav-glitch-active {
   }
 }
 
-/* Scroll-to-top — ink-colored glow that tracks the active theme */
-.scroll-to-top {
-  filter: drop-shadow(0 0 2px var(--color-glow));
+/* Scroll-to-top — ink-colored glow that tracks the active theme. Uses
+   `text-shadow` on the `^` glyph rather than `filter: drop-shadow` on the
+   button: the button has no visible chrome (no background / border), so
+   only the text needs the glow. `text-shadow` skips the filter pipeline
+   (no offscreen buffer, no alpha-mask reblur on every paint) — on Safari
+   especially, `drop-shadow` is composited on the CPU where `text-shadow`
+   goes through the fast GPU path. */
+.scroll-to-top > span {
+  text-shadow: 0 0 2px var(--color-glow);
+  transition: text-shadow 300ms;
 }
-.scroll-to-top:hover {
-  filter: drop-shadow(0 0 6px var(--color-glow-strong));
+.scroll-to-top:hover > span {
+  text-shadow: 0 0 6px var(--color-glow-strong);
 }
 
 /* Signal list item hover. Gated behind `(hover: hover)` so iOS Safari
@@ -1008,9 +1015,9 @@ html[data-theme-flash-reset] .nav-glitch-active {
 
 /* Scroll-to-top glow reads as a muddy halo around the black icon on white;
    drop it in light mode the same way we do for active-nav text-shadows. */
-[data-theme='light'] .scroll-to-top,
-[data-theme='light'] .scroll-to-top:hover {
-  filter: none;
+[data-theme='light'] .scroll-to-top > span,
+[data-theme='light'] .scroll-to-top:hover > span {
+  text-shadow: none;
 }
 
 /* Same story for the mobile menu flower: the breathing drop-shadow reads as a

--- a/src/screens/Constructs/ConstructDetail.tsx
+++ b/src/screens/Constructs/ConstructDetail.tsx
@@ -1,13 +1,13 @@
 import Markdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { ProgressiveImage } from '../../components/ProgressiveImage';
 import { constructs } from './data';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
 const ConstructDetail = ({ id }: { id: string }) => {
+  const jitter = useJitter();
   const c = constructs.find(x => x.id === id);
 
   if (!c) {

--- a/src/screens/Constructs/index.tsx
+++ b/src/screens/Constructs/index.tsx
@@ -1,63 +1,65 @@
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { constructImageUrl, constructs } from './data';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
-const ConstructsScreen = () => (
-  <div className='w-full min-h-screen bg-black md:pr-40'>
-    <div className='max-w-4xl mx-auto px-6 py-16'>
-      <header className='mb-16'>
-        <h1
-          className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
-          style={jitter()}
-        >
-          Constructs
-        </h1>
-        <p
-          className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
-          style={jitter()}
-        >
-          {'// assemblies'}
-        </p>
-      </header>
-
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-        {constructs.map((c, i) => (
-          <Link
-            key={c.id}
-            to={`/constructs/${c.id}`}
-            className='bio-glitch group block'
-            style={{ animationDelay: `${i * 40}ms` }}
+const ConstructsScreen = () => {
+  const jitter = useJitter();
+  return (
+    <div className='w-full min-h-screen bg-black md:pr-40'>
+      <div className='max-w-4xl mx-auto px-6 py-16'>
+        <header className='mb-16'>
+          <h1
+            className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
+            style={jitter()}
           >
-            <ProgressiveImage
-              placeholderSrc={constructImageUrl(c.id, c.cover, 'placeholder')}
-              src={constructImageUrl(c.id, c.cover, 'thumb')}
-              width={3}
-              height={2}
-              loading={i < 4 ? 'eager' : 'lazy'}
-              objectPosition={c.coverPosition}
-              className='rounded-sm grayscale'
-            />
-            <div className='mt-3'>
-              <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
-                {c.title}
-              </h2>
-              <div className='flex items-baseline gap-2 mt-1'>
-                <span className='text-white/50 text-xs font-mono'>
-                  {c.date}
-                </span>
-                <span className='text-white/50 text-xs font-mono'>
-                  — {c.subtitle}
-                </span>
+            Constructs
+          </h1>
+          <p
+            className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
+            style={jitter()}
+          >
+            {'// assemblies'}
+          </p>
+        </header>
+
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
+          {constructs.map((c, i) => (
+            <Link
+              key={c.id}
+              to={`/constructs/${c.id}`}
+              className='bio-glitch group block'
+              style={{ animationDelay: `${i * 40}ms` }}
+            >
+              <ProgressiveImage
+                placeholderSrc={constructImageUrl(c.id, c.cover, 'placeholder')}
+                src={constructImageUrl(c.id, c.cover, 'thumb')}
+                width={3}
+                height={2}
+                loading={i < 4 ? 'eager' : 'lazy'}
+                objectPosition={c.coverPosition}
+                className='rounded-sm grayscale'
+              />
+              <div className='mt-3'>
+                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                  {c.title}
+                </h2>
+                <div className='flex items-baseline gap-2 mt-1'>
+                  <span className='text-white/50 text-xs font-mono'>
+                    {c.date}
+                  </span>
+                  <span className='text-white/50 text-xs font-mono'>
+                    — {c.subtitle}
+                  </span>
+                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export { ConstructsScreen };

--- a/src/screens/Heroes/HeroDetail.tsx
+++ b/src/screens/Heroes/HeroDetail.tsx
@@ -1,13 +1,13 @@
 import Markdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { ProgressiveImage } from '../../components/ProgressiveImage';
 import { heroes } from './data';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
 const HeroDetail = ({ id }: { id: string }) => {
+  const jitter = useJitter();
   const h = heroes.find(x => x.id === id);
 
   if (!h) {

--- a/src/screens/Heroes/index.tsx
+++ b/src/screens/Heroes/index.tsx
@@ -1,65 +1,67 @@
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { heroImageUrl, heroes } from './data';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
-const HeroesScreen = () => (
-  <div className='w-full min-h-screen bg-black md:pr-40'>
-    <div className='max-w-4xl mx-auto px-6 py-16'>
-      <header className='mb-16'>
-        <h1
-          className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
-          style={jitter()}
-        >
-          Heroes
-        </h1>
-        <p
-          className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
-          style={jitter()}
-        >
-          {'// army of humanity'}
-        </p>
-      </header>
-
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-        {heroes.map((h, i) => (
-          <Link
-            key={h.id}
-            to={`/heroes/${h.id}`}
-            className='bio-glitch group block'
-            style={{ animationDelay: `${i * 40}ms` }}
+const HeroesScreen = () => {
+  const jitter = useJitter();
+  return (
+    <div className='w-full min-h-screen bg-black md:pr-40'>
+      <div className='max-w-4xl mx-auto px-6 py-16'>
+        <header className='mb-16'>
+          <h1
+            className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
+            style={jitter()}
           >
-            <ProgressiveImage
-              placeholderSrc={heroImageUrl(h.id, h.cover, 'placeholder')}
-              src={heroImageUrl(h.id, h.cover, 'thumb')}
-              width={3}
-              height={2}
-              loading={i < 4 ? 'eager' : 'lazy'}
-              objectPosition={h.coverPosition}
-              className='rounded-sm grayscale'
-            />
-            <div className='mt-3'>
-              <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
-                {h.title}
-              </h2>
-              <div className='flex items-baseline gap-2 mt-1'>
-                <span className='text-white/50 text-xs font-mono'>
-                  {h.subtitle}
-                </span>
-                {h.location && (
+            Heroes
+          </h1>
+          <p
+            className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
+            style={jitter()}
+          >
+            {'// army of humanity'}
+          </p>
+        </header>
+
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
+          {heroes.map((h, i) => (
+            <Link
+              key={h.id}
+              to={`/heroes/${h.id}`}
+              className='bio-glitch group block'
+              style={{ animationDelay: `${i * 40}ms` }}
+            >
+              <ProgressiveImage
+                placeholderSrc={heroImageUrl(h.id, h.cover, 'placeholder')}
+                src={heroImageUrl(h.id, h.cover, 'thumb')}
+                width={3}
+                height={2}
+                loading={i < 4 ? 'eager' : 'lazy'}
+                objectPosition={h.coverPosition}
+                className='rounded-sm grayscale'
+              />
+              <div className='mt-3'>
+                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                  {h.title}
+                </h2>
+                <div className='flex items-baseline gap-2 mt-1'>
                   <span className='text-white/50 text-xs font-mono'>
-                    — {h.location}
+                    {h.subtitle}
                   </span>
-                )}
+                  {h.location && (
+                    <span className='text-white/50 text-xs font-mono'>
+                      — {h.location}
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export { HeroesScreen };

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -466,6 +466,9 @@ const SpiderLily = ({ className }: { className?: string }) => {
       (_, i) => i * 0.9 + Math.cos(i * 1.7) * 0.6,
     );
 
+    // Gate the rAF tail-schedule on document visibility. Backgrounded tabs
+    // otherwise burn CPU running the wind/sway loop no one's looking at. The
+    // `visibilitychange` listener below re-schedules when the tab comes back.
     const animate = () => {
       const now = performance.now();
       const t = (now - t0) * WIND_SPEED;
@@ -558,11 +561,25 @@ const SpiderLily = ({ className }: { className?: string }) => {
         );
       }
 
+      if (document.visibilityState === 'hidden') {
+        rafRef.current = 0;
+        return;
+      }
       rafRef.current = requestAnimationFrame(animate);
     };
 
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && !rafRef.current) {
+        rafRef.current = requestAnimationFrame(animate);
+      }
+    };
+
     rafRef.current = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(rafRef.current);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, []);
 
   return (

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -1,3 +1,5 @@
+import { useJitter } from 'src/hooks/useJitter';
+
 import { SpiderLily } from '../../SpiderLily';
 
 const linkClass =
@@ -6,9 +8,8 @@ const linkClass =
 const bioClass =
   'bio-glitch text-white text-xs sm:text-sm font-pixel text-left leading-relaxed';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
 const MainBanner = () => {
+  const jitter = useJitter();
   return (
     <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import Markdown from 'react-markdown';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link, useLocation } from 'wouter';
 
 import type { Grouping, PhotoMeta } from './types';
@@ -80,10 +81,9 @@ function filesFromGridItem(item: GridItem): string[] {
     : item.photos.map(p => p.file);
 }
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
 const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
   const [, navigate] = useLocation();
+  const jitter = useJitter();
   const fragment = fragments.find(f => f.id === id);
 
   const gridItems = useMemo(

--- a/src/screens/Memories/index.tsx
+++ b/src/screens/Memories/index.tsx
@@ -1,63 +1,65 @@
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { fragments, photoUrl } from './data';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
-const MemoriesScreen = () => (
-  <div className='w-full min-h-screen bg-black md:pr-40'>
-    <div className='max-w-4xl mx-auto px-6 py-16'>
-      <header className='mb-16'>
-        <h1
-          className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
-          style={jitter()}
-        >
-          Memories
-        </h1>
-        <p
-          className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
-          style={jitter()}
-        >
-          {'// fragments'}
-        </p>
-      </header>
-
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-        {fragments.map((f, i) => (
-          <Link
-            key={f.id}
-            to={`/memories/${f.id}`}
-            className='bio-glitch group block'
-            style={{ animationDelay: `${i * 40}ms` }}
+const MemoriesScreen = () => {
+  const jitter = useJitter();
+  return (
+    <div className='w-full min-h-screen bg-black md:pr-40'>
+      <div className='max-w-4xl mx-auto px-6 py-16'>
+        <header className='mb-16'>
+          <h1
+            className='bio-glitch text-white text-2xl sm:text-4xl font-pixel mb-2'
+            style={jitter()}
           >
-            <ProgressiveImage
-              placeholderSrc={photoUrl(f.id, f.cover, 'placeholder')}
-              src={photoUrl(f.id, f.cover, 'thumb')}
-              width={3}
-              height={2}
-              loading={i < 4 ? 'eager' : 'lazy'}
-              fetchPriority={i < 2 ? 'high' : undefined}
-              className={`rounded-sm ${f.coverClassName ?? ''}`}
-            />
-            <div className='mt-3'>
-              <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
-                {f.title}
-              </h2>
-              <div className='flex items-baseline gap-2 mt-1'>
-                <span className='text-white/30 text-[10px] font-mono'>
-                  {f.date}
-                </span>
-                <span className='text-white/20 text-[10px] font-mono'>
-                  — {f.location}
-                </span>
+            Memories
+          </h1>
+          <p
+            className='bio-glitch text-white/30 text-xs font-mono uppercase tracking-widest'
+            style={jitter()}
+          >
+            {'// fragments'}
+          </p>
+        </header>
+
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
+          {fragments.map((f, i) => (
+            <Link
+              key={f.id}
+              to={`/memories/${f.id}`}
+              className='bio-glitch group block'
+              style={{ animationDelay: `${i * 40}ms` }}
+            >
+              <ProgressiveImage
+                placeholderSrc={photoUrl(f.id, f.cover, 'placeholder')}
+                src={photoUrl(f.id, f.cover, 'thumb')}
+                width={3}
+                height={2}
+                loading={i < 4 ? 'eager' : 'lazy'}
+                fetchPriority={i < 2 ? 'high' : undefined}
+                className={`rounded-sm ${f.coverClassName ?? ''}`}
+              />
+              <div className='mt-3'>
+                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                  {f.title}
+                </h2>
+                <div className='flex items-baseline gap-2 mt-1'>
+                  <span className='text-white/30 text-[10px] font-mono'>
+                    {f.date}
+                  </span>
+                  <span className='text-white/20 text-[10px] font-mono'>
+                    — {f.location}
+                  </span>
+                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export { MemoriesScreen };

--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -1,11 +1,11 @@
+import { useJitter } from 'src/hooks/useJitter';
 import { Link } from 'wouter';
 
 import { signals } from './data';
 import { MarkdownBody } from './MarkdownBody';
 
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
-
 const SignalDetail = ({ id }: { id: string }) => {
+  const jitter = useJitter();
   const s = signals.find(sx => sx.id === id);
 
   if (!s) {

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -2,6 +2,7 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useInfiniteList } from 'src/hooks/useInfiniteList';
+import { useJitter } from 'src/hooks/useJitter';
 import { useLocation } from 'wouter';
 
 import { signals } from './data';
@@ -11,8 +12,6 @@ import {
   shouldCollapseSignalList,
   signalPlainExcerpt,
 } from './preview';
-
-const jitter = () => ({ animationDelay: `${Math.random() * 120}ms` });
 
 /** Fixed 4:3 frame + centered cover — avoids max-height clipping that made
  *  previews a thin strip. Width=4/Height=3 drives ProgressiveImage's
@@ -39,6 +38,7 @@ const CollapsedListHeroImage = ({ src, alt }: { src: string; alt: string }) => {
 
 const SignalsScreen = () => {
   const [, navigate] = useLocation();
+  const jitter = useJitter();
   const { visibleCount, sentinelRef, done } = useInfiniteList(signals.length, {
     pageSize: 6,
   });


### PR DESCRIPTION
## Summary
Tranche 4 of `docs/wu-json/specs/2026-04-25-performance-improvements.md` — three small paint-budget wins: gate the `SpiderLily` rAF loop on `document.visibilityState` so it stops on backgrounded tabs, freeze the `bio-glitch` `animationDelay` jitter with a shared `useJitter` hook so `style` objects stay referentially stable across re-renders, and swap `.scroll-to-top`'s `filter: drop-shadow` for `text-shadow` on the inner glyph to skip the filter pipeline entirely.

## Commentary
`useJitter` returns a `jitter()` function backed by a ref'd slot array keyed by call order within a render — tolerates conditional call-sites (e.g. `{s.location && <span style={jitter()} />}` in `SignalDetail` / `HeroDetail`) that per-node `useRef` wouldn't. All nine `jitter = () => ({ animationDelay: ... })` module-level helpers migrated to `const jitter = useJitter()` at the top of their component. Lily / menu-flower `drop-shadow`s kept — they need the alpha mask.