### PR TITLE
fix: remove sidebar flower glow in light mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1027,6 +1027,13 @@ html[data-theme-flash-reset] .nav-glitch-active {
   filter: none;
 }
 
+/* Same story for the sidebar nav flower indicator: the breathing drop-shadow
+   reads as a muddy halo around the black petals on white. Kill it in light mode. */
+[data-theme='light'] .lunar-tear-active {
+  animation: none;
+  filter: none;
+}
+
 /*
  * Inline arbitrary text-shadow utilities used throughout the codebase
  * (`[text-shadow:0_0_Npx_rgba(255,255,255,…)]`). In light mode these become


### PR DESCRIPTION
## Summary
Removes the black glow animation around the sidebar flower indicator in light mode, matching the treatment already applied to the mobile menu flower.

## Commentary
The sidebar's `.lunar-tear-active` class uses a `lunar-tear-glow` animation based on `drop-shadow` filters. Like the mobile menu's `.menu-flower-glow` class, this creates a muddy dark halo around the black flower petals on a light background. Added a `[data-theme='light']` override to disable both the animation and filter, consistent with the existing mobile menu fix.