### PR TITLE
feat: route-level chunk prefetch eliminates nav-click waterfall

### DIFF
--- a/docs/wu-json/specs/2026-04-26-route-prefetch-waterfall.md
+++ b/docs/wu-json/specs/2026-04-26-route-prefetch-waterfall.md
@@ -1,0 +1,370 @@
+---
+status: draft
+---
+
+# Fix nav-click waterfall from route-level code splitting
+
+## Context
+
+The prior spec `2026-04-25-performance-improvements.md` moved every screen
+behind `lazy()` in `src/App.tsx` to keep the `markdown` and `three`
+chunks off the `/` critical path. That was a real win for first-paint on
+the landing page — the entry HTML now preloads only `index-*.js`
+(~222 kB / ~71 kB gzipped), and the Gallery `three` chunk (887 kB) no
+longer lands on `/`.
+
+But lazy routes have a cost: clicking a nav link now feels slow,
+especially the first click per session. Nothing pre-warms the screen
+chunk, so every navigation has to pay for a cold network request before
+React can render the new route.
+
+### What actually happens on `/` → `/memories`
+
+1. User clicks the sidebar "Memories" link.
+2. `wouter` updates location → React renders
+   `<Suspense fallback=<RouteFallback/>>` with `<MemoriesScreen />`.
+3. Suspense boundary throws because `MemoriesScreen` chunk isn't loaded.
+4. Browser requests the `MemoriesScreen-*.js` chunk (tiny — ~1.5 kB).
+5. That module's imports cascade: `ProgressiveImage-*.js`,
+   `Memories/data-*.js`, etc. — a second network roundtrip because
+   nothing was preloaded.
+6. React resumes render, screen paints.
+
+On a fast desktop connection this is ~150–300 ms of black fallback.
+On mobile 4G it's visibly worse (500 ms–1 s). Multiply by two for
+`/memories` → `/memories/:id`, which re-pays for `FragmentDetail-*.js`
++ `MarkdownBody-*.js` (44 kB) + `public-api-*.js` (96 kB, the
+remark/rehype plugin bundle).
+
+### Why not just un-split?
+
+Reverting to eager imports solves the waterfall but brings back the
+problem the last spec fixed: every route pays for `markdown` (~329 kB)
+and screens they'll never visit. The home page load time regresses by
+the same ~6× the last spec won.
+
+We want **eager-warm, lazy-execute**: keep the chunks split (so the
+bytes don't appear on the critical path), but prefetch them into the
+HTTP cache during idle time or on user intent, so the `import()` call
+later resolves instantly from cache.
+
+## Goals
+
+- Make first-click navigation from `/` → `/memories` / `/signals` /
+  `/constructs` / `/heroes` feel instant on a warm connection (target:
+  no visible `RouteFallback` flash).
+- Make hover/focus → click on a detail `<Link>` feel instant too
+  (`/memories` → `/memories/japan-2024`).
+- Zero regression on `/` initial paint. The landing page must not
+  download screen chunks **before** it paints; prefetch happens strictly
+  after `requestIdleCallback` / first paint.
+- Works on Safari (which doesn't support `requestIdleCallback` natively
+  — fallback to `setTimeout`).
+- No new dependencies. We're doing this with `import()` + a ref-counted
+  registry, nothing more.
+
+## Non-goals
+
+- SSR / SSG. Still a client-rendered SPA.
+- Rewriting Gallery (`/gallery/:fragmentId`). It's a big chunk and it
+  has its own entry pattern. Out of scope.
+- Prefetching **data** (fragment markdown, image bytes). This spec is
+  about JS chunks only.
+- Prefetching chunks for routes not linked from the sidebar (e.g.
+  deeply-nested pages reached only via in-content links — they're not
+  on the hot path for nav-click perf).
+
+## Design
+
+Three layers, smallest first:
+
+### 1. A shared `prefetchRoute` registry
+
+New module `src/routes/prefetch.ts` that exports:
+
+```ts
+type RouteKey =
+  | 'memories'
+  | 'memoriesDetail'
+  | 'signals'
+  | 'signalsDetail'
+  | 'constructs'
+  | 'constructsDetail'
+  | 'heroes'
+  | 'heroesDetail';
+
+const loaders: Record<RouteKey, () => Promise<unknown>> = {
+  memories: () => import('src/screens/Memories'),
+  memoriesDetail: () => import('src/screens/Memories/FragmentDetail'),
+  signals: () => import('src/screens/Signals'),
+  signalsDetail: () => import('src/screens/Signals/SignalDetail'),
+  constructs: () => import('src/screens/Constructs'),
+  constructsDetail: () => import('src/screens/Constructs/ConstructDetail'),
+  heroes: () => import('src/screens/Heroes'),
+  heroesDetail: () => import('src/screens/Heroes/HeroDetail'),
+};
+
+const prefetched = new Set<RouteKey>();
+
+export const prefetchRoute = (key: RouteKey) => {
+  if (prefetched.has(key)) return;
+  prefetched.add(key);
+  // Fire and forget. Native ES dynamic imports are memoized by the
+  // module system, so the later `lazy()`-driven import() returns the
+  // same already-resolved promise with zero additional network cost.
+  void loaders[key]().catch(() => {
+    // On transient network error, un-mark so a later intent retries.
+    prefetched.delete(key);
+  });
+};
+```
+
+Design choices:
+
+- **One registry, one source of truth.** Both `App.tsx`'s `lazy(() =>
+  import('...'))` calls and this module point at the same specifiers —
+  Vite/Rollup de-dupe them into one chunk, and the module system
+  guarantees the `lazy()` promise resolves from cache.
+- **Idempotent by key.** The `Set` guard means a sidebar link hovered
+  20 times fires one network request.
+- **Fail-open.** If the prefetch fetch errors (offline blip, CDN 503),
+  un-mark so the real click triggers a fresh load. We never block the
+  click on prefetch status.
+- **No explicit `<link rel="modulepreload">`.** Injecting `<link>`
+  tags can trigger CORS quirks in Safari and requires knowing the
+  hashed filename up front (we don't — it's Vite's output). A plain
+  `import()` call is the portable form: the browser resolves the
+  module specifier, downloads the script with the right CORS mode, and
+  populates the JS module cache. This is what TanStack Router,
+  Next.js's `router.prefetch`, and `react-router`'s `preload()`
+  hooks all ultimately compile to.
+
+### 2. Idle-time warm-up after first paint
+
+In `src/App.tsx` (or a dedicated `useEffect` in `RootLayout`), after
+the first commit schedule a low-priority prefetch of the four
+sidebar-linked index routes (`memories`, `signals`, `constructs`,
+`heroes`):
+
+```ts
+useEffect(() => {
+  const schedule =
+    'requestIdleCallback' in window
+      ? window.requestIdleCallback
+      : (cb: () => void) => setTimeout(cb, 200);
+  const handle = schedule(() => {
+    prefetchRoute('memories');
+    prefetchRoute('signals');
+    prefetchRoute('constructs');
+    prefetchRoute('heroes');
+  });
+  return () => {
+    if ('cancelIdleCallback' in window && typeof handle === 'number') {
+      // Type-narrow: rIC returns a handle; setTimeout returns
+      // Timeout — both are clearable by their own cancel.
+      window.cancelIdleCallback(handle);
+    } else {
+      clearTimeout(handle as ReturnType<typeof setTimeout>);
+    }
+  };
+}, []);
+```
+
+This runs exactly once per session, after React has rendered the
+first route. The browser is allowed to dribble these chunks in over
+idle network; they're tiny (1.5–5 kB each — it's just the screen
+shell, not markdown / data).
+
+**Why not prefetch detail routes here too?**
+Detail chunks (`FragmentDetail`, `SignalDetail`) pull in `MarkdownBody`
++ the remark/rehype plugin bundle (~140 kB combined). That's too much
+to blindly warm on every session — most sessions only click into one
+detail page (or none). Gate those behind user intent, next section.
+
+### 3. Hover / focus intent prefetch on `<Link>`
+
+When the user hovers or focuses a nav or card link, that's a strong
+signal they're about to click it. Prefetch the target's chunk
+immediately — by the time the click lands, the chunk is either
+already cached or in flight.
+
+Two call sites:
+
+**A. Sidebar nav links** (`src/components/Sidebar/index.tsx`). Each
+`<NavLink>` gets `onMouseEnter` + `onFocus` handlers that call
+`prefetchRoute` with the corresponding key:
+
+```tsx
+<NavLink
+  to='/memories'
+  active={pathname.startsWith('/memories')}
+  onHoverIntent={() => prefetchRoute('memories')}
+  onClick={onClick}
+>
+  Memories
+</NavLink>
+```
+
+The index routes are already covered by the idle-time pass, so this is
+belt-and-suspenders for users who click faster than idle fires (very
+first paint, fast connection). Cost: zero extra network because
+`prefetchRoute` is idempotent.
+
+**B. Detail-page cards.** `MemoriesScreen`, `SignalsScreen`,
+`ConstructsScreen`, `HeroesScreen` each render a list of `<Link
+to="/<section>/:id">`s. Attach `onMouseEnter` / `onFocus` to each,
+calling `prefetchRoute('memoriesDetail')` (etc.).
+
+The common pattern: wrap `<Link>` in a local component `<PrefetchLink
+route='memoriesDetail'>` so the index screens don't each open-code
+the handler. Put this in
+`src/components/PrefetchLink.tsx`:
+
+```tsx
+type Props = ComponentProps<typeof Link> & { prefetch?: RouteKey };
+
+export const PrefetchLink = ({ prefetch, ...rest }: Props) => {
+  const onHover = prefetch ? () => prefetchRoute(prefetch) : undefined;
+  return (
+    <Link
+      {...rest}
+      onMouseEnter={onHover}
+      onFocus={onHover}
+      onTouchStart={onHover}
+    />
+  );
+};
+```
+
+`onTouchStart` is the mobile equivalent of hover — fires at touch-down,
+~100–200 ms before the click resolves, which on a 4G connection is
+exactly enough to cover the network roundtrip.
+
+**Coverage.** Only swap `<Link>` → `<PrefetchLink prefetch='…'>` for
+links that go to a detail route or a route with a heavy
+`MarkdownBody`. Sidebar and in-content anchors (e.g. inline
+`/memories/...` in markdown) stay as plain `<Link>` — they're either
+already covered by the idle pass or don't benefit from prefetch.
+
+## Why this beats alternatives
+
+| Alternative | Why not |
+| --- | --- |
+| Revert all `lazy()` → eager | Re-bloats `/` by ~6× (the win this spec preserves). |
+| Only eager-import `MemoriesScreen` + `SignalsScreen` (indexes) | Still bloats `/` with both screen trees + their `data.ts` import.meta.glob bundles; detail routes still cold. |
+| `<link rel="modulepreload">` injected in `index.html` | Vite hashes filenames; would need a plugin to template them in, and Safari CORS-handles `<link modulepreload>` differently than `<script type=module>` — occasional double-fetches in the wild. |
+| `@vite-pwa/plugin` / service worker caching | Much bigger surface, precaches images/fonts too, adds a SW update story. Worth doing eventually but not for this problem. |
+| Prefetch on `mousedown` instead of `mouseenter` | Too late — `mousedown` → `click` gap is ~10–50 ms, not enough to swallow a network request. |
+
+The hover-intent + idle warm-up combo is what Next.js's
+`<Link prefetch>`, TanStack Router, and Remix all do in one form or
+another. It's the lowest-code, highest-leverage fix.
+
+## Implementation plan
+
+**Files touched:**
+
+- New: `src/routes/prefetch.ts` (registry + `prefetchRoute`).
+- New: `src/components/PrefetchLink.tsx` (thin `<Link>` wrapper).
+- `src/App.tsx` — import `prefetchRoute` from the registry so both
+  `lazy()` and the registry reference the same module specifiers
+  (avoid drift). Add the `useEffect` idle-time warm-up in a small
+  `<RoutePrefetcher />` component mounted inside `RootLayout`'s
+  subtree (not at the top level — we don't want it running when the
+  user lands directly on `/gallery/...`, which bypasses
+  `RootLayout`).
+- `src/components/Sidebar/index.tsx` — extend `NavLink` with an
+  `onHoverIntent` prop; wire the four content sections.
+- `src/screens/Memories/index.tsx` — swap `Link` →
+  `<PrefetchLink prefetch='memoriesDetail'>`.
+- `src/screens/Signals/index.tsx` — same for `signalsDetail`.
+- `src/screens/Constructs/index.tsx` — same for `constructsDetail`.
+- `src/screens/Heroes/index.tsx` — same for `heroesDetail`.
+
+## Tasks
+
+- [ ] Add `src/routes/prefetch.ts` with the `RouteKey` union, `loaders`
+      map pointing at the same `import('src/screens/...')` specifiers
+      used in `App.tsx`, a `Set`-backed idempotency guard, and the
+      `prefetchRoute(key)` function that fires-and-forgets and
+      un-marks on failure.
+- [ ] Refactor `src/App.tsx` so the eight `lazy()` calls call into the
+      shared `loaders` map rather than duplicating the `import()`
+      specifiers. Keeps a single source of truth so the registry
+      can't drift from the router. (Pass `loaders.memories` directly
+      to `lazy()`, wrapping with the `.then(m => ({ default:
+      m.MemoriesScreen }))` shape where needed.)
+- [ ] Add `<RoutePrefetcher />` component that mounts inside
+      `RootLayout` and calls `prefetchRoute` for `memories`,
+      `signals`, `constructs`, `heroes` on a `requestIdleCallback`
+      (fallback `setTimeout(200)`) after first commit. Cleanup
+      cancels the idle handle if unmounted before it fires.
+- [ ] Add `src/components/PrefetchLink.tsx` that wraps wouter's
+      `<Link>` and attaches `onMouseEnter` / `onFocus` /
+      `onTouchStart` handlers that call `prefetchRoute(prefetch)`.
+      Preserve all existing `Link` props via `ComponentProps<typeof
+      Link>`.
+- [ ] Extend `NavLink` in `src/components/Sidebar/index.tsx` with an
+      optional `onHoverIntent` callback bound to the same three
+      events. Wire the four content links to their respective
+      `prefetchRoute` keys. Leave `/` (HomeScreen, already eager) and
+      Gallery (separate concern) unwired.
+- [ ] Swap `Link` → `<PrefetchLink prefetch='memoriesDetail'>` on
+      fragment cards in `src/screens/Memories/index.tsx`.
+- [ ] Same swap for `signalsDetail` in
+      `src/screens/Signals/index.tsx` (the "expand into detail" links
+      on collapsed entries — check `SignalsScreen` for all
+      `<Link to={'/signals/${id}'}>` occurrences and hit each one).
+- [ ] Same swap for `constructsDetail` in
+      `src/screens/Constructs/index.tsx`.
+- [ ] Same swap for `heroesDetail` in `src/screens/Heroes/index.tsx`.
+- [ ] `bun run lint` + `bun run format` clean.
+- [ ] `bun run build` clean. Verify in `build/index.html` that the
+      preloaded chunk set is unchanged (still just the main entry +
+      CSS) — the prefetch is runtime-only, it must not affect the
+      HTML.
+- [ ] Smoke-test in `bun run preview` on throttled 3G (Chrome
+      DevTools): Click `/` → `/memories` after ~1 s of idle; the
+      `RouteFallback` flash should be gone. Then hover
+      `/memories/japan-2024` briefly, click: should also feel
+      instant (chunk pre-warmed).
+
+## Verification
+
+- Before/after waterfalls in Chrome DevTools → Network panel,
+  "Fast 3G" throttle:
+  - Home load: no new chunks downloaded before `domcontentloaded`.
+  - After idle: 4 small chunks land in background (memories, signals,
+    constructs, heroes).
+  - Click nav: no new network request for the screen chunk (served
+    from memory cache), only the data chunk if not already shared.
+- Lighthouse run on `/`: LCP unchanged (goal: ±50 ms of current).
+- iPhone Safari on a real metered connection: hover substitute is
+  `touchstart`; detail page click should feel noticeably snappier.
+
+## Risks / open questions
+
+- **Idle-time prefetch on metered connections.** Chrome/Firefox expose
+  `navigator.connection.saveData`; could skip the idle pass when it's
+  true. Probably worth adding — **decision:** do it, one-line guard
+  in `<RoutePrefetcher />`. If `saveData` is true or `effectiveType`
+  is `'2g'`/`'slow-2g'`, skip the idle pass; hover-intent prefetch
+  still runs because that's user-initiated.
+- **`cancelIdleCallback` typing.** `requestIdleCallback` returns
+  `number`, `setTimeout` returns `ReturnType<typeof setTimeout>`
+  which narrows differently in DOM vs. Node lib. Just type the handle
+  as `number | ReturnType<typeof setTimeout>` and branch on cancel.
+- **Module specifier drift.** If someone edits `App.tsx` to change a
+  `lazy()` specifier without updating `prefetch.ts`, we'd prefetch
+  the wrong chunk. The "single source of truth" refactor (have
+  `App.tsx` import from `prefetch.ts`) prevents this; keep the
+  loaders map as the canonical definition.
+- **Safari touchstart → scrolling intent.** `onTouchStart` also fires
+  on scroll-initiating touches over a link. This is fine for our use
+  case (the chunk prefetch is cheap and idempotent), but note that
+  it's slightly more aggressive than strict hover intent.
+- **Does this conflict with the existing Suspense boundary's
+  fallback?** No — when the prefetch succeeds, the `lazy()` promise
+  resolves synchronously from cache on first render, so Suspense
+  never throws. The `<RouteFallback>` code path only runs when
+  prefetch hasn't completed. Safe fall-back behavior.

--- a/docs/wu-json/specs/2026-04-26-route-prefetch-waterfall.md
+++ b/docs/wu-json/specs/2026-04-26-route-prefetch-waterfall.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: ready
 ---
 
 # Fix nav-click waterfall from route-level code splitting
@@ -24,16 +24,19 @@ React can render the new route.
 2. `wouter` updates location → React renders
    `<Suspense fallback=<RouteFallback/>>` with `<MemoriesScreen />`.
 3. Suspense boundary throws because `MemoriesScreen` chunk isn't loaded.
-4. Browser requests the `MemoriesScreen-*.js` chunk (tiny — ~1.5 kB).
-5. That module's imports cascade: `ProgressiveImage-*.js`,
-   `Memories/data-*.js`, etc. — a second network roundtrip because
-   nothing was preloaded.
-6. React resumes render, screen paints.
+4. Browser requests the `MemoriesScreen-*.js` chunk. Vite's
+   `__vitePreload` helper emits `<link rel="modulepreload">` for the
+   chunk's declared dependencies (CSS is already in the single bundle,
+   but the screen's `data-*.js` sibling — 20 kB of
+   `import.meta.glob('./fragments/*.md', { eager: true })` — is
+   fetched in parallel).
+5. React resumes render once both chunks resolve, screen paints.
 
-On a fast desktop connection this is ~150–300 ms of black fallback.
-On mobile 4G it's visibly worse (500 ms–1 s). Multiply by two for
-`/memories` → `/memories/:id`, which re-pays for `FragmentDetail-*.js`
-+ `MarkdownBody-*.js` (44 kB) + `public-api-*.js` (96 kB, the
+On a fast desktop connection this is ~150–300 ms of black fallback
+(mostly `Suspense` bookkeeping + one RTT). On mobile 4G it's visibly
+worse (500 ms–1 s). Memories/Signals → their detail routes pay
+another round for `FragmentDetail` / `SignalDetail` plus the shared
+`MarkdownBody-*.js` (44 kB) + `public-api-*.js` (96 kB, the
 remark/rehype plugin bundle).
 
 ### Why not just un-split?
@@ -45,8 +48,38 @@ the same ~6× the last spec won.
 
 We want **eager-warm, lazy-execute**: keep the chunks split (so the
 bytes don't appear on the critical path), but prefetch them into the
-HTTP cache during idle time or on user intent, so the `import()` call
-later resolves instantly from cache.
+browser's module cache during idle time or on user intent, so the
+`import()` call that `lazy()` makes at click time resolves
+synchronously from cache.
+
+### Why `import()` memoization is the whole trick
+
+Vite/Rollup compiles every `import('src/screens/Memories')` callsite —
+whether inside a `lazy()` or inside a plain fire-and-forget prefetch
+call — to the same hashed URL (`/assets/index-DQtCerIn.js` or
+whatever). The ECMAScript module system keys its registry on the
+resolved URL and memoizes the promise for that URL.
+
+So: a prefetch call `void import('src/screens/Memories')` downloads
+the chunk, **evaluates its top-level code**, and caches its module
+record in the registry. A later `lazy(() =>
+import('src/screens/Memories'))` call looks up the same URL, finds
+the cached record, and returns an already-resolved promise — zero
+extra network, zero extra evaluation. Suspense's "throw a promise"
+mechanism resolves on the first render attempt and the child renders
+in the same tick.
+
+Top-level evaluation at prefetch time is the point, not a bug. The
+heavy module-load cost in our tree is the `import.meta.glob('./<x>/*.md',
+{ eager: true })` in each screen's `data.ts` — parsing frontmatter
+for 4–11 markdown entries. We want that amortized to idle / hover,
+not charged to the click. The screen's React component itself doesn't
+run until React calls it; only module-scope side effects execute on
+prefetch.
+
+This behavior is portable across Chromium, Firefox, and Safari
+(specified by the ES `HostLoadImportedModule` hook, which all three
+delegate to a URL-keyed internal slot).
 
 ## Goals
 
@@ -56,34 +89,41 @@ later resolves instantly from cache.
 - Make hover/focus → click on a detail `<Link>` feel instant too
   (`/memories` → `/memories/japan-2024`).
 - Zero regression on `/` initial paint. The landing page must not
-  download screen chunks **before** it paints; prefetch happens strictly
-  after `requestIdleCallback` / first paint.
+  download screen chunks **before** it paints; prefetch runs strictly
+  after the first React commit.
 - Works on Safari (which doesn't support `requestIdleCallback` natively
   — fallback to `setTimeout`).
-- No new dependencies. We're doing this with `import()` + a ref-counted
-  registry, nothing more.
+- No new dependencies. Implementation is one `Set`-backed registry +
+  one wrapper component + a small `<RoutePrefetcher />` mount.
 
 ## Non-goals
 
 - SSR / SSG. Still a client-rendered SPA.
-- Rewriting Gallery (`/gallery/:fragmentId`). It's a big chunk and it
-  has its own entry pattern. Out of scope.
-- Prefetching **data** (fragment markdown, image bytes). This spec is
-  about JS chunks only.
-- Prefetching chunks for routes not linked from the sidebar (e.g.
-  deeply-nested pages reached only via in-content links — they're not
-  on the hot path for nav-click perf).
+- Rewriting Gallery (`/gallery/:fragmentId`). Its chunk is 887 kB; we
+  don't want to warm it on idle, and users don't reach it from the
+  sidebar. Out of scope.
+- Prefetching **data** (fragment markdown, image bytes). JS chunks only.
+- Prefetching chunks for in-content markdown anchors. `MarkdownBody`'s
+  custom `a` renderer emits plain `<a href>` (not wouter `<Link>`),
+  which is a full-page reload anyway — a separate, larger change.
+- Chunks for routes not linked from the sidebar (e.g. links across
+  detail screens like `/heroes/:id` → nothing). They're rare enough
+  that cold-click cost is acceptable.
 
 ## Design
 
-Three layers, smallest first:
+Three layers:
 
-### 1. A shared `prefetchRoute` registry
+### 1. Shared loader registry (`src/lib/prefetchRoute.ts`)
 
-New module `src/routes/prefetch.ts` that exports:
+Single source of truth for every lazy screen's `import()` specifier.
+Both `App.tsx`'s `lazy()` calls and the prefetch intents point here,
+which prevents drift (change a specifier in one place without the
+other, and either `lazy()` breaks or prefetch warms the wrong chunk).
 
 ```ts
