### PR TITLE
chore: fix AGENTS.md node engine reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Personal site for Jason Wu ([jasonwu.ink](https://jasonwu.ink)): React + TypeScr
 - **Styling**: Tailwind CSS v4 (`@tailwindcss/vite`)
 - **3D**: `three`, `@react-three/fiber`, `@react-three/drei`
 - **Markdown**: `react-markdown`, `remark-gfm`, `rehype-raw`
-- **Package manager**: Bun (>=1.3.4); **Node**: 22.x (`engines` in `package.json`)
+- **Runtime**: Bun (>=1.3.4)
 - **Lint / format**: Oxlint, Oxfmt
 - **Git hooks**: [prek](https://github.com/j178/prek) (runs on `bun install`, skipped in CI)
 


### PR DESCRIPTION
## Summary
Remove incorrect reference to Node 22.x in AGENTS.md — the project only specifies Bun in `engines` from `package.json`.

## Commentary
The previous line said **Node: 22.x (`engines` in `package.json`)** but the `engines` field only contains `bun: ">=1.3.4"`. Updated to accurately reflect Bun as the sole runtime.