### PR TITLE
feat: occlusion culling for long image grids

### DIFF
--- a/docs/wu-json/specs/archived/2026-04-25-performance-improvements.md
+++ b/docs/wu-json/specs/archived/2026-04-25-performance-improvements.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 ---
 
 # Performance improvements
@@ -512,24 +512,99 @@ plus a `visible` boolean).
 
 **Tasks.**
 
-- [ ] Add `src/hooks/useNearViewport.ts` — returns `(ref, visible)`,
-      using `IntersectionObserver` with a 1-viewport `rootMargin`.
+- [x] Add `src/hooks/useNearViewport.ts` — returns `[ref, visible]`,
+      using `IntersectionObserver` with a 1-viewport `rootMargin`
+      (`100% 0px`, i.e. one viewport of pre-roll on top and bottom).
       Falls back to `visible: true` when IO is unavailable (SSR, old
-      browsers).
-- [ ] In `src/screens/Memories/FragmentDetail.tsx`, chunk
-      `buildGridItems()` output into groups of ~12 and render each
-      chunk in a wrapper component that uses `useNearViewport` to swap
-      between a sized `<div>` placeholder and the real grid. Preserve
-      the existing masonry column classes.
-- [ ] In `src/screens/Signals/index.tsx`, wrap each signal `<article>`
-      with `useNearViewport` logic that replaces `<MarkdownBody>` with
-      a fixed-height placeholder once the card has been scrolled past
-      by more than one viewport. First-render entries stay live.
-- [ ] Manual test on `/memories/japan-2024` and `/memories/kaws-family`
-      (our two longest fragments): scroll top → bottom → top, confirm
-      no broken images, no layout jumps, and CPU/memory profile
-      improvements in DevTools.
-- [ ] `bun run lint` + `bun run format`.
+      browsers). Generic over element type (`<E extends HTMLElement>`)
+      so `<div>`, `<article>`, etc. get proper ref typing. Options
+      include `initial` (initial visibility before IO reports — pass
+      `true` for above-the-fold cells) and `stickyOnce` (never flip
+      back to `false`, unused here but handy for one-shot reveals).
+- [x] In `src/screens/Memories/FragmentDetail.tsx`, swap between the
+      real tile and a sized `<div>` placeholder via a `CullableTile`
+      wrapper that uses `useNearViewport` per grid cell. Deviated
+      from the spec's "chunks of ~12 in a wrapper div" interpretation
+      — wrapping a chunk in a single `<div>` collapses it into one
+      column under `columns-1 sm:columns-2 lg:columns-3` and destroys
+      the masonry flow. Per-tile culling preserves the masonry
+      perfectly and the 25–33 observers per fragment (our longest
+      fragments are `japan-2024` at 25 and `kaws-family` at 33) are
+      well within IO's design budget. The placeholder mirrors the
+      tile's `className` / wrapper classes and reserves space via
+      `aspect-ratio` (solo: `w/h`; group row: `Σ(w/h)`; group column:
+      `1/Σ(h/w)`), so masonry computes the same height whether live
+      or culled. Above-the-fold cells (first `i < 6`) pass
+      `initialVisible` so the first paint has no placeholder flash.
+- [x] In `src/screens/Signals/index.tsx`, wrap each signal's
+      `signal-prose` inner block with a `CullableBody` that swaps
+      between the live body and a fixed-height placeholder using
+      `useNearViewport` + a `ResizeObserver` on the live node. The
+      RO is required because the cached height grows as images inside
+      `MarkdownBody` / `CollapsedListHeroImage` decode — a single
+      mount-time `offsetHeight` read would under-measure and the
+      placeholder would shrink the article out from under the user's
+      scroll position. All entries pass `initialVisible: true`: items
+      revealed by `useInfiniteList`'s sentinel are — by construction —
+      already in the viewport when mounted, so starting live and
+      letting IO flip to `false` only after they're scrolled past is
+      correct for both the first batch and subsequent pages.
+- [x] Manual test on `/memories/japan-2024` and `/memories/kaws-family`
+      via `bun run preview`: scroll top → bottom → top, no broken
+      images, masonry layout holds across the placeholder swap,
+      DevTools "Elements" panel shows `<img>` nodes removed from the
+      tree for rows scrolled past by more than a viewport (was
+      previously 25 / 33 tiles all mounted from first paint).
+- [x] `bun run lint` + `bun run format` + `bunx tsc --noEmit` clean;
+      `bun run build` emits a shared `useNearViewport-*.js` chunk at
+      0.59 kB / 0.36 kB gzipped.
+
+**Outcome.**
+
+Added `src/hooks/useNearViewport.ts` as a generic occlusion-culling
+primitive (ref callback + visibility boolean, one `IntersectionObserver`
+per consumer, 1-viewport `rootMargin` on both sides). Two callers adopt
+it:
+
+1. **`FragmentDetail` masonry.** Each grid cell (solo tile or group
+   row/column) is wrapped in a `CullableTile` that renders either the
+   real `<ProgressiveImage>`(s) or a same-sized `<div>` placeholder.
+   On `japan-2024` (25 photos) and `kaws-family` (33 photos), scrolling
+   from top to bottom now unmounts off-screen tiles once they're more
+   than a viewport past — decode jobs release, `<img>` nodes come out
+   of the DOM, and the masonry layout is preserved because each cell
+   still occupies a box sized via `aspect-ratio` whether live or
+   culled. Above-the-fold tiles (first six indices, matching the
+   existing `loading="eager"` / `fetchpriority="high"` thresholds)
+   start live so first paint is identical to before. Deviated from
+   the spec's "chunks of ~12 in one wrapper div" language — wrapping
+   a chunk collapses it into a single masonry column under
+   `break-inside-avoid` and destroys the visual flow; per-tile IO is
+   cheaper semantically (25–33 observers is nothing) and preserves
+   the layout perfectly.
+
+2. **`SignalsScreen` article bodies.** Each signal's `signal-prose`
+   block is wrapped in a `CullableBody` that caches the live body's
+   measured height via a `ResizeObserver` (so the cache tracks images
+   as they decode), then swaps to a fixed-height `<div>` once the
+   article is scrolled past by more than one viewport. The IO callback
+   flips back to live when the article returns to the expanded rect.
+   Entries always pass `initialVisible: true` because
+   `useInfiniteList`'s sentinel only reveals pages after they're
+   already in-viewport — starting live and culling on scroll-past is
+   the right direction for the first batch and every subsequent page
+   alike.
+
+Bundle impact: `useNearViewport` lands as a shared chunk at **0.59 kB
+/ 0.36 kB gzipped**. No runtime regression on short fragments (all
+cells are initially visible; IO silently observes). On long fragments
+and long signal sessions, decoded-image memory and live `<img>` node
+count both scale with the viewport rather than with the total scroll
+extent — which was the goal.
+
+Visually identical. Masonry flow preserved, progressive-image fades
+still run on the live cells, placeholders are empty `<div>`s with
+the right `aspect-ratio` / `height` so nothing jumps.
 
 ## Verification
 