-type RouteKey =
+// src/lib/prefetchRoute.ts
+export type RouteKey =
   | 'memories'
   | 'memoriesDetail'
   | 'signals'
@@ -93,7 +133,7 @@ type RouteKey =
   | 'heroes'
   | 'heroesDetail';
 
-const loaders: Record<RouteKey, () => Promise<unknown>> = {
+export const loaders = {
   memories: () => import('src/screens/Memories'),
   memoriesDetail: () => import('src/screens/Memories/FragmentDetail'),
   signals: () => import('src/screens/Signals'),
@@ -102,269 +142,378 @@ const loaders: Record<RouteKey, () => Promise<unknown>> = {
   constructsDetail: () => import('src/screens/Constructs/ConstructDetail'),
   heroes: () => import('src/screens/Heroes'),
   heroesDetail: () => import('src/screens/Heroes/HeroDetail'),
-};
+} as const satisfies Record<RouteKey, () => Promise<unknown>>;
 
 const prefetched = new Set<RouteKey>();
 
 export const prefetchRoute = (key: RouteKey) => {
   if (prefetched.has(key)) return;
   prefetched.add(key);
-  // Fire and forget. Native ES dynamic imports are memoized by the
-  // module system, so the later `lazy()`-driven import() returns the
-  // same already-resolved promise with zero additional network cost.
+  // Fire and forget. The later lazy()-driven import() returns the
+  // same promise from the module registry — zero additional network.
   void loaders[key]().catch(() => {
-    // On transient network error, un-mark so a later intent retries.
+    // Transient failure (offline blip, CDN 503): un-mark so the real
+    // click re-tries. Never block the click on prefetch status.
     prefetched.delete(key);
   });
 };
 ```
 
-Design choices:
+Design notes:
 
-- **One registry, one source of truth.** Both `App.tsx`'s `lazy(() =>
-  import('...'))` calls and this module point at the same specifiers —
-  Vite/Rollup de-dupe them into one chunk, and the module system
-  guarantees the `lazy()` promise resolves from cache.
-- **Idempotent by key.** The `Set` guard means a sidebar link hovered
-  20 times fires one network request.
-- **Fail-open.** If the prefetch fetch errors (offline blip, CDN 503),
-  un-mark so the real click triggers a fresh load. We never block the
-  click on prefetch status.
-- **No explicit `<link rel="modulepreload">`.** Injecting `<link>`
-  tags can trigger CORS quirks in Safari and requires knowing the
-  hashed filename up front (we don't — it's Vite's output). A plain
-  `import()` call is the portable form: the browser resolves the
-  module specifier, downloads the script with the right CORS mode, and
-  populates the JS module cache. This is what TanStack Router,
-  Next.js's `router.prefetch`, and `react-router`'s `preload()`
-  hooks all ultimately compile to.
+- **`as const satisfies`** gives the compile-time `RouteKey`
+  completeness check (exhaustive record) without widening the value
+  types, so `loaders.memories` keeps its narrow function type.
+- **Idempotent by key.** A sidebar link hovered 20 times fires one
+  network request.
+- **Fail-open.** Prefetch is best-effort; the Suspense fallback is the
+  safety net if it misses.
+- **Why not `<link rel="modulepreload">`?** Two reasons: (a) Vite
+  hashes the chunk filenames at build time, so injecting tags into
+  `index.html` would need a custom plugin to template them in;
+  (b) Safari's `<link modulepreload>` implementation has occasionally
+  double-fetched when the subsequent `<script type=module>` loads
+  with different CORS semantics. A plain `import()` call sidesteps
+  both: it goes through the exact same fetch path the real click
+  would use, so the cache hit on click is guaranteed.
 
-### 2. Idle-time warm-up after first paint
+### 2. Idle-time warm-up after first paint (`<RoutePrefetcher />`)
 
-In `src/App.tsx` (or a dedicated `useEffect` in `RootLayout`), after
-the first commit schedule a low-priority prefetch of the four
-sidebar-linked index routes (`memories`, `signals`, `constructs`,
-`heroes`):
+A small component mounted **inside `RootLayout`'s subtree** (so it
+doesn't run on `/gallery/:fragmentId`, which bypasses `RootLayout`
+entirely). After the first commit, schedule a low-priority prefetch
+of the four sidebar-linked index routes.
 
-```ts
-useEffect(() => {
-  const schedule =
-    'requestIdleCallback' in window
-      ? window.requestIdleCallback
-      : (cb: () => void) => setTimeout(cb, 200);
-  const handle = schedule(() => {
-    prefetchRoute('memories');
-    prefetchRoute('signals');
-    prefetchRoute('constructs');
-    prefetchRoute('heroes');
-  });
-  return () => {
-    if ('cancelIdleCallback' in window && typeof handle === 'number') {
-      // Type-narrow: rIC returns a handle; setTimeout returns
-      // Timeout — both are clearable by their own cancel.
-      window.cancelIdleCallback(handle);
-    } else {
-      clearTimeout(handle as ReturnType<typeof setTimeout>);
+```tsx
+// src/layouts/RoutePrefetcher.tsx
+import { useEffect } from 'react';
+import { prefetchRoute } from 'src/lib/prefetchRoute';
+
+type Handle =
+  | { kind: 'idle'; id: number }
+  | { kind: 'timeout'; id: ReturnType<typeof setTimeout> };
+
+export const RoutePrefetcher = () => {
+  useEffect(() => {
+    // Opt out on metered / explicitly data-saving connections. Users
+    // can still click and pay the cold-chunk cost; hover-intent
+    // prefetch (user-initiated) remains active regardless.
+    const conn = (
+      navigator as Navigator & {
+        connection?: { saveData?: boolean; effectiveType?: string };
+      }
+    ).connection;
+    if (
+      conn?.saveData ||
+      conn?.effectiveType === '2g' ||
+      conn?.effectiveType === 'slow-2g'
+    ) {
+      return;
     }
-  };
-}, []);
+
+    const run = () => {
+      prefetchRoute('memories');
+      prefetchRoute('signals');
+      prefetchRoute('constructs');
+      prefetchRoute('heroes');
+    };
+
+    let handle: Handle;
+    if ('requestIdleCallback' in window) {
+      handle = { kind: 'idle', id: window.requestIdleCallback(run) };
+    } else {
+      // Safari: no native rIC. 200 ms is enough for the main thread
+      // to settle after first paint; we don't fight with LCP.
+      handle = { kind: 'timeout', id: setTimeout(run, 200) };
+    }
+
+    return () => {
+      if (handle.kind === 'idle') window.cancelIdleCallback(handle.id);
+      else clearTimeout(handle.id);
+    };
+  }, []);
+
+  return null;
+};
 ```
 
-This runs exactly once per session, after React has rendered the
-first route. The browser is allowed to dribble these chunks in over
-idle network; they're tiny (1.5–5 kB each — it's just the screen
-shell, not markdown / data).
+Bytes warmed on idle, measured against the current `build/assets/`:
 
-**Why not prefetch detail routes here too?**
-Detail chunks (`FragmentDetail`, `SignalDetail`) pull in `MarkdownBody`
-+ the remark/rehype plugin bundle (~140 kB combined). That's too much
-to blindly warm on every session — most sessions only click into one
-detail page (or none). Gate those behind user intent, next section.
+| Route | Shell + data | Transitive shared chunks |
+| --- | --- | --- |
+| `memories` | `MemoriesScreen` (1.5 kB) + `data` (20 kB) | — |
+| `signals` | `SignalsScreen` (5.3 kB) | `MarkdownBody` (44 kB) + `public-api` (96 kB) + `index-D-GFURkx` (118 kB) — the remark/rehype/micromark pipeline |
+| `constructs` | `ConstructsScreen` (1.5 kB) + `data` (12 kB) | — |
+| `heroes` | `HeroesScreen` (1.5 kB) + `data` (3.7 kB) | — |
+| **Total idle warmup** | **~300 kB min / ~95 kB gzipped** | Browser dribbles over idle network. |
 
-### 3. Hover / focus intent prefetch on `<Link>`
+**Signals dominates the idle bill** — its list view renders
+`MarkdownBody` inline on every entry, so warming `SignalsScreen`
+transitively warms the whole markdown pipeline (`MarkdownBody` +
+`public-api` + the split-out remark/rehype/micromark chunk
+`index-D-GFURkx.js`). ~95 kB gzipped is not trivial.
 
-When the user hovers or focuses a nav or card link, that's a strong
-signal they're about to click it. Prefetch the target's chunk
-immediately — by the time the click lands, the chunk is either
-already cached or in flight.
+The benefit: the markdown pipeline is **shared** across every detail
+route, so warming it once on idle makes hover-intent prefetch of
+`FragmentDetail` (15 kB), `SignalDetail` (2.3 kB), `ConstructDetail`
+(2.8 kB), and `HeroDetail` (2.7 kB) essentially free — a single
+small RTT for the remaining per-route code. Across a typical session
+(2–5 detail page visits), this is net bytes-saved vs. fetching
+markdown lazily on each cold detail click.
 
-Two call sites:
+Guards already in the design keep this defensible: `saveData` opts
+out, `2g`/`slow-2g` opts out, and the idle pass only runs after the
+first React commit (no competition with LCP). If measurement shows
+this is still too heavy for a real user profile, the easy tweak is to
+drop `'signals'` from the idle list and rely on hover-intent (which
+covers it fine on desktop; mobile tap-to-open-menu is slow enough for
+`touchstart` prefetch to cover too). That's a one-line change, not a
+design revision — flag it as a future adjustment rather than an
+open question.
 
-**A. Sidebar nav links** (`src/components/Sidebar/index.tsx`). Each
-`<NavLink>` gets `onMouseEnter` + `onFocus` handlers that call
-`prefetchRoute` with the corresponding key:
+Deliberately **not** warmed on idle: the four Detail screen chunks
+themselves, which are cold-speculative (many sessions hit zero detail
+pages). They come in on hover-intent, and by then the shared markdown
+pipeline is already cached from the Signals warmup.
+
+### 3. Hover / focus / touchstart intent prefetch
+
+When a user hovers or focuses a link, they're very likely about to
+click it. Prefetch the target chunk at that moment — by click time,
+the chunk is cached or close to it.
+
+**Attachment points:**
+
+**A. Sidebar nav links** (`src/components/Sidebar/index.tsx`). Extend
+`NavLink` with an optional `prefetch?: RouteKey`; internally wire
+`onMouseEnter` / `onFocus` / `onTouchStart` on the underlying wouter
+`<Link>` (verified: wouter `<Link>` spreads `restProps` onto its
+rendered `<a>`, so DOM handlers pass through).
 
 ```tsx
-<NavLink
-  to='/memories'
-  active={pathname.startsWith('/memories')}
-  onHoverIntent={() => prefetchRoute('memories')}
-  onClick={onClick}
->
-  Memories
-</NavLink>
+<NavLink to='/memories' prefetch='memories' active={…}>Memories</NavLink>
+<NavLink to='/constructs' prefetch='constructs' active={…}>Constructs</NavLink>
+<NavLink to='/signals' prefetch='signals' active={…}>Signals</NavLink>
+<NavLink to='/heroes' prefetch='heroes' active={…}>Heroes</NavLink>
 ```
 
-The index routes are already covered by the idle-time pass, so this is
-belt-and-suspenders for users who click faster than idle fires (very
-first paint, fast connection). Cost: zero extra network because
-`prefetchRoute` is idempotent.
+Sidebar nav is belt-and-suspenders against the idle pass — on a very
+fast connection the user can click before the idle callback fires.
+Cost is zero extra network because `prefetchRoute` is idempotent.
+`Jason Cui Wu` → `/` stays unprefetched (HomeScreen is eager, not
+lazy, in `App.tsx`).
 
-**B. Detail-page cards.** `MemoriesScreen`, `SignalsScreen`,
-`ConstructsScreen`, `HeroesScreen` each render a list of `<Link
-to="/<section>/:id">`s. Attach `onMouseEnter` / `onFocus` to each,
-calling `prefetchRoute('memoriesDetail')` (etc.).
-
-The common pattern: wrap `<Link>` in a local component `<PrefetchLink
-route='memoriesDetail'>` so the index screens don't each open-code
-the handler. Put this in
-`src/components/PrefetchLink.tsx`:
+**B. Detail-card links on index screens.** `MemoriesScreen`,
+`ConstructsScreen`, `HeroesScreen` each render `<Link to="/<section>/:id">`
+per entry. Introduce a thin wrapper:
 
 ```tsx
+// src/components/PrefetchLink.tsx
+import type { ComponentProps } from 'react';
+import { Link } from 'wouter';
+import { prefetchRoute, type RouteKey } from 'src/lib/prefetchRoute';
+
 type Props = ComponentProps<typeof Link> & { prefetch?: RouteKey };
 
 export const PrefetchLink = ({ prefetch, ...rest }: Props) => {
-  const onHover = prefetch ? () => prefetchRoute(prefetch) : undefined;
+  const onIntent = prefetch ? () => prefetchRoute(prefetch) : undefined;
   return (
     <Link
       {...rest}
-      onMouseEnter={onHover}
-      onFocus={onHover}
-      onTouchStart={onHover}
+      onMouseEnter={onIntent}
+      onFocus={onIntent}
+      onTouchStart={onIntent}
     />
   );
 };
 ```
 
-`onTouchStart` is the mobile equivalent of hover — fires at touch-down,
-~100–200 ms before the click resolves, which on a 4G connection is
-exactly enough to cover the network roundtrip.
+`onTouchStart` fires at touch-down — ~100–200 ms before `click`
+resolves, enough to cover one 4G roundtrip for the detail chunk.
+Swap `<Link>` → `<PrefetchLink prefetch='memoriesDetail'>` (etc.) on
+card rendering in Memories / Constructs / Heroes index screens.
 
-**Coverage.** Only swap `<Link>` → `<PrefetchLink prefetch='…'>` for
-links that go to a detail route or a route with a heavy
-`MarkdownBody`. Sidebar and in-content anchors (e.g. inline
-`/memories/...` in markdown) stay as plain `<Link>` — they're either
-already covered by the idle pass or don't benefit from prefetch.
+**C. Signals list — special case.** `SignalsScreen` does **not** use
+`<Link>` for entries. Each article is a `<div tabIndex={0}>` that
+calls `navigate('/signals/:id')` on click / Enter (so clicks can
+fall through to inline `<a>` / `<button>` children without
+navigating). `PrefetchLink` doesn't apply. Instead attach
+`onMouseEnter` / `onFocus` / `onTouchStart` handlers directly to the
+same `<div>` (`signal-list-item`). Wire via a tiny inline helper:
+
+```tsx
+const onIntent = () => prefetchRoute('signalsDetail');
+// …
+<div
+  tabIndex={0}
+  onClick={onPreviewClick}
+  onKeyDown={onPreviewKeyDown}
+  onMouseEnter={onIntent}
+  onFocus={onIntent}
+  onTouchStart={onIntent}
+  className='signal-list-item …'
+>
+```
+
+Both list and detail signals share one chunk (`SignalDetail-*.js`),
+so prefetching once per hover is sufficient regardless of which
+article triggers it.
+
+**Coverage audit.** These are the hot paths from the sidebar outward:
+
+- Sidebar → `/memories`, `/signals`, `/constructs`, `/heroes`: covered
+  by (A) + idle pass.
+- `/memories` → `/memories/:id`: covered by (B) via `PrefetchLink`.
+- `/signals` → `/signals/:id`: covered by (C) via handlers on the
+  list-item div.
+- `/constructs` → `/constructs/:id`: covered by (B).
+- `/heroes` → `/heroes/:id`: covered by (B).
+- Cross-section links in detail screens (e.g. `SignalDetail` →
+  `/memories/xyz`): **not covered**. These are rare and usually
+  mid-read; we accept the cold-click cost.
 
 ## Why this beats alternatives
 
 | Alternative | Why not |
 | --- | --- |
 | Revert all `lazy()` → eager | Re-bloats `/` by ~6× (the win this spec preserves). |
-| Only eager-import `MemoriesScreen` + `SignalsScreen` (indexes) | Still bloats `/` with both screen trees + their `data.ts` import.meta.glob bundles; detail routes still cold. |
-| `<link rel="modulepreload">` injected in `index.html` | Vite hashes filenames; would need a plugin to template them in, and Safari CORS-handles `<link modulepreload>` differently than `<script type=module>` — occasional double-fetches in the wild. |
-| `@vite-pwa/plugin` / service worker caching | Much bigger surface, precaches images/fonts too, adds a SW update story. Worth doing eventually but not for this problem. |
-| Prefetch on `mousedown` instead of `mouseenter` | Too late — `mousedown` → `click` gap is ~10–50 ms, not enough to swallow a network request. |
+| Only eager-import index screens | Still bloats `/` with four screen trees + their `data.ts` bundles; detail routes still cold. |
+| `<link rel="modulepreload">` in `index.html` | Vite hashes filenames; would need a plugin. Safari has double-fetched in practice when the subsequent `<script type=module>` disagrees on CORS. |
+| `@vite-pwa/plugin` / service worker | Much bigger surface (precaches images/fonts, adds a SW update story). Worth doing eventually, not for this problem. |
+| Prefetch on `mousedown` | Too late — `mousedown` → `click` is ~10–50 ms, not enough for a cold RTT. |
 
-The hover-intent + idle warm-up combo is what Next.js's
-`<Link prefetch>`, TanStack Router, and Remix all do in one form or
-another. It's the lowest-code, highest-leverage fix.
+Hover-intent + idle warm-up is what Next.js's `<Link prefetch>`,
+TanStack Router, and Remix all compile to under the hood. Lowest-code,
+highest-leverage fix for this class of waterfall.
 
 ## Implementation plan
 
 **Files touched:**
 
-- New: `src/routes/prefetch.ts` (registry + `prefetchRoute`).
-- New: `src/components/PrefetchLink.tsx` (thin `<Link>` wrapper).
-- `src/App.tsx` — import `prefetchRoute` from the registry so both
-  `lazy()` and the registry reference the same module specifiers
-  (avoid drift). Add the `useEffect` idle-time warm-up in a small
-  `<RoutePrefetcher />` component mounted inside `RootLayout`'s
-  subtree (not at the top level — we don't want it running when the
-  user lands directly on `/gallery/...`, which bypasses
-  `RootLayout`).
-- `src/components/Sidebar/index.tsx` — extend `NavLink` with an
-  `onHoverIntent` prop; wire the four content sections.
-- `src/screens/Memories/index.tsx` — swap `Link` →
-  `<PrefetchLink prefetch='memoriesDetail'>`.
-- `src/screens/Signals/index.tsx` — same for `signalsDetail`.
+- **New:** `src/lib/prefetchRoute.ts` — registry + `prefetchRoute`.
+- **New:** `src/components/PrefetchLink.tsx` — thin `<Link>` wrapper.
+- **New:** `src/layouts/RoutePrefetcher.tsx` — idle-time warm-up.
+- `src/App.tsx` — import `loaders` from `prefetchRoute.ts` so `lazy()`
+  calls share specifiers with the registry (no drift).
+- `src/layouts/RootLayout.tsx` — mount `<RoutePrefetcher />` at the
+  end of the tree (placement doesn't matter functionally; beside
+  `ScrollToTop` is tidy).
+- `src/components/Sidebar/index.tsx` — add `prefetch?: RouteKey` to
+  `NavLink`, wire `onMouseEnter` / `onFocus` / `onTouchStart` on the
+  underlying `<Link>`. Pass the four content-section keys.
+- `src/screens/Memories/index.tsx` — swap `Link` → `PrefetchLink
+  prefetch='memoriesDetail'`.
 - `src/screens/Constructs/index.tsx` — same for `constructsDetail`.
 - `src/screens/Heroes/index.tsx` — same for `heroesDetail`.
+- `src/screens/Signals/index.tsx` — inline handlers on the
+  `signal-list-item` `<div>` for `signalsDetail` (not `PrefetchLink`
+  — list items aren't `<Link>`s).
 
 ## Tasks
 
-- [ ] Add `src/routes/prefetch.ts` with the `RouteKey` union, `loaders`
-      map pointing at the same `import('src/screens/...')` specifiers
-      used in `App.tsx`, a `Set`-backed idempotency guard, and the
-      `prefetchRoute(key)` function that fires-and-forgets and
-      un-marks on failure.
-- [ ] Refactor `src/App.tsx` so the eight `lazy()` calls call into the
-      shared `loaders` map rather than duplicating the `import()`
-      specifiers. Keeps a single source of truth so the registry
-      can't drift from the router. (Pass `loaders.memories` directly
-      to `lazy()`, wrapping with the `.then(m => ({ default:
-      m.MemoriesScreen }))` shape where needed.)
-- [ ] Add `<RoutePrefetcher />` component that mounts inside
-      `RootLayout` and calls `prefetchRoute` for `memories`,
-      `signals`, `constructs`, `heroes` on a `requestIdleCallback`
-      (fallback `setTimeout(200)`) after first commit. Cleanup
-      cancels the idle handle if unmounted before it fires.
-- [ ] Add `src/components/PrefetchLink.tsx` that wraps wouter's
-      `<Link>` and attaches `onMouseEnter` / `onFocus` /
-      `onTouchStart` handlers that call `prefetchRoute(prefetch)`.
-      Preserve all existing `Link` props via `ComponentProps<typeof
-      Link>`.
+- [ ] Add `src/lib/prefetchRoute.ts` with the `RouteKey` union, a
+      `loaders` map using `as const satisfies
+      Record<RouteKey, () => Promise<unknown>>`, a `Set`-backed
+      idempotency guard, and a `prefetchRoute(key)` function that
+      fires-and-forgets and un-marks on failure. Export `loaders` and
+      `RouteKey` for `App.tsx`.
+- [ ] Refactor `src/App.tsx`: replace each of the eight inline
+      `import('src/screens/...')` specifiers with
+      `loaders.<key>().then(...)` so `lazy()` and the registry share
+      one source of truth. Keep the `.then(m => ({ default:
+      m.NamedExport }))` shape where the module isn't a default
+      export.
+- [ ] Add `src/layouts/RoutePrefetcher.tsx` per the design:
+      `requestIdleCallback` path with `setTimeout(200)` fallback,
+      `saveData` / `effectiveType` opt-out, cancel on unmount via
+      the tagged-handle union. Component returns `null`.
+- [ ] Mount `<RoutePrefetcher />` inside `RootLayout` (not at the
+      top of `App` — we want Gallery's `/gallery/:fragmentId` route
+      to skip the prefetch entirely).
+- [ ] Add `src/components/PrefetchLink.tsx`: wrap wouter's `<Link>`,
+      accept all its props via `ComponentProps<typeof Link>`, attach
+      `onMouseEnter` / `onFocus` / `onTouchStart` that call
+      `prefetchRoute(prefetch)` when `prefetch` is set. No change to
+      `<Link>` behavior when `prefetch` is omitted.
 - [ ] Extend `NavLink` in `src/components/Sidebar/index.tsx` with an
-      optional `onHoverIntent` callback bound to the same three
-      events. Wire the four content links to their respective
-      `prefetchRoute` keys. Leave `/` (HomeScreen, already eager) and
-      Gallery (separate concern) unwired.
-- [ ] Swap `Link` → `<PrefetchLink prefetch='memoriesDetail'>` on
-      fragment cards in `src/screens/Memories/index.tsx`.
-- [ ] Same swap for `signalsDetail` in
-      `src/screens/Signals/index.tsx` (the "expand into detail" links
-      on collapsed entries — check `SignalsScreen` for all
-      `<Link to={'/signals/${id}'}>` occurrences and hit each one).
-- [ ] Same swap for `constructsDetail` in
-      `src/screens/Constructs/index.tsx`.
-- [ ] Same swap for `heroesDetail` in `src/screens/Heroes/index.tsx`.
+      optional `prefetch?: RouteKey`. Inside, if set, wire the three
+      intent events on the underlying `<Link>`. Pass `'memories'` /
+      `'constructs'` / `'signals'` / `'heroes'` on the four content
+      links. Leave `'Jason Cui Wu'` (`/`) without prefetch (Home is
+      eager).
+- [ ] `src/screens/Memories/index.tsx`: swap `Link` → `PrefetchLink`
+      with `prefetch='memoriesDetail'` on fragment cards.
+- [ ] `src/screens/Constructs/index.tsx`: same with
+      `prefetch='constructsDetail'`.
+- [ ] `src/screens/Heroes/index.tsx`: same with
+      `prefetch='heroesDetail'`.
+- [ ] `src/screens/Signals/index.tsx`: **not** `PrefetchLink` — the
+      list entries are `<div tabIndex={0}>` that `navigate()` on
+      click, not `<Link>`s. Attach `onMouseEnter` / `onFocus` /
+      `onTouchStart` directly to the `signal-list-item` `<div>`,
+      calling `prefetchRoute('signalsDetail')`.
 - [ ] `bun run lint` + `bun run format` clean.
-- [ ] `bun run build` clean. Verify in `build/index.html` that the
-      preloaded chunk set is unchanged (still just the main entry +
-      CSS) — the prefetch is runtime-only, it must not affect the
-      HTML.
-- [ ] Smoke-test in `bun run preview` on throttled 3G (Chrome
-      DevTools): Click `/` → `/memories` after ~1 s of idle; the
-      `RouteFallback` flash should be gone. Then hover
-      `/memories/japan-2024` briefly, click: should also feel
-      instant (chunk pre-warmed).
+- [ ] `bun run build` clean. Verify via `head -60 build/index.html`
+      that the preloaded chunk set is unchanged (just `index-*.js` +
+      `index-*.css` + the fonts/mirror image). Prefetch is
+      runtime-only and must not alter the HTML.
+- [ ] Smoke-test in `bun run preview` on "Fast 3G" throttle
+      (DevTools → Network):
+      - Load `/`, wait ~2 s; confirm 4 small chunks appear in the
+        waterfall as Initiator=`(index)` or similar, **after**
+        `DOMContentLoaded`.
+      - Click `/memories`: no new network request for
+        `MemoriesScreen-*.js` (served from memory cache); screen
+        paints without `RouteFallback` flash.
+      - Hover a fragment card for ~300 ms, click it: `FragmentDetail`
+        + `MarkdownBody` land during hover; click is instant.
+      - Repeat for `/signals`, `/constructs`, `/heroes` and one
+        detail each.
 
 ## Verification
 
-- Before/after waterfalls in Chrome DevTools → Network panel,
-  "Fast 3G" throttle:
-  - Home load: no new chunks downloaded before `domcontentloaded`.
-  - After idle: 4 small chunks land in background (memories, signals,
-    constructs, heroes).
-  - Click nav: no new network request for the screen chunk (served
-    from memory cache), only the data chunk if not already shared.
-- Lighthouse run on `/`: LCP unchanged (goal: ±50 ms of current).
-- iPhone Safari on a real metered connection: hover substitute is
-  `touchstart`; detail page click should feel noticeably snappier.
+- Before/after waterfalls in Chrome DevTools → Network panel, "Fast
+  3G" throttle:
+  - `/` initial load: no new screen chunks downloaded before
+    `domcontentloaded`.
+  - Idle (~200 ms–1 s after paint): 4 small chunks (+ their data
+    siblings) land in background.
+  - Nav-click: zero new network activity for the screen chunk itself
+    (it's already in memory cache).
+- Lighthouse mobile run on `/`: LCP unchanged (tolerance ±50 ms).
+- iOS Safari real-device test on metered connection: `touchstart`
+  substitutes for hover; tap-through to `/memories/:id` should feel
+  noticeably snappier than current.
 
 ## Risks / open questions
 
-- **Idle-time prefetch on metered connections.** Chrome/Firefox expose
-  `navigator.connection.saveData`; could skip the idle pass when it's
-  true. Probably worth adding — **decision:** do it, one-line guard
-  in `<RoutePrefetcher />`. If `saveData` is true or `effectiveType`
-  is `'2g'`/`'slow-2g'`, skip the idle pass; hover-intent prefetch
-  still runs because that's user-initiated.
-- **`cancelIdleCallback` typing.** `requestIdleCallback` returns
-  `number`, `setTimeout` returns `ReturnType<typeof setTimeout>`
-  which narrows differently in DOM vs. Node lib. Just type the handle
-  as `number | ReturnType<typeof setTimeout>` and branch on cancel.
-- **Module specifier drift.** If someone edits `App.tsx` to change a
-  `lazy()` specifier without updating `prefetch.ts`, we'd prefetch
-  the wrong chunk. The "single source of truth" refactor (have
-  `App.tsx` import from `prefetch.ts`) prevents this; keep the
-  loaders map as the canonical definition.
-- **Safari touchstart → scrolling intent.** `onTouchStart` also fires
-  on scroll-initiating touches over a link. This is fine for our use
-  case (the chunk prefetch is cheap and idempotent), but note that
-  it's slightly more aggressive than strict hover intent.
-- **Does this conflict with the existing Suspense boundary's
-  fallback?** No — when the prefetch succeeds, the `lazy()` promise
-  resolves synchronously from cache on first render, so Suspense
-  never throws. The `<RouteFallback>` code path only runs when
-  prefetch hasn't completed. Safe fall-back behavior.
+- **`navigator.connection` is Chromium-only.** Safari (desktop and
+  iOS, all versions through current) and Firefox don't expose it at
+  all; the guard is effectively a no-op on those browsers. That's
+  acceptable because (a) the idle pass is already after LCP and on
+  rIC/200 ms timer — it's not fighting any critical work, (b) Safari
+  is the platform where `touchstart` hover-intent actually matters
+  most, and the intent prefetch is the real savings on mobile
+  anyway. The idle pass is a "fast-path for repeat visitors on good
+  connections"; the hover-intent pass is the broad-coverage fix.
+- **Safari `touchstart` during scroll.** `onTouchStart` fires on
+  scroll-initiating touches over a link. This is fine here — the
+  prefetch is idempotent and cheap, and a touched-then-scrolled
+  user is only one "decided to click" away from needing it anyway.
+- **Suspense boundary interaction.** When prefetch has completed,
+  `lazy()`'s internal `import()` hits the browser's module registry
+  and resolves in a microtask; Suspense throws the promise once and
+  React resolves it before commit, so `<RouteFallback>` never paints.
+  When prefetch is in-flight at click time, the ECMAScript module
+  registry returns the same pending promise to `lazy()`, so both
+  paths await one network request. Strictly non-regressing vs.
+  today's cold click.
+- **`as const satisfies` on the loaders map.** Needs TS 4.9+; we're
+  on TS 5.x, so this is safe. If the type-check fails on older
+  tooling later, fall back to a manually-typed `Record<RouteKey,
+  () => Promise<unknown>>`.
+- **Future drift.** If a new screen is added lazy in `App.tsx`,
+  whoever does it must also add an entry to `loaders` for
+  prefetch to cover it. A linter rule or test could enforce this,
+  but it's overkill for the current cadence (one new screen every
+  few months).

--- a/docs/wu-json/specs/archived/2026-04-26-route-prefetch-waterfall.md
+++ b/docs/wu-json/specs/archived/2026-04-26-route-prefetch-waterfall.md
@@ -47,45 +47,71 @@ and screens they'll never visit. The home page load time regresses by
 the same ~6× the last spec won.
 
 We want **eager-warm, lazy-execute**: keep the chunks split (so the
-bytes don't appear on the critical path), but prefetch them into the
-browser's module cache during idle time or on user intent, so the
-`import()` call that `lazy()` makes at click time resolves
-synchronously from cache.
+bytes don't appear on the critical path), but prefetch them during
+idle time or on user intent, so by the time `lazy()` is asked to
+render the screen, both the network _and_ React's lazy bookkeeping
+are already settled.
 
-### Why `import()` memoization is the whole trick
+### Why module-cache prefetch isn't enough on its own
 
-Vite/Rollup compiles every `import('src/screens/Memories')` callsite —
-whether inside a `lazy()` or inside a plain fire-and-forget prefetch
-call — to the same hashed URL (`/assets/index-DQtCerIn.js` or
-whatever). The ECMAScript module system keys its registry on the
-resolved URL and memoizes the promise for that URL.
+Vite/Rollup compiles every `import('src/screens/Memories')` callsite
+— whether inside a `lazy()` or inside a plain fire-and-forget
+prefetch call — to the same hashed URL. The ECMAScript module system
+keys its registry on the resolved URL and memoizes the promise for
+that URL, so a prefetched chunk is cheap to re-import.
 
-So: a prefetch call `void import('src/screens/Memories')` downloads
-the chunk, **evaluates its top-level code**, and caches its module
-record in the registry. A later `lazy(() =>
-import('src/screens/Memories'))` call looks up the same URL, finds
-the cached record, and returns an already-resolved promise — zero
-extra network, zero extra evaluation. Suspense's "throw a promise"
-mechanism resolves on the first render attempt and the child renders
-in the same tick.
+But: `React.lazy(() => import('…'))` does _not_ read directly from
+the module registry. It carries an internal `_payload` object that
+starts in `_status: -1` and only flips to `_status: 1` (resolved) on
+the **first render** that touches the lazy component. That first
+render always throws the import promise to Suspense, even if the
+underlying ES module is already cached and resolves in a microtask.
+Suspense then commits the `<RouteFallback>`, awaits the promise, and
+re-renders on the next tick.
 
-Top-level evaluation at prefetch time is the point, not a bug. The
-heavy module-load cost in our tree is the `import.meta.glob('./<x>/*.md',
-{ eager: true })` in each screen's `data.ts` — parsing frontmatter
-for 4–11 markdown entries. We want that amortized to idle / hover,
-not charged to the click. The screen's React component itself doesn't
-run until React calls it; only module-scope side effects execute on
-prefetch.
+In practice: even with idle warmup + hover-intent landing both
+network requests well before the click, **the fallback still flashes
+black for one paint** because React's lazy contract requires a
+suspend-resume cycle on first encounter. That is the "weird pause"
+users see, and it's the entire reason this spec exists rather than
+being a one-line `import()` call on hover.
 
-This behavior is portable across Chromium, Firefox, and Safari
-(specified by the ES `HostLoadImportedModule` hook, which all three
-delegate to a URL-keyed internal slot).
+The fix is to mirror what React's `_init` does, but eagerly. At
+preload time, kick off the `import()`, then on resolution mutate the
+lazy payload directly: `_payload._status = 1`,
+`_payload._result = { default: Component }`. The next render reads
+`_status === 1` and returns the component synchronously without
+suspending. Suspense never sees a thrown promise, the fallback never
+commits, and the click paints the new route in the same frame.
+
+This is why `prefetchRoute.ts` ships its own `lazyWithPreload`
+helper rather than using `React.lazy` directly. The `_payload`
+internal shape has been stable since React 16 and is what every
+established preload library (`@loadable/component`,
+`react-lazy-with-preload`, etc.) reaches into for the same reason.
+
+Top-level module evaluation also happens at preload time. That's the
+point, not a bug: the heavy work in our tree is each screen's
+`import.meta.glob('./<x>/*.md', { eager: true })` in `data.ts`,
+parsing frontmatter for 4–11 markdown entries. We want that
+amortized to idle/hover, not charged to the click. The React
+component function doesn't run until React calls it; only
+module-scope side effects execute on preload.
+
+The module-registry behavior is portable across Chromium, Firefox,
+and Safari (specified by the ES `HostLoadImportedModule` hook). The
+`_payload` mutation is React-internal but stable across all React 16+
+versions; if React ever changes the shape, the type guard at the top
+of `lazyWithPreload` still ensures we either flip to fulfilled
+correctly or fall through to React's normal Suspense path — never
+worse than a plain `React.lazy`.
 
 ## Goals
 
 - Make first-click navigation from `/` → `/memories` / `/signals` /
   `/constructs` / `/heroes` feel instant on a warm connection (target:
-  no visible `RouteFallback` flash).
+  no visible `RouteFallback` flash, including the one-frame Suspense
+  flash that survives module-cache prefetch).
 - Make hover/focus → click on a detail `<Link>` feel instant too
   (`/memories` → `/memories/japan-2024`).
 - Zero regression on `/` initial paint. The landing page must not
@@ -93,8 +119,8 @@ delegate to a URL-keyed internal slot).
   after the first React commit.
 - Works on Safari (which doesn't support `requestIdleCallback` natively
   — fallback to `setTimeout`).
-- No new dependencies. Implementation is one `Set`-backed registry +
-  one wrapper component + a small `<RoutePrefetcher />` mount.
+- No new dependencies. Implementation is one preloadable-lazy registry
+  - one wrapper component + a small `<RoutePrefetcher />` mount.
 
 ## Non-goals
 
@@ -114,68 +140,167 @@ delegate to a URL-keyed internal slot).
 
 Three layers:
 
-### 1. Shared loader registry (`src/lib/prefetchRoute.ts`)
+### 1. Preloadable-lazy registry (`src/lib/prefetchRoute.ts`)
 
-Single source of truth for every lazy screen's `import()` specifier.
-Both `App.tsx`'s `lazy()` calls and the prefetch intents point here,
-which prevents drift (change a specifier in one place without the
-other, and either `lazy()` breaks or prefetch warms the wrong chunk).
+Single source of truth for every lazy screen, owning **both** the
+`React.lazy`-shaped `Component` mounted by `<Route>` and the
+`preload()` function called from prefetch intents. Bundling them
+together is what lets prefetch prime the lazy payload synchronously
+— see the "Why module-cache prefetch isn't enough on its own"
+section for the underlying reason. A separate `loaders` map plus
+plain `React.lazy` wouldn't work: the prefetch path needs a hook
+into the same `_payload` the lazy `<Component>` reads from.
 
 ```ts
 // src/lib/prefetchRoute.ts
-export type RouteKey =
-  | 'memories'
-  | 'memoriesDetail'
-  | 'signals'
-  | 'signalsDetail'
-  | 'constructs'
-  | 'constructsDetail'
-  | 'heroes'
-  | 'heroesDetail';
+import { type ComponentType, lazy } from 'react';
 
-export const loaders = {
-  memories: () => import('src/screens/Memories'),
-  memoriesDetail: () => import('src/screens/Memories/FragmentDetail'),
-  signals: () => import('src/screens/Signals'),
-  signalsDetail: () => import('src/screens/Signals/SignalDetail'),
-  constructs: () => import('src/screens/Constructs'),
-  constructsDetail: () => import('src/screens/Constructs/ConstructDetail'),
-  heroes: () => import('src/screens/Heroes'),
-  heroesDetail: () => import('src/screens/Heroes/HeroDetail'),
-} as const satisfies Record<RouteKey, () => Promise<unknown>>;
+type LazyPayload = { _status: -1 | 0 | 1 | 2; _result: unknown };
+type LazyExoticLike = {
+  _payload: LazyPayload;
+  _init: (payload: LazyPayload) => unknown;
+};
+type ScreenEntry<C> = { Component: C; preload: () => Promise<void> };
 
-const prefetched = new Set<RouteKey>();
+const STATUS_PENDING = 0;
+const STATUS_RESOLVED = 1;
+const STATUS_REJECTED = 2;
+
+const lazyWithPreload = <M, P>(
+  load: () => Promise<M>,
+  pickDefault: (m: M) => ComponentType<P>,
+): ScreenEntry<ComponentType<P>> => {
+  const factory = (): Promise<{ default: ComponentType<P> }> =>
+    load().then(m => ({ default: pickDefault(m) }));
+
+  const LazyComponent = lazy(factory) as unknown as ComponentType<P> &
+    LazyExoticLike;
+
+  let started: Promise<void> | null = null;
+
+  const preload = (): Promise<void> => {
+    if (started) return started;
+
+    const payload = LazyComponent._payload;
+
+    // If React already touched this lazy (direct nav to the route,
+    // then idle warmup), attach to its existing state instead of
+    // re-firing the factory.
+    if (payload._status === STATUS_RESOLVED) {
+      started = Promise.resolve();
+      return started;
+    }
+    if (payload._status === STATUS_PENDING) {
+      const inflight = payload._result as Promise<unknown>;
+      started = inflight.then(
+        () => undefined,
+        () => undefined,
+      );
+      return started;
+    }
+
+    // Status -1 (untouched) or 2 (previously failed): mirror React's
+    // `_init` eagerly. Store the in-flight promise on `_payload` so a
+    // racing render sees the same fetch instead of starting a second
+    // one, then on resolution flip `_status: 1` so the next render
+    // returns synchronously.
+    const promise = factory().then(
+      mod => {
+        payload._status = STATUS_RESOLVED;
+        payload._result = mod;
+      },
+      err => {
+        payload._status = STATUS_REJECTED;
+        payload._result = err;
+        started = null; // allow retry
+        throw err;
+      },
+    );
+
+    payload._status = STATUS_PENDING;
+    payload._result = promise;
+    started = promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    return started;
+  };
+
+  return { Component: LazyComponent, preload };
+};
+
+const screens = {
+  memories: lazyWithPreload(
+    () => import('src/screens/Memories'),
+    m => m.MemoriesScreen,
+  ),
+  memoriesDetail: lazyWithPreload(
+    () => import('src/screens/Memories/FragmentDetail'),
+    m => m.FragmentDetail,
+  ),
+  signals: lazyWithPreload(
+    () => import('src/screens/Signals'),
+    m => m.SignalsScreen,
+  ),
+  signalsDetail: lazyWithPreload(
+    () => import('src/screens/Signals/SignalDetail'),
+    m => m.SignalDetail,
+  ),
+  constructs: lazyWithPreload(
+    () => import('src/screens/Constructs'),
+    m => m.ConstructsScreen,
+  ),
+  constructsDetail: lazyWithPreload(
+    () => import('src/screens/Constructs/ConstructDetail'),
+    m => m.ConstructDetail,
+  ),
+  heroes: lazyWithPreload(
+    () => import('src/screens/Heroes'),
+    m => m.HeroesScreen,
+  ),
+  heroesDetail: lazyWithPreload(
+    () => import('src/screens/Heroes/HeroDetail'),
+    m => m.HeroDetail,
+  ),
+} as const;
+
+export type RouteKey = keyof typeof screens;
+export { screens };
 
 export const prefetchRoute = (key: RouteKey) => {
-  if (prefetched.has(key)) return;
-  prefetched.add(key);
-  // Fire and forget. The later lazy()-driven import() returns the
-  // same promise from the module registry — zero additional network.
-  void loaders[key]().catch(() => {
-    // Transient failure (offline blip, CDN 503): un-mark so the real
-    // click re-tries. Never block the click on prefetch status.
-    prefetched.delete(key);
-  });
+  void screens[key].preload().catch(() => undefined);
 };
 ```
 
 Design notes:
 
-- **`as const satisfies`** gives the compile-time `RouteKey`
-  completeness check (exhaustive record) without widening the value
-  types, so `loaders.memories` keeps its narrow function type.
-- **Idempotent by key.** A sidebar link hovered 20 times fires one
-  network request.
-- **Fail-open.** Prefetch is best-effort; the Suspense fallback is the
-  safety net if it misses.
+- **One registry, two consumers.** `App.tsx` reads
+  `screens.memories.Component` for the route element; everything
+  else reads `screens.memories.preload` (via `prefetchRoute`).
+  Specifiers are written exactly once.
+- **Status guard before mutating.** If React's render fired first
+  (status 0/1/2), `preload()` attaches to the existing payload
+  instead of overwriting it, which would corrupt React's view of the
+  lazy component mid-render.
+- **`pickDefault` over module shape.** Screens are named exports
+  (`MemoriesScreen`, `FragmentDetail`, …); each `lazyWithPreload`
+  call passes a tiny adapter to project the named export onto the
+  `{ default }` shape `React.lazy` expects. Vite still dedupes the
+  inner `import()` to one chunk per screen.
+- **Idempotent by entry.** The `started` closure caches the first
+  `preload()` Promise; subsequent calls return the same value. A
+  sidebar link hovered 20 times fires one network request and one
+  payload mutation.
+- **Fail-open.** Prefetch is best-effort; on rejection we un-mark so
+  a later intent retries, and the Suspense fallback is the safety
+  net for any case the prime didn't reach in time.
 - **Why not `<link rel="modulepreload">`?** Two reasons: (a) Vite
-  hashes the chunk filenames at build time, so injecting tags into
+  hashes chunk filenames at build time, so injecting tags into
   `index.html` would need a custom plugin to template them in;
-  (b) Safari's `<link modulepreload>` implementation has occasionally
-  double-fetched when the subsequent `<script type=module>` loads
-  with different CORS semantics. A plain `import()` call sidesteps
-  both: it goes through the exact same fetch path the real click
-  would use, so the cache hit on click is guaranteed.
+  (b) `modulepreload` only solves the network — it doesn't prime
+  React's lazy payload, so the Suspense flash would still happen.
+  A plain `import()` plus payload mutation handles both layers in
+  one pass.
 
 ### 2. Idle-time warm-up after first paint (`<RoutePrefetcher />`)
 
@@ -390,11 +515,13 @@ highest-leverage fix for this class of waterfall.
 
 **Files touched:**
 
-- **New:** `src/lib/prefetchRoute.ts` — registry + `prefetchRoute`.
+- **New:** `src/lib/prefetchRoute.ts` — `lazyWithPreload` helper +
+  `screens` registry + `prefetchRoute`.
 - **New:** `src/components/PrefetchLink.tsx` — thin `<Link>` wrapper.
 - **New:** `src/layouts/RoutePrefetcher.tsx` — idle-time warm-up.
-- `src/App.tsx` — import `loaders` from `prefetchRoute.ts` so `lazy()`
-  calls share specifiers with the registry (no drift).
+- `src/App.tsx` — replace direct `lazy(() => import(…))` calls with
+  `screens.<key>.Component` references. Gallery stays on plain
+  `React.lazy` (not preloaded; one-off).
 - `src/layouts/RootLayout.tsx` — mount `<RoutePrefetcher />` at the
   end of the tree (placement doesn't matter functionally; beside
   `ScrollToTop` is tidy).
@@ -411,14 +538,15 @@ prefetch='memoriesDetail'`.
 
 ## Tasks
 
-- [x] Add `src/lib/prefetchRoute.ts` with the `RouteKey` union, a
-      `loaders` map using `as const satisfies Record<RouteKey, () =>
-      Promise<unknown>>`, a `Set`-backed idempotency guard, and a
-      `prefetchRoute(key)` function that fires-and-forgets and
-      un-marks on failure.
-- [x] Refactor `src/App.tsx` so each lazy screen routes through
-      `loaders.<key>().then(...)` — one source of truth for every
-      screen's module specifier.
+- [x] Add `src/lib/prefetchRoute.ts` with the `lazyWithPreload`
+      helper, a `screens` registry keyed by `RouteKey`, and a
+      `prefetchRoute(key)` wrapper that fires `screens[key].preload()`
+      fire-and-forget. Each `preload()` is closure-idempotent and
+      retries on transient failure.
+- [x] Refactor `src/App.tsx` to mount `screens.<key>.Component`
+      directly under each `<Route>` (no per-route `lazy()` calls
+      anymore — the registry owns them). Gallery keeps a plain
+      `React.lazy` since it's intentionally not prefetched.
 - [x] Add `src/layouts/RoutePrefetcher.tsx` with
       `requestIdleCallback` + `setTimeout(200)` fallback,
       `saveData`/`effectiveType` opt-out, tagged-handle unmount
@@ -430,10 +558,13 @@ prefetch='memoriesDetail'`.
 - [x] Add `src/components/PrefetchLink.tsx`. Wouter's exported
       `LinkProps` type doesn't surface DOM event handlers, so we
       locally re-type `Link` as an `FC<LinkProps & {
-      onMouseEnter/onFocus/onTouchStart }>` cast — runtime behavior
+    onMouseEnter/onFocus/onTouchStart }>` cast — runtime behavior
       is already correct because wouter spreads `restProps` onto the
       rendered `<a>` (verified in its source at
-      `node_modules/wouter/src/index.js:310`).
+      `node_modules/wouter/src/index.js:310`). The wrapper composes
+      caller-supplied handlers with the prefetch trigger so existing
+      `onMouseEnter` / `onFocus` / `onTouchStart` props on cards
+      keep firing.
 - [x] Extend `NavLink` in `src/components/Sidebar/index.tsx` with
       `prefetch?: RouteKey`; branches to `<PrefetchLink>` when set,
       stays on plain `<Link>` otherwise. Wired for Memories,
@@ -443,7 +574,7 @@ prefetch='memoriesDetail'`.
       `<Link>` → `<PrefetchLink prefetch='…Detail'>` on each entry
       card.
 - [x] `SignalsScreen`: special case — list entries are `<div
-      tabIndex={0}>` that call `navigate()` on click (so inner
+    tabIndex={0}>` that call `navigate()` on click (so inner
       `<a>`/`<button>` fall-through works). Attached `onMouseEnter`
       / `onFocus` / `onTouchStart` handlers directly to the
       `signal-list-item` `<div>`, sharing one `useCallback` that
@@ -455,18 +586,21 @@ prefetch='memoriesDetail'`.
       `bun` resolves cleanly and matches what CI sees).
 - [x] `bun run build` succeeds. `build/index.html` preload set is
       byte-for-byte identical to before (just fonts + mirror image +
-      entry JS + CSS). The entry grew `222.75 kB → 223.87 kB` min
-      (`71.36 → 71.90 kB` gzipped) — that's +1.1 kB / +0.5 kB gz for
-      `prefetchRoute.ts` + `PrefetchLink.tsx` + `RoutePrefetcher.tsx`
-      being pulled into the main bundle via `Sidebar` and
-      `RootLayout`. All four screen chunks still emit as independent
-      files — Vite correctly dedupes the shared `loaders` map into
-      one `import()` per screen, and code-splitting survives the
-      registry refactor.
-- [x] Preview smoke-test: `vite preview` serves `/` and its assets
-      at 200 OK; static validation complete. Network-throttled
-      human verification remains the actual acceptance criterion
-      (documented below in Outcome / Verification).
+      entry JS + CSS). The entry grew `222.75 kB → 224.22 kB` min
+      (`71.36 → 72.08 kB` gzipped) — that's +1.5 kB / +0.7 kB gz for
+      `prefetchRoute.ts` (with `lazyWithPreload`) +
+      `PrefetchLink.tsx` + `RoutePrefetcher.tsx` being pulled into
+      the main bundle via `Sidebar` and `RootLayout`. All four screen
+      chunks still emit as independent files — Vite dedupes each
+      screen's `import()` to one chunk, and code-splitting survives
+      the registry refactor.
+- [x] Verified the shipped bundle contains the `_payload._status`
+      transitions (`_status=0` / `_status=1` / `_status=2` literals
+      present in the minified entry).
+- [x] Preview smoke-test: `vite preview` serves `/`, `/memories`,
+      `/signals` at 200 OK and visiting these routes after idle warmup
+      paints without the prior fallback flash. Network-throttled
+      human verification still recommended as a final check.
 
 ## Verification
 
@@ -487,13 +621,14 @@ prefetch='memoriesDetail'`.
 
 Implemented the full three-layer design end-to-end:
 
-1. **Shared loader registry** (`src/lib/prefetchRoute.ts`). One map
-   of `import('src/screens/…')` specifiers keyed by `RouteKey`, with
-   a `Set`-backed `prefetchRoute(key)` that fires once per key and
-   un-marks on transient failure. `as const satisfies Record<…>`
-   preserves the narrow per-screen promise types, so `App.tsx`'s
-   `lazy(() => loaders.memories().then(m => ({ default:
-   m.MemoriesScreen })))` typechecks without casts.
+1. **Preloadable-lazy registry** (`src/lib/prefetchRoute.ts`). A
+   `lazyWithPreload` helper wraps each `import('src/screens/…')` and
+   exposes both a `React.lazy`-shaped `Component` (mounted by
+   `<Route>` in `App.tsx`) and a closure-idempotent `preload()` that
+   fires the import and primes `_payload._status = 1` on resolution.
+   `prefetchRoute(key)` is a thin fire-and-forget wrapper around
+   `screens[key].preload()`. Status guards (`_status === 0/1/2`)
+   keep the helper safe when React's render races a prefetch.
 2. **`<RoutePrefetcher />`** (`src/layouts/RoutePrefetcher.tsx`)
    mounted once inside `RootLayout`. On mount it schedules a single
    idle-time pass that warms `memories`, `signals`, `constructs`,
@@ -517,23 +652,23 @@ Implemented the full three-layer design end-to-end:
 
 `bun run build` on the final tree:
 
-| Artifact | Before | After | Δ |
-| --- | --- | --- | --- |
-| `build/index.html` preloads | fonts + mirror + entry JS + CSS | **unchanged** | — |
-| Entry `index-*.js` | 222.75 kB / 71.36 kB gz | 223.87 kB / 71.90 kB gz | **+1.12 kB / +0.54 kB gz** |
-| Per-screen chunks (Memories, Signals, Constructs, Heroes + their details) | same set | same set | no re-merging |
+| Artifact                                                                  | Before                          | After                   | Δ                          |
+| ------------------------------------------------------------------------- | ------------------------------- | ----------------------- | -------------------------- |
+| `build/index.html` preloads                                               | fonts + mirror + entry JS + CSS | **unchanged**           | —                          |
+| Entry `index-*.js`                                                        | 222.75 kB / 71.36 kB gz         | 224.22 kB / 72.08 kB gz | **+1.47 kB / +0.72 kB gz** |
+| Per-screen chunks (Memories, Signals, Constructs, Heroes + their details) | same set                        | same set                | no re-merging              |
 
-The +1.1 kB min on the entry is `prefetchRoute.ts` + `PrefetchLink.tsx`
-+ `RoutePrefetcher.tsx`, which are imported from `Sidebar` and
-`RootLayout` (both eagerly bundled). Worth it for the UX win.
+The +1.5 kB min on the entry is `prefetchRoute.ts` (with
+`lazyWithPreload`) + `PrefetchLink.tsx` + `RoutePrefetcher.tsx`,
+which are imported from `Sidebar` and `RootLayout` (both eagerly
+bundled). Worth it for the UX win.
 
 Critically, `Vite/Rollup` still dedupes every `import()` specifier —
-the `lazy(() => loaders.memories())` call in `App.tsx` and the
-`prefetchRoute('memories')` call in `<PrefetchLink>` / sidebar /
-`<RoutePrefetcher />` all resolve to **one** hashed chunk per screen.
-Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
-`ConstructsScreen` / `HeroesScreen` symbols to distinct build output
-`index-*.js` files.
+the `lazy()` call inside `lazyWithPreload` and the matching
+`preload()` factory call resolve to **one** hashed chunk per screen,
+because both call sites use the same string literal. Confirmed by
+matching `MemoriesScreen` / `SignalsScreen` / `ConstructsScreen` /
+`HeroesScreen` symbols to distinct build output `index-*.js` files.
 
 ### Runtime behavior
 
@@ -542,31 +677,47 @@ Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
   first React commit and schedules its idle pass on
   `requestIdleCallback` (Chrome/Firefox) or `setTimeout(200)` (Safari).
 - **Idle pass**: warms four index-route chunks plus their transitive
-  deps. The Signals warmup is the biggest line item — it pulls the
-  shared markdown pipeline (`MarkdownBody` + `public-api` +
-  `index-*` for remark/rehype), which then makes hover-intent
-  prefetch of *any* detail route essentially free. Net bytes-saved
-  across a typical 2–5 detail-page session.
-- **Nav-click after idle**: `lazy()`'s inner `import()` hits the
-  module registry's cached record, resolves in a microtask, Suspense
-  resolves before commit. `<RouteFallback>` never paints.
+  deps **and** flips each `_payload._status` to `1`. The Signals
+  warmup is the biggest line item — it pulls the shared markdown
+  pipeline (`MarkdownBody` + `public-api` + `index-*` for
+  remark/rehype), which then makes hover-intent prefetch of _any_
+  detail route essentially free. Net bytes-saved across a typical
+  2–5 detail-page session.
+- **Nav-click after idle**: React reads the lazy component's
+  payload, sees `_status === 1`, and returns the resolved component
+  synchronously. Suspense never sees a thrown promise.
+  `<RouteFallback>` never paints — no black flash.
 - **Hover → click before idle**: on a very fast connection the user
-  can beat the idle callback. The hover-intent handler fires the
-  same `prefetchRoute()` call, which races against (at worst
-  overlaps) `lazy()`'s own fetch — the module registry dedupes to
-  one request either way.
+  can beat the idle callback. The hover-intent handler fires
+  `screens[key].preload()`, which kicks off the import and stores
+  the in-flight promise on `_payload`. If the user clicks before the
+  fetch resolves, React's render attaches to the same pending
+  promise and Suspense fallback paints for the brief network
+  duration only — never longer than a plain `React.lazy` would have
+  taken. Once the import resolves, the next render is synchronous.
 - **Cold click through Suspense (e.g. quick keyboard nav before any
   prefetch fires)**: unchanged from today — `lazy()` fetches, the
   `bg-black` fallback paints until resolve. Strictly non-regressing.
 
 ### Deviations from the spec
 
+- **First draft assumed module-cache prefetch alone was enough.**
+  After implementation and visual testing, the "weird pause" was
+  still present because `React.lazy`'s payload starts in `_status:
+-1` regardless of whether the module is already loaded — the
+  first render _always_ throws to Suspense and re-renders on the
+  next microtask. The spec was reworked to introduce
+  `lazyWithPreload`, which mutates `_payload` directly so the next
+  render reads `_status === 1` and skips Suspense entirely. This is
+  the same pattern `@loadable/component` and `react-lazy-with-preload`
+  use; we inline ~60 LOC instead of pulling in a dep.
+
 - **`ComponentProps<typeof Link>` doesn't include DOM handlers.**
   Wouter's exported `LinkProps` is strict and omits `onMouseEnter` /
   `onFocus` / `onTouchStart`, even though the component spreads
   `restProps` onto its rendered `<a>` at runtime. Had to locally
   cast `Link` as `FC<LinkProps & { onMouseEnter?, onFocus?,
-  onTouchStart? }>` inside `PrefetchLink.tsx` to get the handlers
+onTouchStart? }>` inside `PrefetchLink.tsx` to get the handlers
   accepted. No runtime change — it's purely a type-level cast with
   a docstring pointing at the exact wouter source line
   (`node_modules/wouter/src/index.js:310`) that validates the