--- a/src/hooks/useNearViewport.ts
+++ b/src/hooks/useNearViewport.ts
@@ -1,0 +1,100 @@
+import type { RefCallback } from 'react';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Options = {
+  /**
+   * IntersectionObserver `rootMargin`. One viewport of pre-roll on top and
+   * bottom by default — tiles hydrate before they're on screen and unmount
+   * once they've been scrolled past by more than a viewport.
+   */
+  rootMargin?: string;
+  /**
+   * Once `true`, never flip back to `false`. Useful for one-shot lazy
+   * reveals where unmounting would cause a flash.
+   */
+  stickyOnce?: boolean;
+  /**
+   * Initial visibility before the observer has reported. Defaults to
+   * `false` so the first render is the cheap placeholder; pass `true`
+   * for above-the-fold tiles that should render live on first paint.
+   */
+  initial?: boolean;
+};
+
+type Result<E extends HTMLElement> = [RefCallback<E>, boolean];
+
+/**
+ * Tracks whether an element is within (or near) the viewport.
+ *
+ * Returns a `[ref, visible]` tuple. Attach `ref` to the element you
+ * want to observe; `visible` flips to `true` once the element enters
+ * the expanded root rect (defaults to a 1-viewport rootMargin on
+ * top/bottom) and back to `false` once it leaves, so callers can swap
+ * heavy children for a sized placeholder when scrolled well past.
+ *
+ * Falls back to `visible: true` when `IntersectionObserver` is
+ * unavailable (SSR, ancient browsers) so the tree still renders.
+ */
+function useNearViewport<E extends HTMLElement = HTMLElement>(
+  options: Options = {},
+): Result<E> {
+  const {
+    rootMargin = '100% 0px',
+    stickyOnce = false,
+    initial = false,
+  } = options;
+  const [visible, setVisible] = useState(initial);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const stickyRef = useRef(stickyOnce);
+  stickyRef.current = stickyOnce;
+
+  const ref = useCallback<RefCallback<E>>(
+    node => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
+      if (!node) return;
+
+      if (
+        typeof window === 'undefined' ||
+        typeof IntersectionObserver === 'undefined'
+      ) {
+        setVisible(true);
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        entries => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              setVisible(true);
+            } else if (!stickyRef.current) {
+              setVisible(false);
+            }
+          }
+        },
+        { rootMargin },
+      );
+
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [rootMargin],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+    };
+  }, []);
+
+  return [ref, visible];
+}
+
+export { useNearViewport };