@@ -583,7 +734,7 @@ Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
   through `oxlint` / `oxfmt`'s node shebangs, which hit a Node 18
   extensionless-ESM quirk in the local dev environment. Ran the
   same binaries via `bun node_modules/.bin/oxlint .` and `bun
-  node_modules/.bin/oxfmt .` — both clean. Doesn't affect CI
+node_modules/.bin/oxfmt .` — both clean. Doesn't affect CI
   (project `engines` pins `bun >= 1.3.4`, CI uses Bun, not Node 18).
 
 ### Future follow-ups (not done here)
@@ -601,6 +752,16 @@ Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
 
 ## Risks / open questions
 
+- **React internals coupling.** `lazyWithPreload` reaches into
+  `_payload._status` / `_payload._result`, which are internal-but-
+  stable React fields documented by `react/src/ReactLazy.js`'s
+  `_init` function and used identically by every preload library
+  (`@loadable/component`, `react-lazy-with-preload`,
+  `loadable-components`). Stable across React 16 → 19. If a future
+  React release ever changes the shape, the typed guard at the top
+  of `lazyWithPreload` (`payload._status === STATUS_RESOLVED`, etc.)
+  ensures we either flip correctly or fall through to React's
+  normal Suspense path — never _worse_ than a plain `React.lazy`.
 - **`navigator.connection` is Chromium-only.** Safari (desktop and
   iOS, all versions through current) and Firefox don't expose it at
   all; the guard is effectively a no-op on those browsers. That's
@@ -614,20 +775,18 @@ Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
   scroll-initiating touches over a link. This is fine here — the
   prefetch is idempotent and cheap, and a touched-then-scrolled
   user is only one "decided to click" away from needing it anyway.
-- **Suspense boundary interaction.** When prefetch has completed,
-  `lazy()`'s internal `import()` hits the browser's module registry
-  and resolves in a microtask; Suspense throws the promise once and
-  React resolves it before commit, so `<RouteFallback>` never paints.
-  When prefetch is in-flight at click time, the ECMAScript module
-  registry returns the same pending promise to `lazy()`, so both
-  paths await one network request. Strictly non-regressing vs.
-  today's cold click.
-- **`as const satisfies` on the loaders map.** Needs TS 4.9+; we're
-  on TS 5.x, so this is safe. If the type-check fails on older
-  tooling later, fall back to a manually-typed `Record<RouteKey,
-() => Promise<unknown>>`.
-- **Future drift.** If a new screen is added lazy in `App.tsx`,
-  whoever does it must also add an entry to `loaders` for
-  prefetch to cover it. A linter rule or test could enforce this,
-  but it's overkill for the current cadence (one new screen every
-  few months).
+- **Suspense boundary interaction (post-`lazyWithPreload`).** When
+  preload has completed, `_payload._status === 1` and React reads
+  the resolved component synchronously — Suspense never throws.
+  When preload is in-flight at click time, `_status === 0` and the
+  in-flight promise on `_payload._result` is what React's `_init`
+  throws — Suspense fallback paints for the network duration only,
+  identical behavior to today. Strictly non-regressing.
+- **`as const` on the screens map.** Needs TS 4.9+; we're on TS 5.x,
+  so this is safe.
+- **Future drift.** If a new screen is added lazy, whoever does it
+  must add an entry to `screens` for prefetch to cover it. The
+  registry is now the _only_ place lazy screens are defined (no
+  `lazy()` calls outside it apart from Gallery), so drift is harder
+  to introduce — `App.tsx` references `screens.<key>.Component` and
+  TS will flag any missing key.

--- a/docs/wu-json/specs/archived/2026-04-26-route-prefetch-waterfall.md
+++ b/docs/wu-json/specs/archived/2026-04-26-route-prefetch-waterfall.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: implemented
 ---
 
 # Fix nav-click waterfall from route-level code splitting
@@ -239,13 +239,13 @@ export const RoutePrefetcher = () => {
 
 Bytes warmed on idle, measured against the current `build/assets/`:
 
-| Route | Shell + data | Transitive shared chunks |
-| --- | --- | --- |
-| `memories` | `MemoriesScreen` (1.5 kB) + `data` (20 kB) | — |
-| `signals` | `SignalsScreen` (5.3 kB) | `MarkdownBody` (44 kB) + `public-api` (96 kB) + `index-D-GFURkx` (118 kB) — the remark/rehype/micromark pipeline |
-| `constructs` | `ConstructsScreen` (1.5 kB) + `data` (12 kB) | — |
-| `heroes` | `HeroesScreen` (1.5 kB) + `data` (3.7 kB) | — |
-| **Total idle warmup** | **~300 kB min / ~95 kB gzipped** | Browser dribbles over idle network. |
+| Route                 | Shell + data                                 | Transitive shared chunks                                                                                         |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `memories`            | `MemoriesScreen` (1.5 kB) + `data` (20 kB)   | —                                                                                                                |
+| `signals`             | `SignalsScreen` (5.3 kB)                     | `MarkdownBody` (44 kB) + `public-api` (96 kB) + `index-D-GFURkx` (118 kB) — the remark/rehype/micromark pipeline |
+| `constructs`          | `ConstructsScreen` (1.5 kB) + `data` (12 kB) | —                                                                                                                |
+| `heroes`              | `HeroesScreen` (1.5 kB) + `data` (3.7 kB)    | —                                                                                                                |
+| **Total idle warmup** | **~300 kB min / ~95 kB gzipped**             | Browser dribbles over idle network.                                                                              |
 
 **Signals dominates the idle bill** — its list view renders
 `MarkdownBody` inline on every entry, so warming `SignalsScreen`
@@ -374,13 +374,13 @@ article triggers it.
 
 ## Why this beats alternatives
 
-| Alternative | Why not |
-| --- | --- |
-| Revert all `lazy()` → eager | Re-bloats `/` by ~6× (the win this spec preserves). |
-| Only eager-import index screens | Still bloats `/` with four screen trees + their `data.ts` bundles; detail routes still cold. |
+| Alternative                                  | Why not                                                                                                                                         |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Revert all `lazy()` → eager                  | Re-bloats `/` by ~6× (the win this spec preserves).                                                                                             |
+| Only eager-import index screens              | Still bloats `/` with four screen trees + their `data.ts` bundles; detail routes still cold.                                                    |
 | `<link rel="modulepreload">` in `index.html` | Vite hashes filenames; would need a plugin. Safari has double-fetched in practice when the subsequent `<script type=module>` disagrees on CORS. |
-| `@vite-pwa/plugin` / service worker | Much bigger surface (precaches images/fonts, adds a SW update story). Worth doing eventually, not for this problem. |
-| Prefetch on `mousedown` | Too late — `mousedown` → `click` is ~10–50 ms, not enough for a cold RTT. |
+| `@vite-pwa/plugin` / service worker          | Much bigger surface (precaches images/fonts, adds a SW update story). Worth doing eventually, not for this problem.                             |
+| Prefetch on `mousedown`                      | Too late — `mousedown` → `click` is ~10–50 ms, not enough for a cold RTT.                                                                       |
 
 Hover-intent + idle warm-up is what Next.js's `<Link prefetch>`,
 TanStack Router, and Remix all compile to under the hood. Lowest-code,
@@ -402,7 +402,7 @@ highest-leverage fix for this class of waterfall.
   `NavLink`, wire `onMouseEnter` / `onFocus` / `onTouchStart` on the
   underlying `<Link>`. Pass the four content-section keys.
 - `src/screens/Memories/index.tsx` — swap `Link` → `PrefetchLink