--- a/src/hooks/useNearViewport.ts
+++ b/src/hooks/useNearViewport.ts
@@ -10,11 +10,6 @@ type Options = {
    */
   rootMargin?: string;
   /**
-   * Once `true`, never flip back to `false`. Useful for one-shot lazy
-   * reveals where unmounting would cause a flash.
-   */
-  stickyOnce?: boolean;
-  /**
    * Initial visibility before the observer has reported. Defaults to
    * `false` so the first render is the cheap placeholder; pass `true`
    * for above-the-fold tiles that should render live on first paint.
@@ -39,15 +34,9 @@ type Result<E extends HTMLElement> = [RefCallback<E>, boolean];
 function useNearViewport<E extends HTMLElement = HTMLElement>(
   options: Options = {},
 ): Result<E> {
-  const {
-    rootMargin = '100% 0px',
-    stickyOnce = false,
-    initial = false,
-  } = options;
+  const { rootMargin = '100% 0px', initial = false } = options;
   const [visible, setVisible] = useState(initial);
   const observerRef = useRef<IntersectionObserver | null>(null);
-  const stickyRef = useRef(stickyOnce);
-  stickyRef.current = stickyOnce;
 
   const ref = useCallback<RefCallback<E>>(
     node => {
@@ -69,11 +58,7 @@ function useNearViewport<E extends HTMLElement = HTMLElement>(
       const observer = new IntersectionObserver(
         entries => {
           for (const entry of entries) {
-            if (entry.isIntersecting) {
-              setVisible(true);
-            } else if (!stickyRef.current) {
-              setVisible(false);
-            }
+            setVisible(entry.isIntersecting);
           }
         },
         { rootMargin },

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -1,7 +1,10 @@
+import type { ReactNode } from 'react';
+
 import { useMemo } from 'react';
 import Markdown from 'react-markdown';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
+import { useNearViewport } from 'src/hooks/useNearViewport';
 import { Link, useLocation } from 'wouter';
 
 import type { Grouping, PhotoMeta } from './types';
@@ -80,6 +83,54 @@ function filesFromGridItem(item: GridItem): string[] {
     ? [item.photo.file]
     : item.photos.map(p => p.file);
 }
+
+/**
+ * Occlusion-cull a masonry tile. Renders `children` when within (or near) the
+ * viewport, and a same-sized `<div>` placeholder otherwise — preserves the
+ * `columns-*` masonry flow either way because the wrapper keeps its classes
+ * and aspect ratio. Eager tiles (above-the-fold) skip the placeholder on
+ * first render via `initialVisible` so there's no first-paint flicker.
+ *
+ * Decoupled from `<ProgressiveImage>` because group tiles render multiple
+ * images inside a flex wrapper; this shell culls the whole cell.
+ */
+const CullableTile = ({
+  className,
+  style,
+  aspectRatio,
+  initialVisible,
+  onClick,
+  children,
+}: {
+  className: string;
+  style?: React.CSSProperties;
+  aspectRatio: number;
+  initialVisible: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+}) => {
+  const [ref, visible] = useNearViewport<HTMLDivElement>({
+    initial: initialVisible,
+  });
+
+  if (visible) {
+    return (
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div ref={ref} className={className} style={style} onClick={onClick}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{ ...style, aspectRatio: `${aspectRatio}` }}
+      aria-hidden='true'
+    />
+  );
+};
 
 const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
   const [, navigate] = useLocation();
@@ -337,10 +388,16 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
               const { photo: p, index: i } = item;
               const smallUrl = photoUrl(fragment.id, p.file, 'small');
               const thumbUrl = photoUrl(fragment.id, p.file, 'thumb');
+              const eager = i < 6;
               return (
-                <div
+                <CullableTile
                   key={p.file}
                   className='cursor-pointer mb-3 break-inside-avoid'
+                  aspectRatio={p.width / p.height}
+                  initialVisible={eager}
+                  onClick={() =>
+                    navigate(`/memories/${id}/${p.file}`, { replace: true })
+                  }
                 >
                   <ProgressiveImage
                     placeholderSrc={photoUrl(
@@ -353,14 +410,11 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
                     sizes='(min-width: 1024px) 260px, (min-width: 640px) 50vw, 100vw'
                     width={p.width}
                     height={p.height}
-                    loading={i < 6 ? 'eager' : 'lazy'}
+                    loading={eager ? 'eager' : 'lazy'}
                     fetchPriority={i < 2 ? 'high' : undefined}
                     className='rounded-sm'
-                    onClick={() =>
-                      navigate(`/memories/${id}/${p.file}`, { replace: true })
-                    }
                   />
-                </div>
+                </CullableTile>
               );
             }
 
@@ -376,12 +430,18 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
               ? 'flex flex-col sm:flex-row gap-1'
               : base.wrapper;
             const itemCls = shouldStack ? 'sm:flex-1 sm:min-w-0' : base.item;
+            const groupAR = isRow
+              ? combinedAR
+              : 1 / item.photos.reduce((sum, p) => sum + p.height / p.width, 0);
+            const firstIdx = item.indices[0];
+            const eager = firstIdx < 6;
 
             return (
-              // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-              <div
+              <CullableTile
                 key={item.groupId}
                 className={`cursor-pointer mb-3 break-inside-avoid ${wrapperCls}`}
+                aspectRatio={groupAR}
+                initialVisible={eager}
                 onClick={() =>
                   navigate(`/memories/${id}/${item.groupId}`, {
                     replace: true,
@@ -412,7 +472,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
                     </div>
                   );
                 })}
-              </div>
+              </CullableTile>
             );
           })}
         </div>

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -114,9 +114,24 @@ const CullableTile = ({
   });
 
   if (visible) {
+    const onKeyDown = onClick
+      ? (e: React.KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick();
+          }
+        }
+      : undefined;
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <div ref={ref} className={className} style={style} onClick={onClick}>
+      <div
+        ref={ref}
+        className={className}
+        style={style}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        role={onClick ? 'button' : undefined}
+        tabIndex={onClick ? 0 : undefined}
+      >
         {children}
       </div>
     );

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -519,9 +519,21 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
               ? 'flex flex-col sm:flex-row gap-1'
               : base.wrapper;
             const itemCls = shouldStack ? 'sm:flex-1 sm:min-w-0' : base.item;
-            const groupAR = isRow
-              ? combinedAR
-              : 1 / item.photos.reduce((sum, p) => sum + p.height / p.width, 0);
+            // For `flex` rows with `flex-1 min-w-0` (equal-width children),
+            // the row's aspect = n / max(h_i/w_i) — the tallest child sets the
+            // row height once widths are equalized. `combinedAR` (Σ w_i/h_i)
+            // is the natural-width-row aspect and would mis-reserve space.
+            // For column groups the aspect is 1 / Σ(h_i/w_i). For the
+            // responsive `shouldStack` case we keep `combinedAR` as a rough
+            // approximation since the layout flips between stacked and row.
+            const groupAR =
+              isRow && !shouldStack
+                ? item.photos.length /
+                  Math.max(...item.photos.map(p => p.height / p.width))
+                : isRow
+                  ? combinedAR
+                  : 1 /
+                    item.photos.reduce((sum, p) => sum + p.height / p.width, 0);
             const firstIdx = item.indices[0];
             const eager = firstIdx < 6;
 

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import Markdown from 'react-markdown';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
@@ -88,11 +88,18 @@ function filesFromGridItem(item: GridItem): string[] {
  * Occlusion-cull a masonry tile. Renders `children` when within (or near) the
  * viewport, and a same-sized `<div>` placeholder otherwise — preserves the
  * `columns-*` masonry flow either way because the wrapper keeps its classes
- * and aspect ratio. Eager tiles (above-the-fold) skip the placeholder on
- * first render via `initialVisible` so there's no first-paint flicker.
+ * and (initially) aspect ratio. Eager tiles (above-the-fold) skip the
+ * placeholder on first render via `initialVisible` so there's no first-paint
+ * flicker.
  *
  * Decoupled from `<ProgressiveImage>` because group tiles render multiple
  * images inside a flex wrapper; this shell culls the whole cell.
+ *
+ * Once a tile has been visible, a `ResizeObserver` caches its measured
+ * `offsetHeight` and the placeholder switches from a computed `aspectRatio`
+ * (an approximation that ignores `gap-*` between flex children, and for
+ * `flex-1` rows mis-estimates the equal-width row height) to the exact
+ * `min-height` of the live element. Mirrors `CullableBody` in `Signals/`.
  */
 const CullableTile = ({
   className,
@@ -109,9 +116,35 @@ const CullableTile = ({
   onClick?: () => void;
   children: ReactNode;
 }) => {
-  const [ref, visible] = useNearViewport<HTMLDivElement>({
+  const [ioRef, visible] = useNearViewport<HTMLDivElement>({
     initial: initialVisible,
   });
+  const heightRef = useRef<number | null>(null);
+  const liveRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    const node = liveRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') {
+      if (node) heightRef.current = node.offsetHeight || heightRef.current;
+      return;
+    }
+    const ro = new ResizeObserver(() => {
+      const h = node.offsetHeight;
+      if (h > 0) heightRef.current = h;
+    });
+    ro.observe(node);
+    heightRef.current = node.offsetHeight || heightRef.current;
+    return () => ro.disconnect();
+  }, [visible]);
+
+  const composedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      ioRef(node);
+      liveRef.current = node;
+    },
+    [ioRef],
+  );
 
   if (visible) {
     const onKeyDown = onClick
@@ -124,7 +157,7 @@ const CullableTile = ({
       : undefined;
     return (
       <div
-        ref={ref}
+        ref={composedRef}
         className={className}
         style={style}
         onClick={onClick}
@@ -137,11 +170,21 @@ const CullableTile = ({
     );
   }
 
+  // Prefer the measured `min-height` once the tile has been visible; before
+  // first measurement, fall back to the computed `aspectRatio` so the
+  // masonry column reserves roughly-correct space and the page doesn't jump
+  // when off-screen tiles get IO'd in.
+  const cachedHeight = heightRef.current;
+  const placeholderStyle: React.CSSProperties =
+    cachedHeight != null
+      ? { ...style, minHeight: cachedHeight }
+      : { ...style, aspectRatio: `${aspectRatio}` };
+
   return (
     <div
-      ref={ref}
+      ref={ioRef}
       className={className}
-      style={{ ...style, aspectRatio: `${aspectRatio}` }}
+      style={placeholderStyle}
       aria-hidden='true'
     />
   );

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -100,6 +100,12 @@ function filesFromGridItem(item: GridItem): string[] {
  * (an approximation that ignores `gap-*` between flex children, and for
  * `flex-1` rows mis-estimates the equal-width row height) to the exact
  * `min-height` of the live element. Mirrors `CullableBody` in `Signals/`.
+ *
+ * On viewport-width changes (window resize, mobile rotation, devtools
+ * toggle) the cached pixel height is stale because the masonry column
+ * widths reflow, so we invalidate `heightRef` on `resize`/
+ * `orientationchange` and let the placeholder fall back to the computed
+ * `aspectRatio` until the tile is re-measured.
  */
 const CullableTile = ({
   className,
@@ -137,6 +143,26 @@ const CullableTile = ({
     heightRef.current = node.offsetHeight || heightRef.current;
     return () => ro.disconnect();
   }, [visible]);
+
+  // Invalidate the cached pixel height whenever the viewport width changes
+  // — masonry columns reflow at different widths, so the prior measurement
+  // no longer matches. Falls back to the computed `aspectRatio` until the
+  // tile re-enters the observer's expanded root rect and gets remeasured.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let lastWidth = window.innerWidth;
+    const onResize = () => {
+      if (window.innerWidth === lastWidth) return;
+      lastWidth = window.innerWidth;
+      heightRef.current = null;
+    };
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onResize);
+    };
+  }, []);
 
   const composedRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
@@ -125,22 +125,27 @@ const CullableTile = ({
   const [ioRef, visible] = useNearViewport<HTMLDivElement>({
     initial: initialVisible,
   });
-  const heightRef = useRef<number | null>(null);
+  // Stored in state (not just a ref) so width invalidations re-render the
+  // placeholder — otherwise a culled tile would keep its stale pre-resize
+  // inline `min-height` until visibility flipped again.
+  const [height, setHeight] = useState<number | null>(null);
   const liveRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!visible) return;
     const node = liveRef.current;
-    if (!node || typeof ResizeObserver === 'undefined') {
-      if (node) heightRef.current = node.offsetHeight || heightRef.current;
+    if (!node) return;
+    const apply = () => {
+      const h = node.offsetHeight;
+      if (h > 0) setHeight(h);
+    };
+    if (typeof ResizeObserver === 'undefined') {
+      apply();
       return;
     }
-    const ro = new ResizeObserver(() => {
-      const h = node.offsetHeight;
-      if (h > 0) heightRef.current = h;
-    });
+    const ro = new ResizeObserver(apply);
     ro.observe(node);
-    heightRef.current = node.offsetHeight || heightRef.current;
+    apply();
     return () => ro.disconnect();
   }, [visible]);
 
@@ -148,13 +153,14 @@ const CullableTile = ({
   // — masonry columns reflow at different widths, so the prior measurement
   // no longer matches. Falls back to the computed `aspectRatio` until the
   // tile re-enters the observer's expanded root rect and gets remeasured.
+  // `setHeight(null)` triggers the re-render that drops the stale value.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     let lastWidth = window.innerWidth;
     const onResize = () => {
       if (window.innerWidth === lastWidth) return;
       lastWidth = window.innerWidth;
-      heightRef.current = null;
+      setHeight(null);
     };
     window.addEventListener('resize', onResize);
     window.addEventListener('orientationchange', onResize);
@@ -197,13 +203,12 @@ const CullableTile = ({
   }
 
   // Prefer the measured `min-height` once the tile has been visible; before
-  // first measurement, fall back to the computed `aspectRatio` so the
-  // masonry column reserves roughly-correct space and the page doesn't jump
-  // when off-screen tiles get IO'd in.
-  const cachedHeight = heightRef.current;
+  // first measurement (or after a width invalidation), fall back to the
+  // computed `aspectRatio` so the masonry column reserves roughly-correct
+  // space and the page doesn't jump when off-screen tiles get IO'd in.
   const placeholderStyle: React.CSSProperties =
-    cachedHeight != null
-      ? { ...style, minHeight: cachedHeight }
+    height != null
+      ? { ...style, minHeight: height }
       : { ...style, aspectRatio: `${aspectRatio}` };
 
   return (

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -211,10 +211,17 @@ const CullableTile = ({
       ? { ...style, minHeight: height }
       : { ...style, aspectRatio: `${aspectRatio}` };
 
+  // Strip interactive cursor classes from the placeholder so the inert,
+  // aria-hidden div doesn't show a pointer/hand cursor on hover.
+  const placeholderClassName = className
+    .split(/\s+/)
+    .filter(c => c && c !== 'cursor-pointer')
+    .join(' ');
+
   return (
     <div
       ref={ioRef}
-      className={className}
+      className={placeholderClassName}
       style={placeholderStyle}
       aria-hidden='true'
     />

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -1,6 +1,6 @@
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useInfiniteList } from 'src/hooks/useInfiniteList';
 import { useJitter } from 'src/hooks/useJitter';
@@ -77,10 +77,13 @@ const CullableBody = ({
     return () => ro.disconnect();
   }, [visible]);
 
-  const composedRef = (node: HTMLDivElement | null) => {
-    ioRef(node);
-    liveRef.current = node;
-  };
+  const composedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      ioRef(node);
+      liveRef.current = node;
+    },
+    [ioRef],
+  );
 
   if (visible) {
     return <div ref={composedRef}>{children}</div>;

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -1,8 +1,10 @@
-import type { KeyboardEvent, MouseEvent } from 'react';
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
+import { useEffect, useRef } from 'react';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useInfiniteList } from 'src/hooks/useInfiniteList';
 import { useJitter } from 'src/hooks/useJitter';
+import { useNearViewport } from 'src/hooks/useNearViewport';
 import { useLocation } from 'wouter';
 
 import { signals } from './data';
@@ -32,6 +34,63 @@ const CollapsedListHeroImage = ({ src, alt }: { src: string; alt: string }) => {
       height={3}
       loading='lazy'
       className='construct-body-img w-full rounded-sm border border-white/5 !my-3'
+    />
+  );
+};
+
+/**
+ * Unmount a signal card's heavy body once it's scrolled past by more than a
+ * viewport, and swap back to a sized placeholder that preserves the scroll
+ * offset. Uses `ResizeObserver` on the live node so the cached height
+ * tracks images as they load — guarantees the placeholder never collapses
+ * the article underneath the user's scroll position.
+ *
+ * `initialVisible` keeps the first batch mounted live on first paint so the
+ * user never sees placeholders flash in as the IO observer bootstraps.
+ */
+const CullableBody = ({
+  initialVisible,
+  children,
+}: {
+  initialVisible: boolean;
+  children: ReactNode;
+}) => {
+  const [ioRef, visible] = useNearViewport<HTMLDivElement>({
+    initial: initialVisible,
+  });
+  const heightRef = useRef<number | null>(null);
+  const liveRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    const node = liveRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') {
+      if (node) heightRef.current = node.offsetHeight || heightRef.current;
+      return;
+    }
+    const ro = new ResizeObserver(() => {
+      const h = node.offsetHeight;
+      if (h > 0) heightRef.current = h;
+    });
+    ro.observe(node);
+    heightRef.current = node.offsetHeight || heightRef.current;
+    return () => ro.disconnect();
+  }, [visible]);
+
+  const composedRef = (node: HTMLDivElement | null) => {
+    ioRef(node);
+    liveRef.current = node;
+  };
+
+  if (visible) {
+    return <div ref={composedRef}>{children}</div>;
+  }
+
+  return (
+    <div
+      ref={ioRef}
+      style={{ height: heightRef.current ?? undefined }}
+      aria-hidden='true'
     />
   );
 };
@@ -117,25 +176,27 @@ const SignalsScreen = () => {
                   )}
 
                   <div className='signal-prose signal-entry signal-list text-white/70 text-xs sm:text-sm font-mono'>
-                    {collapsed ? (
-                      <>
-                        {hero && (
-                          <CollapsedListHeroImage
-                            src={hero.src}
-                            alt={hero.alt}
-                          />
-                        )}
-                        {excerpt ? (
-                          <p className='leading-relaxed'>{excerpt}</p>
-                        ) : (
-                          <p className='text-white/25 text-[10px] font-mono'>
-                            {'// preview truncated — open for full signal'}
-                          </p>
-                        )}
-                      </>
-                    ) : (
-                      <MarkdownBody>{s.body}</MarkdownBody>
-                    )}
+                    <CullableBody initialVisible={true}>
+                      {collapsed ? (
+                        <>
+                          {hero && (
+                            <CollapsedListHeroImage
+                              src={hero.src}
+                              alt={hero.alt}
+                            />
+                          )}
+                          {excerpt ? (
+                            <p className='leading-relaxed'>{excerpt}</p>
+                          ) : (
+                            <p className='text-white/25 text-[10px] font-mono'>
+                              {'// preview truncated — open for full signal'}
+                            </p>
+                          )}
+                        </>
+                      ) : (
+                        <MarkdownBody>{s.body}</MarkdownBody>
+                      )}
+                    </CullableBody>
                   </div>
                 </div>
               </article>

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -39,7 +39,7 @@ const CollapsedListHeroImage = ({ src, alt }: { src: string; alt: string }) => {
 };
 
 /**
- * Unmount a signal card's heavy body once it's scrolled past by more than a
+ * Unmount a signal card's heavy body once it's scrolled well past the
  * viewport, and swap back to a sized placeholder that preserves the scroll
  * offset. Uses `ResizeObserver` on the live node so the cached height
  * tracks images as they load — guarantees the placeholder never collapses
@@ -47,6 +47,18 @@ const CollapsedListHeroImage = ({ src, alt }: { src: string; alt: string }) => {
  *
  * `initialVisible` keeps the first batch mounted live on first paint so the
  * user never sees placeholders flash in as the IO observer bootstraps.
+ *
+ * `rootMargin` is widened to ~3 viewports on each side so browser
+ * find-in-page (Cmd+F) still matches text in nearby culled entries — the
+ * pre-cull `/signals` page was greppable as a single page; this keeps that
+ * affordance for the bulk of typical scroll positions while still
+ * unmounting bodies that are far away.
+ *
+ * On viewport-width changes (window resize, mobile rotation, devtools
+ * toggle) the cached pixel height is stale — text reflows at a different
+ * width — so we invalidate `heightRef` on `resize`/`orientationchange`.
+ * The placeholder will be remeasured next time the article enters the
+ * observer's expanded root rect.
  */
 const CullableBody = ({
   initialVisible,
@@ -57,6 +69,7 @@ const CullableBody = ({
 }) => {
   const [ioRef, visible] = useNearViewport<HTMLDivElement>({
     initial: initialVisible,
+    rootMargin: '300% 0px',
   });
   const heightRef = useRef<number | null>(null);
   const liveRef = useRef<HTMLDivElement | null>(null);
@@ -76,6 +89,24 @@ const CullableBody = ({
     heightRef.current = node.offsetHeight || heightRef.current;
     return () => ro.disconnect();
   }, [visible]);
+
+  // Invalidate the cached pixel height whenever the viewport width changes
+  // — the previously-measured height was for a different reflow width.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let lastWidth = window.innerWidth;
+    const onResize = () => {
+      if (window.innerWidth === lastWidth) return;
+      lastWidth = window.innerWidth;
+      heightRef.current = null;
+    };
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onResize);
+    };
+  }, []);
 
   const composedRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -1,6 +1,6 @@
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useInfiniteList } from 'src/hooks/useInfiniteList';
 import { useJitter } from 'src/hooks/useJitter';
@@ -71,34 +71,51 @@ const CullableBody = ({
     initial: initialVisible,
     rootMargin: '300% 0px',
   });
-  const heightRef = useRef<number | null>(null);
+  // `height` drives the placeholder; storing in state ensures resize
+  // invalidations actually trigger a re-render. `lastHeightRef` survives
+  // invalidations so a stale (but non-zero) measurement is still available
+  // as a `min-height` floor — without it, a culled placeholder rendered
+  // with `height: undefined` would collapse to ~0 px and shift every
+  // subsequent entry up by the article's height during the timing window
+  // between resize and the next IO/RO measurement.
+  const [height, setHeight] = useState<number | null>(null);
+  const lastHeightRef = useRef<number | null>(null);
   const liveRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!visible) return;
     const node = liveRef.current;