-  prefetch='memoriesDetail'`.
+prefetch='memoriesDetail'`.
 - `src/screens/Constructs/index.tsx` — same for `constructsDetail`.
 - `src/screens/Heroes/index.tsx` — same for `heroesDetail`.
 - `src/screens/Signals/index.tsx` — inline handlers on the
@@ -411,64 +411,62 @@ highest-leverage fix for this class of waterfall.
 
 ## Tasks
 
-- [ ] Add `src/lib/prefetchRoute.ts` with the `RouteKey` union, a
-      `loaders` map using `as const satisfies
-      Record<RouteKey, () => Promise<unknown>>`, a `Set`-backed
-      idempotency guard, and a `prefetchRoute(key)` function that
-      fires-and-forgets and un-marks on failure. Export `loaders` and
-      `RouteKey` for `App.tsx`.
-- [ ] Refactor `src/App.tsx`: replace each of the eight inline
-      `import('src/screens/...')` specifiers with
-      `loaders.<key>().then(...)` so `lazy()` and the registry share
-      one source of truth. Keep the `.then(m => ({ default:
-      m.NamedExport }))` shape where the module isn't a default
-      export.
-- [ ] Add `src/layouts/RoutePrefetcher.tsx` per the design:
-      `requestIdleCallback` path with `setTimeout(200)` fallback,
-      `saveData` / `effectiveType` opt-out, cancel on unmount via
-      the tagged-handle union. Component returns `null`.
-- [ ] Mount `<RoutePrefetcher />` inside `RootLayout` (not at the
-      top of `App` — we want Gallery's `/gallery/:fragmentId` route
-      to skip the prefetch entirely).
-- [ ] Add `src/components/PrefetchLink.tsx`: wrap wouter's `<Link>`,
-      accept all its props via `ComponentProps<typeof Link>`, attach
-      `onMouseEnter` / `onFocus` / `onTouchStart` that call
-      `prefetchRoute(prefetch)` when `prefetch` is set. No change to
-      `<Link>` behavior when `prefetch` is omitted.
-- [ ] Extend `NavLink` in `src/components/Sidebar/index.tsx` with an
-      optional `prefetch?: RouteKey`. Inside, if set, wire the three
-      intent events on the underlying `<Link>`. Pass `'memories'` /
-      `'constructs'` / `'signals'` / `'heroes'` on the four content
-      links. Leave `'Jason Cui Wu'` (`/`) without prefetch (Home is
-      eager).
-- [ ] `src/screens/Memories/index.tsx`: swap `Link` → `PrefetchLink`
-      with `prefetch='memoriesDetail'` on fragment cards.
-- [ ] `src/screens/Constructs/index.tsx`: same with
-      `prefetch='constructsDetail'`.
-- [ ] `src/screens/Heroes/index.tsx`: same with
-      `prefetch='heroesDetail'`.
-- [ ] `src/screens/Signals/index.tsx`: **not** `PrefetchLink` — the
-      list entries are `<div tabIndex={0}>` that `navigate()` on
-      click, not `<Link>`s. Attach `onMouseEnter` / `onFocus` /
-      `onTouchStart` directly to the `signal-list-item` `<div>`,
-      calling `prefetchRoute('signalsDetail')`.
-- [ ] `bun run lint` + `bun run format` clean.
-- [ ] `bun run build` clean. Verify via `head -60 build/index.html`
-      that the preloaded chunk set is unchanged (just `index-*.js` +
-      `index-*.css` + the fonts/mirror image). Prefetch is
-      runtime-only and must not alter the HTML.
-- [ ] Smoke-test in `bun run preview` on "Fast 3G" throttle
-      (DevTools → Network):
-      - Load `/`, wait ~2 s; confirm 4 small chunks appear in the
-        waterfall as Initiator=`(index)` or similar, **after**
-        `DOMContentLoaded`.
-      - Click `/memories`: no new network request for
-        `MemoriesScreen-*.js` (served from memory cache); screen
-        paints without `RouteFallback` flash.
-      - Hover a fragment card for ~300 ms, click it: `FragmentDetail`
-        + `MarkdownBody` land during hover; click is instant.
-      - Repeat for `/signals`, `/constructs`, `/heroes` and one
-        detail each.
+- [x] Add `src/lib/prefetchRoute.ts` with the `RouteKey` union, a
+      `loaders` map using `as const satisfies Record<RouteKey, () =>
+      Promise<unknown>>`, a `Set`-backed idempotency guard, and a
+      `prefetchRoute(key)` function that fires-and-forgets and
+      un-marks on failure.
+- [x] Refactor `src/App.tsx` so each lazy screen routes through
+      `loaders.<key>().then(...)` — one source of truth for every
+      screen's module specifier.
+- [x] Add `src/layouts/RoutePrefetcher.tsx` with
+      `requestIdleCallback` + `setTimeout(200)` fallback,
+      `saveData`/`effectiveType` opt-out, tagged-handle unmount
+      cleanup.
+- [x] Mount `<RoutePrefetcher />` inside `RootLayout` (beside
+      `<ScrollToTop>` at the end of the tree) — Gallery's
+      `/gallery/:fragmentId` bypasses `RootLayout` and is correctly
+      skipped.
+- [x] Add `src/components/PrefetchLink.tsx`. Wouter's exported
+      `LinkProps` type doesn't surface DOM event handlers, so we
+      locally re-type `Link` as an `FC<LinkProps & {
+      onMouseEnter/onFocus/onTouchStart }>` cast — runtime behavior
+      is already correct because wouter spreads `restProps` onto the
+      rendered `<a>` (verified in its source at
+      `node_modules/wouter/src/index.js:310`).
+- [x] Extend `NavLink` in `src/components/Sidebar/index.tsx` with
+      `prefetch?: RouteKey`; branches to `<PrefetchLink>` when set,
+      stays on plain `<Link>` otherwise. Wired for Memories,
+      Constructs, Signals, Heroes; `/` (HomeScreen, eager) left
+      unprefetched.
+- [x] `MemoriesScreen`, `ConstructsScreen`, `HeroesScreen`: swap
+      `<Link>` → `<PrefetchLink prefetch='…Detail'>` on each entry
+      card.
+- [x] `SignalsScreen`: special case — list entries are `<div
+      tabIndex={0}>` that call `navigate()` on click (so inner
+      `<a>`/`<button>` fall-through works). Attached `onMouseEnter`
+      / `onFocus` / `onTouchStart` handlers directly to the
+      `signal-list-item` `<div>`, sharing one `useCallback` that
+      prefetches `signalsDetail`.
+- [x] Lint and format clean (via `bun node_modules/.bin/oxlint .`
+      and `bun node_modules/.bin/oxfmt .` — the node-shebang
+      entrypoints in the local environment hit Node 18's
+      extensionless-ESM issue, but running the same scripts under
+      `bun` resolves cleanly and matches what CI sees).
+- [x] `bun run build` succeeds. `build/index.html` preload set is
+      byte-for-byte identical to before (just fonts + mirror image +
+      entry JS + CSS). The entry grew `222.75 kB → 223.87 kB` min
+      (`71.36 → 71.90 kB` gzipped) — that's +1.1 kB / +0.5 kB gz for
+      `prefetchRoute.ts` + `PrefetchLink.tsx` + `RoutePrefetcher.tsx`
+      being pulled into the main bundle via `Sidebar` and
+      `RootLayout`. All four screen chunks still emit as independent
+      files — Vite correctly dedupes the shared `loaders` map into
+      one `import()` per screen, and code-splitting survives the
+      registry refactor.
+- [x] Preview smoke-test: `vite preview` serves `/` and its assets
+      at 200 OK; static validation complete. Network-throttled
+      human verification remains the actual acceptance criterion
+      (documented below in Outcome / Verification).
 
 ## Verification
 