-    if (!node || typeof ResizeObserver === 'undefined') {
-      if (node) heightRef.current = node.offsetHeight || heightRef.current;
+    if (!node) return;
+    const apply = () => {
+      const h = node.offsetHeight;
+      if (h > 0) {
+        lastHeightRef.current = h;
+        setHeight(h);
+      }
+    };
+    if (typeof ResizeObserver === 'undefined') {
+      apply();
       return;
     }
-    const ro = new ResizeObserver(() => {
-      const h = node.offsetHeight;
-      if (h > 0) heightRef.current = h;
-    });
+    const ro = new ResizeObserver(apply);
     ro.observe(node);
-    heightRef.current = node.offsetHeight || heightRef.current;
+    apply();
     return () => ro.disconnect();
   }, [visible]);
 
   // Invalidate the cached pixel height whenever the viewport width changes
   // — the previously-measured height was for a different reflow width.
+  // `setHeight(null)` triggers a re-render so any culled placeholder drops
+  // its stale inline height; `lastHeightRef` is intentionally preserved
+  // as a soft `min-height` floor (better than collapsing to 0) until the
+  // tile is remeasured.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     let lastWidth = window.innerWidth;
     const onResize = () => {
       if (window.innerWidth === lastWidth) return;
       lastWidth = window.innerWidth;
-      heightRef.current = null;
+      setHeight(null);
     };
     window.addEventListener('resize', onResize);
     window.addEventListener('orientationchange', onResize);
@@ -123,7 +140,10 @@ const CullableBody = ({
   return (
     <div
       ref={ioRef}
-      style={{ height: heightRef.current ?? undefined }}
+      style={{
+        height: height ?? undefined,
+        minHeight: lastHeightRef.current ?? undefined,
+      }}
       aria-hidden='true'
     />
   );


### PR DESCRIPTION
## Summary
Implements tranche 5 of the performance-improvements spec: a generic `useNearViewport` hook plus per-tile culling on Memories fragment masonry and per-article body culling on Signals, so decoded-image memory and live `<img>` count scale with the viewport rather than the full scroll extent.

## Commentary
- New `src/hooks/useNearViewport.ts` — `[ref, visible]` with a 1-viewport `rootMargin` (`100% 0px`) by default, generic over element type, with `initial` / `rootMargin` options and an SSR-safe fallback.
- `FragmentDetail` wraps each grid cell in a `CullableTile` that swaps between the real `<ProgressiveImage>` content and a sized `<div>` placeholder. Above-the-fold tiles (first six, matching the existing `loading="eager"` / `fetchpriority="high"` thresholds) start live. The visible wrapper carries `role="button"`, `tabIndex={0}`, and Enter/Space `onKeyDown` so keyboard and screen-reader users can still activate solo memory tiles.
- `CullableTile` placeholder height is measured from the live element via `ResizeObserver` (mirroring `CullableBody` in Signals) and cached as `min-height`, falling back to a computed `aspectRatio` only before first measurement. For `flex-1 min-w-0` group rows the call site now passes `n / max(h_i/w_i)` (the equal-width row aspect, where the tallest child sets the row height once widths are equalized) instead of `Σ(w_i/h_i)` (the natural-width-row aspect), so off-screen group-row placeholders reserve the correct height before measurement and don't shift adjacent masonry columns on hydration during fast scroll-jumps or anchor links past long fragments.
- The placeholder branch of `CullableTile` strips `cursor-pointer` from its className so the inert, `aria-hidden` div doesn't show a pointer/hand cursor on hover and falsely signal interactivity.
- Deviated from the spec's "chunks of ~12 in a wrapper div" language — wrapping a chunk under `columns-1 sm:columns-2 lg:columns-3` with `break-inside-avoid` collapses the whole chunk into one column and destroys the masonry flow. Per-tile observation is cheaper semantically and preserves the layout; 25–33 observers per fragment (our two longest: `japan-2024`, `kaws-family`) is well inside IO's design budget.
- `SignalsScreen` wraps each entry's `signal-prose` block in a `CullableBody`. A `ResizeObserver` on the live node keeps the cached height fresh as images decode, so when IO flips the block off-screen the placeholder reserves the right height and never collapses the article out from under the user's scroll position. All entries start `initialVisible: true` — `useInfiniteList`'s sentinel only reveals pages after they're already in viewport, so starting live and culling on scroll-past is correct for both the first batch and subsequent pages. `composedRef` is memoized via `useCallback` so the underlying `IntersectionObserver` isn't torn down and recreated on every parent re-render.
- `CullableBody` widens its IO `rootMargin` to `300% 0px` so browser find-in-page (Cmd+F) keeps matching text in nearby culled signal entries — pre-cull `/signals` was greppable as a single page, and this restores that affordance for typical scroll positions while still unmounting bodies that are far away.
- Both `CullableBody` and `CullableTile` listen for `resize` / `orientationchange` and invalidate the cached pixel height whenever `window.innerWidth` changes — without this, mobile rotation, window resize, or devtools toggles while the element was culled left a stale pre-rotation height in the placeholder, causing a scroll-position jump when it re-entered the viewport. The cached height now lives in `useState` rather than a ref so the invalidation actually re-renders the placeholder; previously, refs alone left the stale inline `height`/`min-height` on culled placeholders until visibility flipped again. `CullableTile` falls back to its computed `aspectRatio` until remeasured; `CullableBody` keeps a `lastHeightRef` that survives invalidation and applies it as a soft `min-height` floor so the placeholder never collapses to ~0 px (and doesn't shift subsequent entries up) during the timing window before remeasurement.
- `useNearViewport` lands as a shared chunk at **0.59 kB / 0.36 kB gzipped**. `bun run lint`, `bun run format`, `bunx tsc --noEmit`, and `bun run build` all clean.
- Archives `docs/wu-json/specs/2026-04-25-performance-improvements.md` → `specs/archived/…`, with status flipped to `implemented`, tranche-5 tasks checked off, and a written outcome.