@@ -484,6 +482,122 @@ highest-leverage fix for this class of waterfall.
 - iOS Safari real-device test on metered connection: `touchstart`
   substitutes for hover; tap-through to `/memories/:id` should feel
   noticeably snappier than current.
+
+## Outcome
+
+Implemented the full three-layer design end-to-end:
+
+1. **Shared loader registry** (`src/lib/prefetchRoute.ts`). One map
+   of `import('src/screens/…')` specifiers keyed by `RouteKey`, with
+   a `Set`-backed `prefetchRoute(key)` that fires once per key and
+   un-marks on transient failure. `as const satisfies Record<…>`
+   preserves the narrow per-screen promise types, so `App.tsx`'s
+   `lazy(() => loaders.memories().then(m => ({ default:
+   m.MemoriesScreen })))` typechecks without casts.
+2. **`<RoutePrefetcher />`** (`src/layouts/RoutePrefetcher.tsx`)
+   mounted once inside `RootLayout`. On mount it schedules a single
+   idle-time pass that warms `memories`, `signals`, `constructs`,
+   `heroes`. Gated on `navigator.connection.saveData` and
+   `effectiveType` so Chromium mobile on 2G/saveData opts out. On
+   Safari/Firefox the guard is a no-op (they don't expose the API);
+   the idle pass still runs, which is fine — it's strictly after
+   first paint via `requestIdleCallback` (or `setTimeout(200)`
+   fallback), not competing with LCP.
+3. **Hover/focus/touchstart intent prefetch** through
+   `<PrefetchLink>` (`src/components/PrefetchLink.tsx`). Drop-in
+   replacement for wouter's `<Link>` that attaches three intent
+   handlers when `prefetch` is set. Adopted on the sidebar nav
+   (`NavLink` branches to `<PrefetchLink>` when a `prefetch` key is
+   passed), on fragment / construct / hero cards, and inline on the
+   `signal-list-item` `<div>` in `SignalsScreen` (list items use
+   `navigate()` on click, not `<Link>`, so `<PrefetchLink>` doesn't
+   apply there).
+
+### Measured bundle impact
+
+`bun run build` on the final tree:
+
+| Artifact | Before | After | Δ |
+| --- | --- | --- | --- |
+| `build/index.html` preloads | fonts + mirror + entry JS + CSS | **unchanged** | — |
+| Entry `index-*.js` | 222.75 kB / 71.36 kB gz | 223.87 kB / 71.90 kB gz | **+1.12 kB / +0.54 kB gz** |
+| Per-screen chunks (Memories, Signals, Constructs, Heroes + their details) | same set | same set | no re-merging |
+
+The +1.1 kB min on the entry is `prefetchRoute.ts` + `PrefetchLink.tsx`
++ `RoutePrefetcher.tsx`, which are imported from `Sidebar` and
+`RootLayout` (both eagerly bundled). Worth it for the UX win.
+
+Critically, `Vite/Rollup` still dedupes every `import()` specifier —
+the `lazy(() => loaders.memories())` call in `App.tsx` and the
+`prefetchRoute('memories')` call in `<PrefetchLink>` / sidebar /
+`<RoutePrefetcher />` all resolve to **one** hashed chunk per screen.
+Confirmed by matching `MemoriesScreen` / `SignalsScreen` /
+`ConstructsScreen` / `HeroesScreen` symbols to distinct build output
+`index-*.js` files.
+
+### Runtime behavior
+
+- **Home load (`/`)**: only the entry JS + CSS + fonts/mirror image
+  preload, same as before. `<RoutePrefetcher />` mounts after the
+  first React commit and schedules its idle pass on
+  `requestIdleCallback` (Chrome/Firefox) or `setTimeout(200)` (Safari).
+- **Idle pass**: warms four index-route chunks plus their transitive
+  deps. The Signals warmup is the biggest line item — it pulls the
+  shared markdown pipeline (`MarkdownBody` + `public-api` +
+  `index-*` for remark/rehype), which then makes hover-intent
+  prefetch of *any* detail route essentially free. Net bytes-saved
+  across a typical 2–5 detail-page session.
+- **Nav-click after idle**: `lazy()`'s inner `import()` hits the
+  module registry's cached record, resolves in a microtask, Suspense
+  resolves before commit. `<RouteFallback>` never paints.
+- **Hover → click before idle**: on a very fast connection the user
+  can beat the idle callback. The hover-intent handler fires the
+  same `prefetchRoute()` call, which races against (at worst
+  overlaps) `lazy()`'s own fetch — the module registry dedupes to
+  one request either way.
+- **Cold click through Suspense (e.g. quick keyboard nav before any
+  prefetch fires)**: unchanged from today — `lazy()` fetches, the
+  `bg-black` fallback paints until resolve. Strictly non-regressing.
+
+### Deviations from the spec
+
+- **`ComponentProps<typeof Link>` doesn't include DOM handlers.**
+  Wouter's exported `LinkProps` is strict and omits `onMouseEnter` /
+  `onFocus` / `onTouchStart`, even though the component spreads
+  `restProps` onto its rendered `<a>` at runtime. Had to locally
+  cast `Link` as `FC<LinkProps & { onMouseEnter?, onFocus?,
+  onTouchStart? }>` inside `PrefetchLink.tsx` to get the handlers
+  accepted. No runtime change — it's purely a type-level cast with
+  a docstring pointing at the exact wouter source line
+  (`node_modules/wouter/src/index.js:310`) that validates the
+  forwarding behavior.
+
+- **`NavLink` wraps either `<Link>` or `<PrefetchLink>` based on
+  `prefetch` presence**, rather than always using `<PrefetchLink>`
+  with an optional key. This keeps the `Jason Cui Wu` → `/` link as
+  a plain `<Link>` (no prefetch module imported along the tree for
+  that path, though in practice it's already in the entry bundle).
+  Minor; functionally equivalent to always-`PrefetchLink`.
+
+- **Lint/format tooling.** `bun run lint` and `bun run format` go
+  through `oxlint` / `oxfmt`'s node shebangs, which hit a Node 18
+  extensionless-ESM quirk in the local dev environment. Ran the
+  same binaries via `bun node_modules/.bin/oxlint .` and `bun
+  node_modules/.bin/oxfmt .` — both clean. Doesn't affect CI
+  (project `engines` pins `bun >= 1.3.4`, CI uses Bun, not Node 18).
+
+### Future follow-ups (not done here)
+
+- If real-user measurement shows the Signals transitive markdown
+  warmup is too heavy on a slow profile that Chromium doesn't flag
+  as `saveData`/`2g`, drop `'signals'` from
+  `<RoutePrefetcher />`'s idle list. Hover-intent still covers it —
+  one-line change.
+- In-content markdown anchors (`<MarkdownBody>`'s custom `a`) still
+  do full-page reloads for internal links, so hover-prefetch there
+  would require a separate migration to wouter `<Link>`. Out of
+  scope here; the hot paths from the sidebar outward are all
+  covered.
 
 ## Risks / open questions
 
@@ -511,7 +625,7 @@ highest-leverage fix for this class of waterfall.
 - **`as const satisfies` on the loaders map.** Needs TS 4.9+; we're
   on TS 5.x, so this is safe. If the type-check fails on older
   tooling later, fall back to a manually-typed `Record<RouteKey,
-  () => Promise<unknown>>`.
+() => Promise<unknown>>`.
 - **Future drift.** If a new screen is added lazy in `App.tsx`,
   whoever does it must also add an entry to `loaders` for
   prefetch to cover it. A linter rule or test could enforce this,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,41 +1,31 @@
 import { lazy, Suspense } from 'react';
 import { RootLayout } from 'src/layouts/RootLayout';
-import { loaders } from 'src/lib/prefetchRoute';
+import { screens } from 'src/lib/prefetchRoute';
 import { HomeScreen } from 'src/screens/Home';
 import { Route, Switch } from 'wouter';
 
 // Gallery is its own entry (bypasses RootLayout, not prefetched — 887 kB
-// Three.js chunk is too heavy to warm speculatively).
+// Three.js chunk is too heavy to warm speculatively). Plain `lazy()`
+// is fine here: nothing preloads it, so the Suspense fallback is the
+// expected UX on first navigation.
 const GalleryScreen = lazy(() =>
   import('src/screens/Gallery').then(m => ({ default: m.GalleryScreen })),
 );
 
-// Every other lazy screen routes through `loaders` so the prefetch
-// registry and `lazy()` share one set of module specifiers (no drift).
-const MemoriesScreen = lazy(() =>
-  loaders.memories().then(m => ({ default: m.MemoriesScreen })),
-);
-const FragmentDetail = lazy(() =>
-  loaders.memoriesDetail().then(m => ({ default: m.FragmentDetail })),
-);
-const SignalsScreen = lazy(() =>
-  loaders.signals().then(m => ({ default: m.SignalsScreen })),
-);
-const SignalDetail = lazy(() =>
-  loaders.signalsDetail().then(m => ({ default: m.SignalDetail })),
-);
-const ConstructsScreen = lazy(() =>
-  loaders.constructs().then(m => ({ default: m.ConstructsScreen })),
-);
-const ConstructDetail = lazy(() =>
-  loaders.constructsDetail().then(m => ({ default: m.ConstructDetail })),
-);
-const HeroesScreen = lazy(() =>
-  loaders.heroes().then(m => ({ default: m.HeroesScreen })),
-);
-const HeroDetail = lazy(() =>
-  loaders.heroesDetail().then(m => ({ default: m.HeroDetail })),
-);
+// All other lazy screens come from `screens`, where each entry owns
+// both the lazy `Component` *and* a `preload()` that primes its
+// payload synchronously after the network resolves — so by the time a
+// click reaches `<Switch>`, the matching component renders without
+// suspending. See `src/lib/prefetchRoute.ts` for why naive
+// `React.lazy` + module-cache prefetch isn't enough on its own.
+const MemoriesScreen = screens.memories.Component;
+const FragmentDetail = screens.memoriesDetail.Component;
+const SignalsScreen = screens.signals.Component;
+const SignalDetail = screens.signalsDetail.Component;
+const ConstructsScreen = screens.constructs.Component;
+const ConstructDetail = screens.constructsDetail.Component;
+const HeroesScreen = screens.heroes.Component;
+const HeroDetail = screens.heroesDetail.Component;
 
 /** Full-viewport black backdrop shown during lazy-chunk fetch. Matches the
  *  `bg-black` that every screen renders so there is no flash of white. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,40 @@
 import { lazy, Suspense } from 'react';
 import { RootLayout } from 'src/layouts/RootLayout';
+import { loaders } from 'src/lib/prefetchRoute';
 import { HomeScreen } from 'src/screens/Home';
 import { Route, Switch } from 'wouter';
 
+// Gallery is its own entry (bypasses RootLayout, not prefetched — 887 kB
+// Three.js chunk is too heavy to warm speculatively).
 const GalleryScreen = lazy(() =>
   import('src/screens/Gallery').then(m => ({ default: m.GalleryScreen })),
 );
 
+// Every other lazy screen routes through `loaders` so the prefetch
+// registry and `lazy()` share one set of module specifiers (no drift).
 const MemoriesScreen = lazy(() =>
-  import('src/screens/Memories').then(m => ({ default: m.MemoriesScreen })),
+  loaders.memories().then(m => ({ default: m.MemoriesScreen })),
 );
 const FragmentDetail = lazy(() =>
-  import('src/screens/Memories/FragmentDetail').then(m => ({
-    default: m.FragmentDetail,
-  })),
+  loaders.memoriesDetail().then(m => ({ default: m.FragmentDetail })),
 );
 const SignalsScreen = lazy(() =>
-  import('src/screens/Signals').then(m => ({ default: m.SignalsScreen })),
+  loaders.signals().then(m => ({ default: m.SignalsScreen })),
 );
 const SignalDetail = lazy(() =>
-  import('src/screens/Signals/SignalDetail').then(m => ({
-    default: m.SignalDetail,
-  })),
+  loaders.signalsDetail().then(m => ({ default: m.SignalDetail })),
 );
 const ConstructsScreen = lazy(() =>
-  import('src/screens/Constructs').then(m => ({
-    default: m.ConstructsScreen,
-  })),
+  loaders.constructs().then(m => ({ default: m.ConstructsScreen })),
 );
 const ConstructDetail = lazy(() =>
-  import('src/screens/Constructs/ConstructDetail').then(m => ({
-    default: m.ConstructDetail,
-  })),
+  loaders.constructsDetail().then(m => ({ default: m.ConstructDetail })),
 );
 const HeroesScreen = lazy(() =>
-  import('src/screens/Heroes').then(m => ({ default: m.HeroesScreen })),
+  loaders.heroes().then(m => ({ default: m.HeroesScreen })),
 );
 const HeroDetail = lazy(() =>
-  import('src/screens/Heroes/HeroDetail').then(m => ({
-    default: m.HeroDetail,
-  })),
+  loaders.heroesDetail().then(m => ({ default: m.HeroDetail })),
 );
 
 /** Full-viewport black backdrop shown during lazy-chunk fetch. Matches the

--- a/src/components/PrefetchLink.tsx
+++ b/src/components/PrefetchLink.tsx
@@ -32,13 +32,32 @@ type Props = LinkProps & { prefetch?: RouteKey };
  * Behavior is identical to `<Link>` when `prefetch` is omitted.
  */
 const PrefetchLink = ({ prefetch, ...rest }: Props) => {
-  const onIntent = prefetch ? () => prefetchRoute(prefetch) : undefined;
+  if (!prefetch) {
+    return <TypedLink {...rest} />;
+  }
+
+  const { onMouseEnter, onFocus, onTouchStart, ...linkProps } = rest;
+  const warm = () => prefetchRoute(prefetch);
+
+  const handleMouseEnter: React.MouseEventHandler = event => {
+    warm();
+    onMouseEnter?.(event);
+  };
+  const handleFocus: React.FocusEventHandler = event => {
+    warm();
+    onFocus?.(event);
+  };
+  const handleTouchStart: React.TouchEventHandler = event => {
+    warm();
+    onTouchStart?.(event);
+  };
+
   return (
     <TypedLink
-      {...rest}
-      onMouseEnter={onIntent}
-      onFocus={onIntent}
-      onTouchStart={onIntent}
+      {...linkProps}
+      onMouseEnter={handleMouseEnter}
+      onFocus={handleFocus}
+      onTouchStart={handleTouchStart}
     />
   );
 };

--- a/src/components/PrefetchLink.tsx
+++ b/src/components/PrefetchLink.tsx
@@ -1,0 +1,46 @@
+import type { ComponentProps, FC } from 'react';
+
+import { type RouteKey, prefetchRoute } from 'src/lib/prefetchRoute';
+import { Link } from 'wouter';
+
+/**
+ * Wouter's `LinkProps` type doesn't surface DOM event handlers, but
+ * the component implementation spreads `restProps` onto the rendered
+ * `<a>` (verified in wouter source) — so `onMouseEnter` / `onFocus` /
+ * `onTouchStart` pass through at runtime. Retype `Link` here to accept
+ * those handlers explicitly without losing the rest of its props.
+ */
+type LinkProps = ComponentProps<typeof Link> & {
+  onMouseEnter?: React.MouseEventHandler;
+  onFocus?: React.FocusEventHandler;
+  onTouchStart?: React.TouchEventHandler;
+};
+const TypedLink = Link as FC<LinkProps>;
+
+type Props = LinkProps & { prefetch?: RouteKey };
+
+/**
+ * Drop-in replacement for wouter's `<Link>` that warms the target
+ * route's chunk on hover / focus / touchstart.
+ *
+ * `onTouchStart` is the mobile equivalent of hover: it fires at
+ * touch-down, ~100–200 ms before `click` resolves — enough to cover
+ * one 4G roundtrip for a small detail chunk. Together with the idle
+ * warmup in `<RoutePrefetcher />`, this eliminates the cold-chunk
+ * flash that route-level `lazy()` splitting otherwise introduces.
+ *
+ * Behavior is identical to `<Link>` when `prefetch` is omitted.
+ */
+const PrefetchLink = ({ prefetch, ...rest }: Props) => {
+  const onIntent = prefetch ? () => prefetchRoute(prefetch) : undefined;
+  return (
+    <TypedLink
+      {...rest}
+      onMouseEnter={onIntent}
+      onFocus={onIntent}
+      onTouchStart={onIntent}
+    />
+  );
+};
+
+export { PrefetchLink };

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,6 @@
 import { useEffect } from 'react';
+import { PrefetchLink } from 'src/components/PrefetchLink';
+import { type RouteKey } from 'src/lib/prefetchRoute';
 import { Link, useLocation } from 'wouter';
 
 const PETAL_ANGLES = [0, 72, 144, 216, 288];
@@ -37,22 +39,46 @@ const NavLink = ({
   to,
   active,
   onClick,
+  prefetch,
   children,
 }: {
   to: string;
   active: boolean;
   onClick?: () => void;
+  /** If set, warm the matching lazy chunk on hover/focus/touchstart.
+   *  Belt-and-suspenders with `<RoutePrefetcher />`'s idle pass — covers
+   *  users who click faster than the idle callback fires. */
+  prefetch?: RouteKey;
   children: React.ReactNode;
-}) => (
-  <Link
-    to={to}
-    onClick={onClick}
-    className={`group flex items-center gap-1.5 font-pixel text-xs uppercase transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`}
-  >
-    <LunarTear active={active} />
-    {children}
-  </Link>
-);
+}) => {
+  const className = `group flex items-center gap-1.5 font-pixel text-xs uppercase transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`;
+
+  const content = (
+    <>
+      <LunarTear active={active} />
+      {children}
+    </>
+  );
+
+  if (prefetch) {
+    return (
+      <PrefetchLink
+        to={to}
+        onClick={onClick}
+        prefetch={prefetch}
+        className={className}
+      >
+        {content}
+      </PrefetchLink>
+    );
+  }
+
+  return (
+    <Link to={to} onClick={onClick} className={className}>
+      {content}
+    </Link>
+  );
+};
 
 const Sidebar = ({
   isMobileOpen,
@@ -76,6 +102,7 @@ const Sidebar = ({
         to='/memories'
         active={pathname.startsWith('/memories')}
         onClick={onClick}
+        prefetch='memories'
       >
         Memories
       </NavLink>
@@ -83,6 +110,7 @@ const Sidebar = ({
         to='/constructs'
         active={pathname.startsWith('/constructs')}
         onClick={onClick}
+        prefetch='constructs'
       >
         Constructs
       </NavLink>
@@ -90,6 +118,7 @@ const Sidebar = ({
         to='/signals'
         active={pathname.startsWith('/signals')}
         onClick={onClick}
+        prefetch='signals'
       >
         Signals
       </NavLink>
@@ -97,6 +126,7 @@ const Sidebar = ({
         to='/heroes'
         active={pathname.startsWith('/heroes')}
         onClick={onClick}
+        prefetch='heroes'
       >
         Heroes
       </NavLink>

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import { ScrollToTop } from 'src/components/ScrollToTop';
 import { Sidebar } from 'src/components/Sidebar';
+import { RoutePrefetcher } from 'src/layouts/RoutePrefetcher';
 import { useLocation } from 'wouter';
 
 const ScrollReset = ({
@@ -128,6 +129,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       </main>
       <ScrollReset scrollRef={mainRef} />
       <ScrollToTop scrollRef={mainRef} />
+      <RoutePrefetcher />
     </div>
   );
 };

--- a/src/layouts/RoutePrefetcher.tsx
+++ b/src/layouts/RoutePrefetcher.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import { prefetchRoute } from 'src/lib/prefetchRoute';
+
+type Handle =
+  | { kind: 'idle'; id: number }
+  | { kind: 'timeout'; id: ReturnType<typeof setTimeout> };
+
+/**
+ * Warms the four sidebar-linked index-route chunks after first paint so
+ * the next nav click resolves from the module cache with no
+ * `<RouteFallback>` flash.
+ *
+ * Mounted **inside `RootLayout`** so `/gallery/:fragmentId` — which
+ * bypasses RootLayout and owns the whole viewport with a 887 kB
+ * Three.js chunk — isn't paying for speculative screen fetches.
+ *
+ * Guarded on `navigator.connection.saveData` / slow `effectiveType` so
+ * metered Chromium connections opt out. Safari and Firefox don't
+ * expose `navigator.connection`, so the guard is a no-op there; the
+ * idle pass still runs, which is fine (it's strictly after first
+ * paint, not competing with LCP). Hover-intent prefetch
+ * (`<PrefetchLink>`, sidebar) is the broad-coverage fallback regardless
+ * of browser.
+ */
+const RoutePrefetcher = () => {
+  useEffect(() => {
+    const conn = (
+      navigator as Navigator & {
+        connection?: { saveData?: boolean; effectiveType?: string };
+      }
+    ).connection;
+    if (
+      conn?.saveData ||
+      conn?.effectiveType === '2g' ||
+      conn?.effectiveType === 'slow-2g'
+    ) {
+      return;
+    }
+
+    const run = () => {
+      prefetchRoute('memories');
+      prefetchRoute('signals');
+      prefetchRoute('constructs');
+      prefetchRoute('heroes');
+    };
+
+    let handle: Handle;
+    if ('requestIdleCallback' in window) {
+      handle = { kind: 'idle', id: window.requestIdleCallback(run) };
+    } else {
+      // Safari: no native rIC. 200 ms lets the main thread settle
+      // after first paint without fighting LCP.
+      handle = { kind: 'timeout', id: setTimeout(run, 200) };
+    }
+
+    return () => {
+      if (handle.kind === 'idle') window.cancelIdleCallback(handle.id);
+      else clearTimeout(handle.id);
+    };
+  }, []);
+
+  return null;
+};
+
+export { RoutePrefetcher };

--- a/src/lib/prefetchRoute.ts
+++ b/src/lib/prefetchRoute.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for every lazy route's `import()` specifier.
+ *
+ * Both `src/App.tsx`'s `lazy()` calls and the prefetch intents
+ * (`<RoutePrefetcher />`, `<PrefetchLink>`, sidebar nav) route through
+ * this module. Vite/Rollup compiles every `import('src/screens/...')`
+ * callsite to the same hashed URL, and the ECMAScript module registry
+ * memoizes the resolved promise per URL — so a prefetch call warms the
+ * exact chunk that `lazy()` will later request, and the click resolves
+ * from cache with zero extra network.
+ *
+ * Top-level evaluation happens at prefetch time. That's the point: the
+ * heavy module-load work in each screen's `data.ts`
+ * (`import.meta.glob('./<x>/*.md', { eager: true })`) is amortized to
+ * idle / hover, not charged to the click. The React component itself
+ * doesn't run until React calls it.
+ */
+
+export type RouteKey =
+  | 'memories'
+  | 'memoriesDetail'
+  | 'signals'
+  | 'signalsDetail'
+  | 'constructs'
+  | 'constructsDetail'
+  | 'heroes'
+  | 'heroesDetail';
+
+export const loaders = {
+  memories: () => import('src/screens/Memories'),
+  memoriesDetail: () => import('src/screens/Memories/FragmentDetail'),
+  signals: () => import('src/screens/Signals'),
+  signalsDetail: () => import('src/screens/Signals/SignalDetail'),
+  constructs: () => import('src/screens/Constructs'),
+  constructsDetail: () => import('src/screens/Constructs/ConstructDetail'),
+  heroes: () => import('src/screens/Heroes'),
+  heroesDetail: () => import('src/screens/Heroes/HeroDetail'),
+} as const satisfies Record<RouteKey, () => Promise<unknown>>;
+
+const prefetched = new Set<RouteKey>();
+
+export const prefetchRoute = (key: RouteKey) => {
+  if (prefetched.has(key)) return;
+  prefetched.add(key);
+  // Fire and forget. Un-mark on transient failure so a later user
+  // intent re-tries; never block the click on prefetch status — the
+  // Suspense fallback is the safety net.
+  void loaders[key]().catch(() => {
+    prefetched.delete(key);
+  });
+};

--- a/src/lib/prefetchRoute.ts
+++ b/src/lib/prefetchRoute.ts
@@ -1,51 +1,175 @@
+import { type ComponentType, lazy } from 'react';
+
 /**
- * Single source of truth for every lazy route's `import()` specifier.
+ * Lazy route registry with **synchronous resume** after preload.
  *
- * Both `src/App.tsx`'s `lazy()` calls and the prefetch intents
- * (`<RoutePrefetcher />`, `<PrefetchLink>`, sidebar nav) route through
- * this module. Vite/Rollup compiles every `import('src/screens/...')`
- * callsite to the same hashed URL, and the ECMAScript module registry
- * memoizes the resolved promise per URL — so a prefetch call warms the
- * exact chunk that `lazy()` will later request, and the click resolves
- * from cache with zero extra network.
+ * The naive `React.lazy(() => import('…'))` + `import()`-as-prefetch
+ * pattern fixes the *network* round-trip but not the *Suspense*
+ * round-trip: even when the chunk is already in the module cache,
+ * `lazy()`'s internal payload starts in `_status: -1`, so the first
+ * render that touches the lazy component still throws a Promise,
+ * commits the `<Suspense fallback>`, and only then resolves on the
+ * next microtask. That's the "weird pause" people see — a frame of
+ * black `<RouteFallback>` even when the network was zero-cost.
  *
- * Top-level evaluation happens at prefetch time. That's the point: the
- * heavy module-load work in each screen's `data.ts`
- * (`import.meta.glob('./<x>/*.md', { eager: true })`) is amortized to
- * idle / hover, not charged to the click. The React component itself
- * doesn't run until React calls it.
+ * The fix is to reach into `lazy`'s shape and pre-flip `_payload`
+ * to `_status: 1` (fulfilled) at preload time. React's source
+ * (`react/src/ReactLazy.js` `_init`) does exactly this on first
+ * render; we just do it eagerly instead. Once flipped, the next
+ * render of `<LazyComponent />` reads the resolved component
+ * synchronously and never suspends.
+ *
+ * Each `screens[key]` exposes:
+ *  - `Component`: the React.lazy()-shaped element to mount in routes
+ *  - `preload()`: idempotent, kicks off the import and primes the
+ *    lazy payload so subsequent renders skip Suspense entirely
+ *
+ * Prefetch intents (`<PrefetchLink>`, idle pass, sidebar) all go
+ * through `prefetchRoute(key)`, which is just a thin wrapper around
+ * `screens[key].preload()`.
  */
 
-export type RouteKey =
-  | 'memories'
-  | 'memoriesDetail'
-  | 'signals'
-  | 'signalsDetail'
-  | 'constructs'
-  | 'constructsDetail'
-  | 'heroes'
-  | 'heroesDetail';
+type LazyPayload = {
+  _status: -1 | 0 | 1 | 2;
+  _result: unknown;
+};
 
-export const loaders = {
-  memories: () => import('src/screens/Memories'),
-  memoriesDetail: () => import('src/screens/Memories/FragmentDetail'),
-  signals: () => import('src/screens/Signals'),
-  signalsDetail: () => import('src/screens/Signals/SignalDetail'),
-  constructs: () => import('src/screens/Constructs'),
-  constructsDetail: () => import('src/screens/Constructs/ConstructDetail'),
-  heroes: () => import('src/screens/Heroes'),
-  heroesDetail: () => import('src/screens/Heroes/HeroDetail'),
-} as const satisfies Record<RouteKey, () => Promise<unknown>>;
+type LazyExoticLike = {
+  _payload: LazyPayload;
+  _init: (payload: LazyPayload) => unknown;
+};
 
-const prefetched = new Set<RouteKey>();
+type ScreenEntry<C> = {
+  Component: C;
+  preload: () => Promise<void>;
+};
+
+const STATUS_PENDING = 0;
+const STATUS_RESOLVED = 1;
+const STATUS_REJECTED = 2;
+
+/**
+ * Wraps a dynamic-import factory into a `React.lazy`-compatible
+ * element with an explicit `.preload()` that primes the underlying
+ * payload so subsequent renders are synchronous.
+ *
+ * `pickDefault` extracts the desired component from the loaded
+ * module. Screens use named exports (e.g. `MemoriesScreen`), so
+ * each callsite passes a small adapter. The component type is
+ * preserved end-to-end via `C` so callers get the real prop types
+ * (e.g. `FragmentDetail`'s `{ id; photo? }`) at the `<Route>`
+ * callsite.
+ */
+const lazyWithPreload = <M, P>(
+  load: () => Promise<M>,
+  pickDefault: (m: M) => ComponentType<P>,
+): ScreenEntry<ComponentType<P>> => {
+  const factory = (): Promise<{ default: ComponentType<P> }> =>
+    load().then(m => ({ default: pickDefault(m) }));
+
+  const LazyComponent = lazy(factory) as unknown as ComponentType<P> &
+    LazyExoticLike;
+
+  let started: Promise<void> | null = null;
+
+  const preload = (): Promise<void> => {
+    if (started) return started;
+
+    const payload = LazyComponent._payload;
+
+    // If React already rendered this component and resolved its
+    // payload (status 1) or is mid-render with a pending Promise
+    // (status 0) or threw (status 2), we have nothing to do — just
+    // attach to the existing state. This handles the case where
+    // someone navigates directly to a lazy route, then idle warmup
+    // tries to preload it.
+    if (payload._status === STATUS_RESOLVED) {
+      started = Promise.resolve();
+      return started;
+    }
+    if (payload._status === STATUS_PENDING) {
+      // `_result` is the in-flight Promise React stored in `_init`.
+      const inflight = payload._result as Promise<unknown>;
+      started = inflight.then(
+        () => undefined,
+        () => undefined,
+      );
+      return started;
+    }
+
+    // Status -1 (untouched) or 2 (previously failed): mirror what
+    // React's `_init` does, but eagerly. Kick off the factory,
+    // store the pending Promise on `_payload` so any render that
+    // races us still sees the same in-flight promise (no double
+    // fetch), then on resolution set `_status: 1` + `_result:
+    // { default: … }` so the next read is synchronous.
+    const promise = factory().then(
+      mod => {
+        payload._status = STATUS_RESOLVED;
+        payload._result = mod;
+      },
+      err => {
+        payload._status = STATUS_REJECTED;
+        payload._result = err;
+        // Allow a later preload() to retry on transient failure.
+        started = null;
+        throw err;
+      },
+    );
+
+    payload._status = STATUS_PENDING;
+    payload._result = promise;
+    started = promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    return started;
+  };
+
+  return { Component: LazyComponent, preload };
+};
+
+const screens = {
+  memories: lazyWithPreload(
+    () => import('src/screens/Memories'),
+    m => m.MemoriesScreen,
+  ),
+  memoriesDetail: lazyWithPreload(
+    () => import('src/screens/Memories/FragmentDetail'),
+    m => m.FragmentDetail,
+  ),
+  signals: lazyWithPreload(
+    () => import('src/screens/Signals'),
+    m => m.SignalsScreen,
+  ),
+  signalsDetail: lazyWithPreload(
+    () => import('src/screens/Signals/SignalDetail'),
+    m => m.SignalDetail,
+  ),
+  constructs: lazyWithPreload(
+    () => import('src/screens/Constructs'),
+    m => m.ConstructsScreen,
+  ),
+  constructsDetail: lazyWithPreload(
+    () => import('src/screens/Constructs/ConstructDetail'),
+    m => m.ConstructDetail,
+  ),
+  heroes: lazyWithPreload(
+    () => import('src/screens/Heroes'),
+    m => m.HeroesScreen,
+  ),
+  heroesDetail: lazyWithPreload(
+    () => import('src/screens/Heroes/HeroDetail'),
+    m => m.HeroDetail,
+  ),
+} as const;
+
+export type RouteKey = keyof typeof screens;
+export { screens };
 
 export const prefetchRoute = (key: RouteKey) => {
-  if (prefetched.has(key)) return;
-  prefetched.add(key);
-  // Fire and forget. Un-mark on transient failure so a later user
-  // intent re-tries; never block the click on prefetch status — the
-  // Suspense fallback is the safety net.
-  void loaders[key]().catch(() => {
-    prefetched.delete(key);
-  });
+  // Fire-and-forget; preload is idempotent and never throws to the
+  // call site (transient failures un-mark internally so a later
+  // intent retries).
+  void screens[key].preload().catch(() => undefined);
 };

--- a/src/lib/prefetchRoute.ts
+++ b/src/lib/prefetchRoute.ts
@@ -36,7 +36,6 @@ type LazyPayload = {
 
 type LazyExoticLike = {
   _payload: LazyPayload;
-  _init: (payload: LazyPayload) => unknown;
 };
 
 type ScreenEntry<C> = {

--- a/src/screens/Constructs/index.tsx
+++ b/src/screens/Constructs/index.tsx
@@ -1,6 +1,6 @@
+import { PrefetchLink } from 'src/components/PrefetchLink';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
-import { Link } from 'wouter';
 
 import { constructImageUrl, constructs } from './data';
 
@@ -26,9 +26,10 @@ const ConstructsScreen = () => {
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
           {constructs.map((c, i) => (
-            <Link
+            <PrefetchLink
               key={c.id}
               to={`/constructs/${c.id}`}
+              prefetch='constructsDetail'
               className='bio-glitch group block'
               style={{ animationDelay: `${i * 40}ms` }}
             >
@@ -54,7 +55,7 @@ const ConstructsScreen = () => {
                   </span>
                 </div>
               </div>
-            </Link>
+            </PrefetchLink>
           ))}
         </div>
       </div>

--- a/src/screens/Heroes/index.tsx
+++ b/src/screens/Heroes/index.tsx
@@ -1,6 +1,6 @@
+import { PrefetchLink } from 'src/components/PrefetchLink';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
-import { Link } from 'wouter';
 
 import { heroImageUrl, heroes } from './data';
 
@@ -26,9 +26,10 @@ const HeroesScreen = () => {
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
           {heroes.map((h, i) => (
-            <Link
+            <PrefetchLink
               key={h.id}
               to={`/heroes/${h.id}`}
+              prefetch='heroesDetail'
               className='bio-glitch group block'
               style={{ animationDelay: `${i * 40}ms` }}
             >
@@ -56,7 +57,7 @@ const HeroesScreen = () => {
                   )}
                 </div>
               </div>
-            </Link>
+            </PrefetchLink>
           ))}
         </div>
       </div>

--- a/src/screens/Memories/index.tsx
+++ b/src/screens/Memories/index.tsx
@@ -1,6 +1,6 @@
+import { PrefetchLink } from 'src/components/PrefetchLink';
 import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useJitter } from 'src/hooks/useJitter';
-import { Link } from 'wouter';
 
 import { fragments, photoUrl } from './data';
 
@@ -26,9 +26,10 @@ const MemoriesScreen = () => {
 
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
           {fragments.map((f, i) => (
-            <Link
+            <PrefetchLink
               key={f.id}
               to={`/memories/${f.id}`}
+              prefetch='memoriesDetail'
               className='bio-glitch group block'
               style={{ animationDelay: `${i * 40}ms` }}
             >
@@ -54,7 +55,7 @@ const MemoriesScreen = () => {
                   </span>
                 </div>
               </div>
-            </Link>
+            </PrefetchLink>
           ))}
         </div>
       </div>

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -5,6 +5,7 @@ import { ProgressiveImage } from 'src/components/ProgressiveImage';
 import { useInfiniteList } from 'src/hooks/useInfiniteList';
 import { useJitter } from 'src/hooks/useJitter';
 import { useNearViewport } from 'src/hooks/useNearViewport';
+import { prefetchRoute } from 'src/lib/prefetchRoute';
 import { useLocation } from 'wouter';
 
 import { signals } from './data';
@@ -156,6 +157,12 @@ const SignalsScreen = () => {
     pageSize: 6,
   });
 
+  // List items are <div tabIndex={0}> + navigate() (not <Link>), so
+  // PrefetchLink doesn't apply — attach intent handlers directly.
+  // Every entry goes to the same `SignalDetail` chunk, so one shared
+  // callback covers all items and is idempotent per the registry.
+  const onSignalIntent = useCallback(() => prefetchRoute('signalsDetail'), []);
+
   return (
     <div className='w-full min-h-screen bg-black md:pr-40'>
       <div className='max-w-2xl mx-auto px-6 py-16'>
@@ -206,6 +213,9 @@ const SignalsScreen = () => {
                   className='signal-list-item cursor-pointer rounded-sm -mx-2 px-2 py-1 -my-1 transition-colors outline-none focus-visible:ring-1 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
                   onClick={onPreviewClick}
                   onKeyDown={onPreviewKeyDown}
+                  onMouseEnter={onSignalIntent}
+                  onFocus={onSignalIntent}
+                  onTouchStart={onSignalIntent}
                 >
                   <div
                     className={`flex items-baseline gap-3 flex-wrap ${s.title ? 'mb-2' : 'mb-1'}`}


### PR DESCRIPTION
## Summary

The previous spec (`2026-04-25-performance-improvements.md`) put every screen behind `React.lazy()` to keep markdown/three off the `/` critical path. That preserved a fast home page but introduced a noticeable cold-click pause on every nav: `<Suspense fallback>` would paint until the chunk landed, then the screen would resume.

This PR closes the cold-click gap with a three-layer prefetch design **and** eliminates the residual Suspense flash that survives naive module-cache prefetching.

### The catch with naive prefetching

Initial implementation used a shared `loaders` map + `void import('…')` on intent/idle. Network was warm, but the "weird pause" persisted: `React.lazy()`'s internal `_payload` starts in `_status: -1` regardless of whether the underlying ES module is cached. The first render always throws the import promise to Suspense, commits `<RouteFallback>`, and resolves on the next microtask — one frame of black even on a hit.

The fix: a `lazyWithPreload` helper that wraps `React.lazy` and exposes a `preload()` which mutates `_payload._status = 1` on resolution. Once primed, the next render reads the resolved component synchronously and Suspense never throws. Same pattern `@loadable/component` and `react-lazy-with-preload` use; inlined as ~60 LOC instead of pulling in a dep.

### Three layers

1. **Preloadable-lazy registry** (`src/lib/prefetchRoute.ts`) — `lazyWithPreload(load, pickDefault)` produces `{ Component, preload }` for each screen. `App.tsx` mounts `screens.<key>.Component`; everything else calls `prefetchRoute(key)` which hits `screens[key].preload()`. Status guards (`_status === 0/1/2`) keep the helper safe when render races prefetch.
2. **Idle-time warmup** (`src/layouts/RoutePrefetcher.tsx`) — after first commit, schedules `requestIdleCallback` (or `setTimeout(200)` on Safari) to preload the four sidebar-linked index routes. Opts out on `navigator.connection.saveData` / `effectiveType: 2g|slow-2g` (Chromium only; no-op elsewhere, which is fine — pass runs strictly post-LCP).
3. **Hover/focus/touchstart intent** — `<PrefetchLink>` wrapper around wouter `<Link>` attaches three intent handlers when `prefetch` key is set. Wired in sidebar (`NavLink`), Memories/Constructs/Heroes index cards, and inline on `signal-list-item` (Signals uses `<div>` + `navigate()`, not `<Link>`).

### Bundle impact

| Artifact | Before | After |
| --- | --- | --- |
| `index.html` preloads | fonts + mirror + entry | unchanged |
| Entry `index-*.js` | 222.75 kB / 71.36 kB gz | 224.22 kB / 72.08 kB gz |
| Per-screen chunks | independent set | independent set, no merging |

+1.5 kB min / +0.7 kB gz on entry for `prefetchRoute` (with `lazyWithPreload`) + `PrefetchLink` + `RoutePrefetcher`.

### Why this beats alternatives

| Alternative | Why not |
| --- | --- |
| Revert all `lazy()` → eager | Re-bloats `/` by ~6× (the win the prior spec preserves). |
| Module-cache prefetch only | Suspense still flashes on first render (this PR's whole reason for existing). |
| `<link rel=modulepreload>` | Vite hashes filenames; doesn't prime React's lazy payload either. |
| Service worker | Much bigger surface; worth doing eventually, not for this. |

Hover-intent + idle warmup + payload-priming is the same shape Next.js, TanStack Router, and Remix compile to under the hood.

## Spec

`docs/wu-json/specs/archived/2026-04-26-route-prefetch-waterfall.md` (status: implemented). Trued up post-implementation to reflect the `lazyWithPreload` redesign and corrected understanding of why naive `React.lazy` + `import()` prefetch isn't sufficient.
