### PR TITLE
feat: smooth carousel swipe in memories lightbox

### DIFF
--- a/docs/wu-json/specs/2026-04-27-memories-mobile-swipe-feel.md
+++ b/docs/wu-json/specs/2026-04-27-memories-mobile-swipe-feel.md
@@ -1,0 +1,466 @@
+---
+status: ready
+---
+
+# Memories lightbox: smooth, satisfying mobile swipe
+
+## Goal
+
+Sliding between photos in the Memories lightbox on mobile (`Lightbox` and
+`GroupLightbox` under `src/screens/Memories/components/`) currently feels
+jittery and unsatisfying. Make it feel native — buttery 60fps drag tracking,
+a real "the next photo is over there" carousel feel, no opacity/placeholder
+flash on commit, and momentum that responds to flick velocity.
+
+The whole interaction should feel as good as Apple Photos / iOS Safari's
+native swipe. Performance is the lever, not visual redesign.
+
+## Non-goals
+
+- Redesigning the lightbox chrome (close button, counter, caption layout,
+  `[close]` styling).
+- Changing the URL-driven navigation model. The route
+  `/memories/:id/:photo?` remains the source of truth. Wouter
+  `navigate(..., { replace: true })` is still how a committed swipe records
+  itself.
+- Changing how the grid (`FragmentDetail`) builds `gridItems` /
+  `lightboxView` / `gridPreloadFiles`.
+- Pinch-to-zoom, double-tap, or any new gestures. Swipe and tap-to-close only.
+- Desktop changes. Keyboard arrows + click `<` / `>` keep working unchanged.
+- The Gallery (Three.js) screen.
+
+## Why it feels bad today
+
+`src/screens/Memories/components/useSwipe.ts` and the two lightbox shells
+have several compounding issues. From most to least impactful:
+
+1. **State-driven drag.** Every `touchmove` calls `setOffsetX(dx)`, which
+   re-renders the entire lightbox tree (`Lightbox` or `GroupLightbox`,
+   including `react-markdown` for the caption) ~60 times per second on a
+   live finger drag. On an iPhone this is the dominant cost — the
+   transform itself is cheap, the React reconciliation is not.
+2. **Listener thrash.** `useSwipe`'s `useEffect` registering
+   `touchstart/move/end` has **no dependency array**, so it re-runs on
+   every render. During a drag, every `setOffsetX` re-render tears down
+   and re-adds three event listeners. This is gross enough on its own to
+   cause visible hitching on Safari.
+3. **No carousel track.** Only the *current* photo translates. When the
+   swipe commits, the photo snaps back to `translateX(0)` *while* the
+   route changes and the new photo's `<img>` mounts. The user sees the
+   old image animate back to center, then a different image abruptly
+   replace it — no sense of "moving through" anything.
+4. **Placeholder + opacity flash on every swipe.** `Lightbox` has
+   `useEffect(() => setLoaded(false), [photo.file])`. Even when the
+   neighbor was preloaded via `new Image()`, the new `<img>` element
+   mounts with `opacity-0`, the blurred placeholder shows, `onLoad`
+   fires, and a 500ms opacity fade runs. After every swipe. So the
+   sequence of images feels like a slideshow of fades, not a slide.
+5. **`new Image()` preloading isn't decoded.** `preloadFiles` kicks off
+   network fetches with `fetchPriority='low'`, but the bitmap isn't
+   decoded until the real `<img>` enters the DOM, which on mobile can
+   add 20–80ms of decode latency at the moment of swipe commit — right
+   when the eye is most sensitive.
+6. **`touchmove` handler is non-passive and calls `preventDefault()`.**
+   Necessary for axis locking, but combined with the per-frame React
+   render it's expensive. Browser scroll/compositor work serializes
+   behind our handler.
+7. **Transform applied on a complex subtree.** The translated element
+   wraps the image *and* the captioned counter row (with `signal-prose`
+   markdown). The caption is not what should be moving; pinning it to
+   the photo means more layer area to repaint each frame and a heavier
+   compositing path.
+
+## Design
+
+Keep the wouter-driven route model. Replace the swipe internals so that:
+
+- Drag tracking happens entirely on the DOM, not in React state.
+- A 3-cell horizontal track renders prev / current / next at all times,
+  so the next photo is already painted before the user even starts to
+  swipe. Sliding feels physical because the next image is *literally
+  there*.
+- The "loaded" state survives across photo changes for any image whose
+  bitmap has already been decoded, eliminating the placeholder flash on
+  warm neighbors.
+- Velocity-based easing replaces the fixed 300ms `cubic-bezier(0.2,0,0,1)`
+  snap.
+
+### 1. New `useSwipe` — DOM-driven carousel hook
+
+Rewrite `src/screens/Memories/components/useSwipe.ts` (keep the file
+name; export shape changes).
+
+**Coordinate system.** All math is in **pixels** relative to the
+gesture surface's `getBoundingClientRect().width`, captured on
+`pointerdown` and stored on a ref (`cellWidthRef`). No `vw`, no
+`window.innerWidth`. The track's resting position is
+`translate3d(-cellWidth, 0, 0)` so the center cell is on screen.
+
+**Transform ownership.** The hook is the *only* writer of
+`trackRef.current.style.transform` and
+`trackRef.current.style.transition`. Lightbox components must not pass
+an inline `transform` style on the track element — otherwise React
+re-renders during the drag (e.g. unrelated parent state changes) would
+clobber the hook's writes. The default resting position is set by the
+hook in a `useLayoutEffect` when `trackRef` is attached, and re-applied
+after every commit reset.
+
+**Events.**
+
+- Switch from manual `touchstart/touchmove/touchend` to **Pointer
+  Events** (`pointerdown` / `pointermove` / `pointerup` /
+  `pointercancel`). Mouse and touch share one path; cancellation is
+  cleaner.
+- Set `touch-action: pan-y` on the gesture surface so the browser
+  hands us horizontal gestures and continues to own vertical scroll.
+  Removes the need for non-passive `preventDefault()` on every move.
+- Keep the existing axis-lock threshold (10px, |dx| vs |dy|) before
+  engaging horizontal drag.
+- Call `setPointerCapture(e.pointerId)` **only after** the axis lock
+  resolves to `'h'` — never on `pointerdown`. This is critical: the
+  close button, `<`, `>` and (in `GroupLightbox`) per-photo
+  drill-in buttons all live inside the gesture surface. Capturing on
+  `pointerdown` would re-target their `click` events to the gesture
+  surface and break tap-to-close / tap-to-zoom. Capturing after
+  axis-lock means a tap (which never crosses the 10px threshold)
+  flows to the real target's `click` handler unchanged.
+- After a horizontal-locked gesture ends, set a `consumedClickRef`
+  flag that suppresses the immediate trailing `click` (some browsers
+  fire one even with capture). The flag is consumed by a single
+  capture-phase `click` listener attached on the gesture surface that
+  calls `e.stopPropagation()` + `e.preventDefault()` once. This
+  protects `GroupLightbox`'s per-photo `onPhotoClick` from firing
+  after a horizontal swipe.
+
+**Render avoidance.**
+
+- **No React state for the live offset.** Track current `dx` in a ref.
+  In `pointermove`, schedule a single `requestAnimationFrame`
+  (deduped via a ref flag) that writes
+  `transform: translate3d(${-cellWidth + dx}px, 0, 0)` directly to
+  the DOM. Coalesces multi-event frames.
+- React state is reduced to `phase: 'idle' | 'committing'`.
+  `'committing'` triggers a `useEffect` that applies the easing
+  transition + reads `transitionend`; on completion, the hook fires
+  the appropriate `onCommitPrev` / `onCommitNext` callback, then
+  resets `style.transition = 'none'` and
+  `style.transform = 'translate3d(${-cellWidth}px, 0, 0)'`, then sets
+  `phase` back to `'idle'`. The next React render of the parent has
+  already swapped the photo props, so the formerly-neighbor cell is
+  now the center cell with the same bitmap.
+- Fall back to a `setTimeout(duration + 50)` in case `transitionend`
+  doesn't fire (rare on Safari but cheap insurance).
+
+**Effect bindings.**
+
+- Bind pointer listeners exactly once per mounted node via a
+  `useLayoutEffect` keyed on the ref-attached node (not on offset
+  state). The current bug — `useEffect` with no deps array tearing
+  down listeners every render — must not return.
+
+**Velocity-based commit duration.** See §6.
+
+**Public API.**
+
+```ts
+const { surfaceRef, trackRef, phase } = useSwipe({
+  hasPrev: boolean,
+  hasNext: boolean,
+  onCommitPrev: () => void,
+  onCommitNext: () => void,
+});
+```
+
+- `surfaceRef` → the full-screen overlay (the `touch-action: pan-y`
+  gesture area).
+- `trackRef` → the 3-cell horizontal strip the hook translates.
+- `phase` is exposed mostly for diagnostics / disabling controls
+  during the brief commit animation; lightbox components don't need
+  to read it for layout.
+
+### 2. Carousel track in `Lightbox`
+
+Today `Lightbox` renders one `<img>` plus its placeholder, sized by
+viewport. Move to a 3-cell track:
+
+```
+  [ prev cell ][ center cell ][ next cell ]
+   -cellWidth        0          +cellWidth
+```
+
+- Layout: track is `position: absolute; inset: 0; display: flex;
+  width: 300%`. Each cell is `flex: 0 0 33.3333%` (= one viewport /
+  surface width). The track is translated by `-cellWidth` so the
+  center cell occupies the visible area.
+- **Cells are keyed by position**, not by photo file:
+  ```tsx
+  <Cell key="prev"   photo={neighbors.prev} />
+  <Cell key="center" photo={photo} />
+  <Cell key="next"   photo={neighbors.next} />
+  ```
+  This is what makes the post-commit reset flicker-free: after
+  committing a swipe-left, the React update swaps `photo` to what was
+  in `neighbors.next`, which means the *center cell's* `<img>` `src`
+  changes to that file. The hook simultaneously resets the track from
+  `-2*cellWidth` back to `-cellWidth`. The pixel content under the
+  user's eye doesn't change. If we keyed by file, React would unmount
+  and remount cells around the swap and the bitmap would briefly
+  blank.
+- On commit:
+  - Hook animates the track to `0` (prev) or `-2*cellWidth` (next)
+    with the velocity-based duration.
+  - On `transitionend` (or the `setTimeout` fallback), hook calls
+    `onCommitPrev` / `onCommitNext`, which invokes
+    `navigate('/memories/:id/:newPhoto', { replace: true })`.
+  - Hook then writes `transition: none; transform: translate3d(-cellWidth, 0, 0)`
+    in the same task. The next React render flushes the new `photo`
+    prop into the center cell. No flicker.
+- The `prev` and `next` cells only render an image if the matching
+  neighbor exists. Boundary edges (no neighbor) leave that cell
+  empty; the rubber-band dampening in §7 still gives the user the
+  edge feel.
+- The caption / counter row stays **outside** the translated track,
+  pinned at the bottom of the overlay. It updates instantly on
+  navigation. Removing it from the moving subtree:
+  - Eliminates `react-markdown` re-rendering during a drag (it only
+    re-renders on commit, when the photo prop actually changes).
+  - Shrinks the GPU layer that recomposites on every frame.
+
+`FragmentDetail` keeps computing `lightboxView` and passing the right
+photo. The neighbor photos for the track come from a new prop:
+
+```ts
+type LightboxNeighbors = {
+  prev: PhotoMeta | null;
+  next: PhotoMeta | null;
+};
+```
+
+`neighbors` is computed in `FragmentDetail` from the existing
+`gridItems` / `groupPhotos` logic so we don't duplicate ordering
+rules. Three cases mirror the existing `lightboxView`:
+
+- **Solo photo** (no `fromGroup`): prev/next come from the prev/next
+  `gridItems` entry. If that entry is a group, its first photo is the
+  preview cell content (matches what the current swipe lands on after
+  navigation: a group cover, which then opens via `GroupLightbox`).
+- **Photo inside a group** (`fromGroup` set): prev/next come from
+  *within* `groupPhotos`. Boundaries return `null` — swiping past
+  the first/last photo in a group does **not** drill out to the
+  group cover. This preserves today's behavior
+  (`Lightbox.onPrev = null` at group boundaries).
+- **Group cover** (`GroupLightbox`): prev/next come from the
+  prev/next `gridItems` entry, same as solo case.
+
+The `preloadFiles` array (distance 2–3) keeps doing what it does
+today but routes through the new `warmImage()` cache (§4) so warm
+state persists across photo changes.
+
+### 3. `GroupLightbox` track
+
+Same pattern. The "cell" for a group is the existing
+`isAlwaysColumn` / `shouldStack` / `isAlwaysRow` flex container. The
+track holds three group-cells (prev / center / next) where each
+existing/missing cell is determined by neighbors in `gridItems`.
+
+Tap-to-zoom on a group photo (`onPhotoClick`) is preserved via the
+`consumedClickRef` mechanism described in §1 — the capture-phase
+`click` interceptor on the gesture surface eats the trailing click
+after any horizontal-locked gesture, so taps that never crossed the
+10px axis-lock threshold reach the per-photo button's `onClick` as
+today.
+
+### 4. Warm-image cache → no placeholder flash
+
+Add a tiny module-level cache in
+`src/screens/Memories/components/imageCache.ts`:
+
+```ts
+const decoded = new Set<string>();
+
+export function warmImage(src: string): Promise<void> {
+  if (decoded.has(src)) return Promise.resolve();
+  const img = new Image();
+  img.src = src;
+  return img.decode().then(
+    () => { decoded.add(src); },
+    () => { /* swallow; will retry on real mount */ },
+  );
+}
+
+export function isWarm(src: string): boolean {
+  return decoded.has(src);
+}
+```
+
+- Replace the current `for (const file of preloadFiles) { new Image()... }`
+  effect with `warmImage(photoUrl(...))` calls. Decoded bitmaps stay
+  hot in browser memory; the `Set` is our hint about which ones we know
+  have finished `.decode()`.
+- In `Lightbox`, replace the `[loaded, setLoaded] = useState(false)` +
+  `setLoaded(false)` on photo change with:
+
+  ```ts
+  const fullSrc = photoUrl(fragmentId, photo.file, 'full');
+  const [loaded, setLoaded] = useState(() => isWarm(fullSrc));
+  useEffect(() => {
+    setLoaded(isWarm(fullSrc));
+  }, [fullSrc]);
+  ```
+
+  Plus an `onLoad` that flips `loaded` true and adds the src to
+  `decoded` (covers the cold case).
+- Net effect: when a user swipes through neighbors that we've already
+  preloaded + decoded, the new center cell is `opacity: 1` from the
+  first frame. No 500ms fade, no blurred placeholder peek. Cold
+  far-away photos still get the existing fade, which is correct.
+
+`GroupLightbox`'s `loadedSet` becomes the same pattern keyed per-photo
+file.
+
+### 5. CSS + GPU hints
+
+- Add `will-change: transform` and `transform: translateZ(0)` on the
+  track element to keep it on its own compositor layer.
+- Add `touch-action: pan-y` to the swipe surface.
+- Add `user-select: none; -webkit-user-select: none;` on the track to
+  avoid iOS text-selection callouts during drag.
+- Add `-webkit-tap-highlight-color: transparent;` on the overlay to
+  kill the flash on tap.
+
+### 6. Velocity easing details
+
+In the new hook's commit path:
+
+```ts
+const velocity = Math.abs(dx) / Math.max(1, elapsed); // px/ms
+const triggered = Math.abs(dx) > 60 || velocity > 0.3; // start with current thresholds
+const remaining = triggered ? cellWidth - Math.abs(dx) : Math.abs(dx);
+const duration = clamp(remaining / Math.max(velocity, 0.5), 180, 360);
+```
+
+So a hard flick lands in ~180ms, a slow controlled drag in ~360ms, and
+a half-hearted partial drag snaps back proportionally. Easing curve
+`cubic-bezier(0.2, 0.8, 0.2, 1)` for both commit and snap-back.
+
+**Threshold caveat.** The 60px / 0.3 px·ms thresholds were tuned for
+the old "snap back, then jump" model. With the carousel track, the
+user sees the next image during the drag, which may shift their
+intuition about when a swipe "counts." Keep the current values for
+the initial implementation to minimize variance, then adjust if the
+final feel suggests it. Any tuning lives in this hook only.
+
+### 7. Boundary rubber-banding
+
+Keep current behavior: at boundary, scale `dx` by `0.2`. With the new
+track this means the prev (or next) cell isn't there, but the current
+cell still resists past zero with the same dampening so users feel the
+edge.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/screens/Memories/components/useSwipe.ts` | Rewrite. Pointer Events, ref-driven transform, rAF throttle, velocity easing, fixed effect deps, click suppression. New return shape (`surfaceRef`, `trackRef`, `phase`). |
+| `src/screens/Memories/components/Lightbox.tsx` | Render 3-cell track keyed by position. Move caption/counter outside track. Use warm-image cache for `loaded`. Wire `surfaceRef` + `trackRef`. Accept new `neighbors` prop. |
+| `src/screens/Memories/components/GroupLightbox.tsx` | Same 3-cell track pattern with group-cell content. Same warm cache integration for `loadedSet`. Accept new `neighbors` prop (neighbor `gridItems` entries). |
+| `src/screens/Memories/components/imageCache.ts` | New. `warmImage` + `isWarm` over `img.decode()`. |
+| `src/screens/Memories/FragmentDetail.tsx` | Compute `neighbors` for each `lightboxView` case (solo, in-group, group cover) using existing `gridItems` / `groupPhotos`. Pass to lightbox. Keep `preloadFiles` for distance-2/3 warming via the new cache. |
+| `src/index.css` (or scoped Tailwind classes) | `.memories-track { will-change: transform; transform: translateZ(0); user-select: none; }` and `.memories-swipe-surface { touch-action: pan-y; -webkit-tap-highlight-color: transparent; }`. |
+
+No content/data changes. No route changes. No other screens touched.
+
+## Implementation order
+
+Do the rip in this order so each step lands in a working state:
+
+1. **`imageCache.ts`** — drop-in. Replace existing `new Image()` loops
+   in both lightboxes with `warmImage(photoUrl(...))` calls and update
+   `loaded` initial state to `isWarm(...)`. Verify warm swipes lose the
+   placeholder fade. (No swipe changes yet.)
+2. **`useSwipe.ts` rewrite** — Pointer Events, ref-driven transform,
+   rAF, velocity easing, fixed effect deps, click suppression. Keep the
+   *single*-cell visual model for now (hook translates the existing
+   image element). Validate drag is buttery and click handlers still
+   fire. This isolates the perf win from the carousel rework.
+3. **Carousel track in `Lightbox`** — introduce 3-cell layout, wire
+   `neighbors` prop from `FragmentDetail`, move caption out of the
+   translated subtree, hand `trackRef` to the hook, implement the
+   `transitionend` → navigate → reset cycle.
+4. **Carousel track in `GroupLightbox`** — mirror step 3 with
+   group-cell content; verify tap-to-zoom still works after a
+   horizontal-locked gesture.
+5. **CSS hints** — add `.memories-track` and `.memories-swipe-surface`
+   rules.
+6. **Lint/format** — `bun run lint && bun run format`.
+
+Each step is independently shippable; if step 3 reveals a layout
+problem we can pause without losing the perf win from steps 1–2.
+
+## Acceptance criteria
+
+Manually on an iPhone (Safari) and on a desktop Chrome touch-emulation:
+
+1. **Drag tracking is 1:1 and smooth.** Finger position and image
+   position never desync visibly during a horizontal drag. No frame
+   drops in a Safari Web Inspector timeline during a 1-second drag.
+2. **Neighbor visible during drag.** As the current photo slides away,
+   the previous or next photo slides in from the edge in lock-step.
+   Boundary edges (no neighbor) rubber-band as today.
+3. **No placeholder flash on warm swipes.** After a fragment has been
+   open for >1s (preload settled), every prev/next swipe lands on a
+   fully-rendered next image with no blur frame and no opacity fade.
+4. **Velocity respects intent.** A quick flick commits in ~180ms; a
+   slow controlled push in ~360ms; a partial drag below threshold
+   snaps back proportionally. The 60px / 0.3 px-ms thresholds remain.
+5. **No listener churn.** A `getEventListeners`-style spot check (or
+   adding a temporary `console.log` in dev) confirms `pointerdown` /
+   `pointermove` / `pointerup` are bound exactly once per mount.
+6. **Group lightbox parity.** Same smoothness when paging through
+   group cells; tap-to-zoom on a group photo still navigates to that
+   photo and is not consumed by the swipe handler.
+7. **Keyboard arrows + close button still work.** Esc closes; Arrow
+   keys page; click outside the photo closes.
+8. **No regressions in routing.** Sharable URLs
+   (`/memories/:id/:photo`) still reflect the visible photo after every
+   commit.
+9. **Lint + format clean.** `bun run lint` and `bun run format` pass.
+
+## Risks / open questions
+
+- **Pointer Events on older iOS Safari.** Pointer Events are supported
+  on iOS 13+, which is fine for this site's audience. If we hit a
+  real device that needs touch fallback we can add one to the hook;
+  punt for now.
+- **`img.decode()` rejection on cancelled loads.** Swallowed; the real
+  `<img>` mount will retry and call `setLoaded(true)` from `onLoad`.
+  The cache only marks an entry warm on resolved decode, never on
+  rejection.
+- **First-open cold neighbors.** The very first time a lightbox opens
+  on a fragment, neighbor cells haven't been preloaded. A swipe in
+  the next 100–300ms may briefly show a blurred placeholder in the
+  arriving cell while its `<img>` finishes fetching. After the
+  initial `preloadFiles` batch lands (distance 2–3), every subsequent
+  swipe is warm. Acceptable; matches what would happen on any real
+  network.
+- **Large captions causing reflow when pulled out of the track.** The
+  caption row is `position: absolute; bottom: …` so its height changes
+  don't push the photo around. Visually almost identical to today.
+- **Cross-fragment navigation.** Out of scope; we don't swipe across
+  fragments, only within one fragment's `gridItems` / group.
+- **3-cell mount cost.** Mounting two extra `<img>` elements per
+  lightbox open is the price for the carousel feel. They're already
+  being preloaded for `preloadFiles`; making them DOM-resident lets
+  the browser keep them painted. Acceptable.
+- **iOS rubber-band of the page.** `Lightbox` already sets
+  `document.body.style.overflow = 'hidden'` while open, so vertical
+  pan within the lightbox does nothing visible. Combined with
+  `touch-action: pan-y` on the gesture surface (which yields vertical
+  pans to the browser), this is the right default. No change needed.
+
+## Out-of-scope follow-ups (do not do in this spec)
+
+- Adding pinch-to-zoom inside a single photo.
+- Cross-fragment swipe (swipe past last photo → next fragment).
+- Replacing wouter's `replace: true` URL updates with a non-routing
+  in-memory model. Probably correct long term but invasive.

--- a/docs/wu-json/specs/archived/2026-04-27-memories-mobile-swipe-feel.md
+++ b/docs/wu-json/specs/archived/2026-04-27-memories-mobile-swipe-feel.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: implemented
 ---
 
 # Memories lightbox: smooth, satisfying mobile swipe
@@ -457,6 +457,18 @@ Manually on an iPhone (Safari) and on a desktop Chrome touch-emulation:
   pan within the lightbox does nothing visible. Combined with
   `touch-action: pan-y` on the gesture surface (which yields vertical
   pans to the browser), this is the right default. No change needed.
+
+## Implementation notes
+
+Deltas from the design that came up during the rip:
+
+- **Extracted `PhotoCell` into its own file** (`src/screens/Memories/components/PhotoCell.tsx`) so both `Lightbox` (all three cells) and `GroupLightbox` (prev/next cells) share one warm-cache-aware photo renderer. The center cell of `GroupLightbox` is its own `GroupCell` since it lays out multiple photos.
+- **`imageCache.ts` exports a third helper, `markWarm(src)`**, called from each `<img onLoad>` so cold loads also populate the warm set without a second decode pass.
+- **`useSwipe` mirrors `phase` into a `phaseRef`** so the `ResizeObserver` callback's closure can read the live phase without re-running the effect on every commit. Resetting the resting transform mid-commit-animation would cancel the transition and snap the track to `-W` with the wrong bitmap visible; the ref-based check avoids it.
+- **`consumedClickRef` is cleared on a `setTimeout(350ms)`** in addition to the click-capture handler. Some browsers don't fire a trailing `click` after a captured horizontal-locked gesture (especially if the displacement was small); without the timeout the flag would persist and eat the next unrelated click.
+- **`lightboxNeighbors` `useMemo` sits after the early `if (!fragment) return ...`** in `FragmentDetail.tsx`, matching the pre-existing `gridPreloadFiles` pattern. The project's oxlint config does not enable the `react-hooks` plugin, so this passes lint as-is.
+- **Caption row** is rendered as `position: absolute; bottom: 1rem` with `pointer-events-none` on the wrapper and `pointer-events-auto` on the inner content row so the swipe surface receives gestures over the caption strip but the caption text remains selectable / link-clickable. Visually nearly identical to the previous flex-column layout for typical photo aspect ratios.
+- **The implementation rips all six steps in one branch** (`feat/memories-swipe-feel`). The step boundaries in the original plan still hold as logical reasoning seams, but each was small enough that splitting commits would have added more rebase cost than safety.
 
 ## Out-of-scope follow-ups (do not do in this spec)
 

--- a/src/index.css
+++ b/src/index.css
@@ -1079,3 +1079,43 @@ html[data-theme-flash-reset] .nav-glitch-active {
   0\.3\)\]:is(:where(.group):hover *) {
   text-shadow: none;
 }
+
+/*
+ * Memories lightbox carousel.
+ *
+ * `memories-swipe-surface` is the gesture-receiving overlay; it owns
+ * `touch-action: pan-y` so the browser hands us horizontal gestures and
+ * keeps vertical pans for itself, which means our pointermove handler
+ * never has to call `preventDefault()` to stay friendly to the scroll
+ * compositor. The transparent tap highlight kills iOS Safari's blue
+ * flash on tap.
+ *
+ * `memories-track` is the 3-cell horizontal strip the swipe hook
+ * translates. `will-change: transform` plus `translateZ(0)` promote it
+ * to its own compositor layer so dragging only repaints the layer's
+ * transform, not the underlying photo bitmap. `user-select: none`
+ * suppresses the iOS text-selection callout that fires on long-press
+ * of an image during a slow drag.
+ *
+ * Each `memories-track-cell` is exactly one viewport / surface width
+ * (the track is `width: 300%` containing three cells), so a center
+ * cell at translate `-cellWidth` lands the photo flush with the
+ * surface bounds.
+ */
+.memories-swipe-surface {
+  touch-action: pan-y;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.memories-track {
+  will-change: transform;
+  transform: translateZ(0);
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.memories-track-cell {
+  flex: 0 0 33.3333%;
+  width: 33.3333%;
+  height: 100%;
+}

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -85,6 +85,19 @@ function filesFromGridItem(item: GridItem): string[] {
 }
 
 /**
+ * Cover photo for a grid item: the photo itself for solos, the first
+ * photo for groups. Used as the prev/next cell content in the
+ * lightbox carousel — when the destination is a group the user sees
+ * its first photo during the slide and (on commit) the route flips
+ * to `GroupLightbox` which reveals the full group layout. Same
+ * concession on the `GroupLightbox` side: its prev/next cells also
+ * hold cover photos.
+ */
+function coverOf(item: GridItem): PhotoMeta {
+  return item.kind === 'solo' ? item.photo : item.photos[0];
+}
+
+/**
  * Occlusion-cull a masonry tile. Renders `children` when within (or near) the
  * viewport, and a same-sized `<div>` placeholder otherwise — preserves the
  * `columns-*` masonry flow either way because the wrapper keeps its classes
@@ -326,6 +339,45 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
     return files;
   }, [lightboxView, gridItems]);
 
+  // Neighbors shown in the carousel's prev / next cells. Mirrors the
+  // ordering rules used by `onPrev`/`onNext` below so the slide
+  // direction lands on the right destination.
+  const lightboxNeighbors = useMemo(() => {
+    if (!lightboxView) return { prev: null, next: null };
+    const total = gridItems.length;
+    if (lightboxView.kind === 'group') {
+      if (total <= 1) return { prev: null, next: null };
+      const gi = lightboxView.gridIndex;
+      return {
+        prev: coverOf(gridItems[(gi - 1 + total) % total]),
+        next: coverOf(gridItems[(gi + 1) % total]),
+      };
+    }
+    // photo
+    const {
+      gridIndex,
+      fromGroup,
+      indexInGroup,
+      groupPhotos: gPhotos,
+    } = lightboxView;
+    if (fromGroup && gPhotos && indexInGroup !== undefined) {
+      // Intra-group navigation. Boundaries return null — swiping past
+      // the first/last photo of a group does not drill out to the
+      // group cover (preserves the existing `Lightbox.onPrev = null`
+      // boundary behavior).
+      return {
+        prev: indexInGroup > 0 ? gPhotos[indexInGroup - 1] : null,
+        next:
+          indexInGroup < gPhotos.length - 1 ? gPhotos[indexInGroup + 1] : null,
+      };
+    }
+    if (total <= 1) return { prev: null, next: null };
+    return {
+      prev: coverOf(gridItems[(gridIndex - 1 + total) % total]),
+      next: coverOf(gridItems[(gridIndex + 1) % total]),
+    };
+  }, [lightboxView, gridItems]);
+
   let lightboxElement: React.ReactNode = null;
 
   if (lightboxView?.kind === 'group') {
@@ -356,6 +408,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
           onPhotoClick={p =>
             navigate(`/memories/${id}/${p.file}`, { replace: true })
           }
+          neighbors={lightboxNeighbors}
           preloadFiles={gridPreloadFiles}
         />
       );
@@ -397,6 +450,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
               ? () => navigate(`/memories/${id}/${nextFile}`, { replace: true })
               : null
           }
+          neighbors={lightboxNeighbors}
           preloadFiles={[...preload, ...gridPreloadFiles]}
         />
       );
@@ -420,6 +474,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
               ? () => navigateToGridItem((gridIndex + 1) % gridItems.length)
               : null
           }
+          neighbors={lightboxNeighbors}
           preloadFiles={gridPreloadFiles}
         />
       );

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -295,36 +295,6 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
     return null;
   }, [photo, fragment, gridItems]);
 
-  const navigateToGridItem = (gi: number) => {
-    const item = gridItems[gi];
-    if (item.kind === 'group') {
-      navigate(`/memories/${id}/${item.groupId}`, { replace: true });
-    } else {
-      navigate(`/memories/${id}/${item.photo.file}`, { replace: true });
-    }
-  };
-
-  if (!fragment) {
-    return (
-      <div className='w-full min-h-screen bg-black flex items-center justify-center md:pr-40'>
-        <div className='flex flex-col items-center gap-3'>
-          <h1 className='bio-glitch text-white text-2xl font-pixel'>
-            FRAGMENT LOST
-          </h1>
-          <p className='bio-glitch text-white/30 text-xs font-mono'>
-            {'// memory not found in archive'}
-          </p>
-          <Link
-            to='/memories'
-            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
-          >
-            {'< return to memories'}
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
   const gridPreloadFiles = useMemo(() => {
     if (!lightboxView) return [];
     const gi = lightboxView.gridIndex;
@@ -377,6 +347,41 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
       next: coverOf(gridItems[(gridIndex + 1) % total]),
     };
   }, [lightboxView, gridItems]);
+
+  // Early return must come *after* every hook call above so the hook
+  // count is stable across render paths (Rules of Hooks). Today this
+  // only ever toggles via route-level remount, but a future change
+  // that flips `fragment` on the same mount would otherwise reorder
+  // hooks between renders.
+  if (!fragment) {
+    return (
+      <div className='w-full min-h-screen bg-black flex items-center justify-center md:pr-40'>
+        <div className='flex flex-col items-center gap-3'>
+          <h1 className='bio-glitch text-white text-2xl font-pixel'>
+            FRAGMENT LOST
+          </h1>
+          <p className='bio-glitch text-white/30 text-xs font-mono'>
+            {'// memory not found in archive'}
+          </p>
+          <Link
+            to='/memories'
+            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+          >
+            {'< return to memories'}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const navigateToGridItem = (gi: number) => {
+    const item = gridItems[gi];
+    if (item.kind === 'group') {
+      navigate(`/memories/${id}/${item.groupId}`, { replace: true });
+    } else {
+      navigate(`/memories/${id}/${item.photo.file}`, { replace: true });
+    }
+  };
 
   let lightboxElement: React.ReactNode = null;
 

--- a/src/screens/Memories/components/GroupLightbox.tsx
+++ b/src/screens/Memories/components/GroupLightbox.tsx
@@ -1,10 +1,128 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 
 import type { PhotoMeta } from '../types';
 
 import { photoUrl } from '../data';
+import { isWarm, markWarm, warmImage } from './imageCache';
+import { PhotoCell } from './PhotoCell';
 import { useSwipe } from './useSwipe';
+
+type Neighbors = {
+  prev: PhotoMeta | null;
+  next: PhotoMeta | null;
+};
+
+/**
+ * Center cell of `GroupLightbox`: renders the multi-photo group with
+ * the appropriate row/column/stacked layout. Each photo is a button
+ * that drills into the single-photo `Lightbox` view via
+ * `onPhotoClick`. Trailing clicks after a horizontal-locked swipe are
+ * suppressed by the capture-phase listener installed in `useSwipe`.
+ */
+const GroupCell = ({
+  photos,
+  fragmentId,
+  layout,
+  onPhotoClick,
+}: {
+  photos: PhotoMeta[];
+  fragmentId: string;
+  layout: string;
+  onPhotoClick: (photo: PhotoMeta) => void;
+}) => {
+  const isAlwaysColumn = layout === 'column';
+  const combinedAR = photos.reduce((sum, p) => sum + p.width / p.height, 0);
+  const shouldStack = !isAlwaysColumn && combinedAR > 2;
+  const isAlwaysRow = !isAlwaysColumn && !shouldStack;
+
+  const containerCls = isAlwaysColumn
+    ? 'flex flex-col'
+    : shouldStack
+      ? 'flex flex-col sm:flex-row'
+      : 'flex';
+
+  return (
+    <div className='memories-track-cell flex items-center justify-center'>
+      <div
+        className={`${containerCls} gap-2 items-center justify-center`}
+        style={{ maxHeight: 'calc(100vh - 8rem)', maxWidth: '90vw' }}
+      >
+        {photos.map(p => (
+          <GroupPhotoButton
+            key={p.file}
+            photo={p}
+            fragmentId={fragmentId}
+            isAlwaysRow={isAlwaysRow}
+            shouldStack={shouldStack}
+            onClick={() => onPhotoClick(p)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const GroupPhotoButton = ({
+  photo,
+  fragmentId,
+  isAlwaysRow,
+  shouldStack,
+  onClick,
+}: {
+  photo: PhotoMeta;
+  fragmentId: string;
+  isAlwaysRow: boolean;
+  shouldStack: boolean;
+  onClick: () => void;
+}) => {
+  const fullSrc = photoUrl(fragmentId, photo.file, 'full');
+  const placeholderSrc = photoUrl(fragmentId, photo.file, 'placeholder');
+  const [loaded, setLoaded] = useState(() => isWarm(fullSrc));
+
+  useEffect(() => {
+    setLoaded(isWarm(fullSrc));
+  }, [fullSrc]);
+
+  return (
+    <button
+      type='button'
+      className={`relative overflow-hidden cursor-pointer min-h-0 max-h-full ${
+        isAlwaysRow
+          ? 'min-w-0'
+          : shouldStack
+            ? 'w-full sm:min-w-0 sm:w-auto'
+            : ''
+      }`}
+      style={
+        isAlwaysRow
+          ? { flex: `${photo.width / photo.height} 1 0%` }
+          : shouldStack
+            ? { flex: '1 1 0%' }
+            : undefined
+      }
+      onClick={onClick}
+    >
+      <img
+        src={placeholderSrc}
+        alt=''
+        aria-hidden
+        className={`absolute inset-0 w-full h-full object-contain scale-110 blur-md transition-opacity duration-500 ${loaded ? 'opacity-0' : 'opacity-100'}`}
+      />
+      <img
+        src={fullSrc}
+        alt={photo.alt ?? photo.caption ?? ''}
+        decoding='async'
+        draggable={false}
+        className={`object-contain w-full h-full transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={() => {
+          markWarm(fullSrc);
+          setLoaded(true);
+        }}
+      />
+    </button>
+  );
+};
 
 const GroupLightbox = ({
   photos,
@@ -16,6 +134,7 @@ const GroupLightbox = ({
   onPrev,
   onNext,
   onPhotoClick,
+  neighbors,
   preloadFiles,
 }: {
   photos: PhotoMeta[];
@@ -27,18 +146,18 @@ const GroupLightbox = ({
   onPrev: (() => void) | null;
   onNext: (() => void) | null;
   onPhotoClick: (photo: PhotoMeta) => void;
+  neighbors: Neighbors;
   preloadFiles: string[];
 }) => {
-  const [loadedSet, setLoadedSet] = useState<Set<string>>(() => new Set());
-  const swipe = useSwipe({ onSwipeLeft: onNext, onSwipeRight: onPrev });
-  const photoKey = useMemo(() => photos.map(p => p.file).join(','), [photos]);
-
-  useEffect(() => {
-    setLoadedSet(new Set());
-  }, [photoKey]);
-
   const callbacksRef = useRef({ onClose, onPrev, onNext });
   callbacksRef.current = { onClose, onPrev, onNext };
+
+  const { surfaceRef, trackRef } = useSwipe({
+    hasPrev: !!onPrev,
+    hasNext: !!onNext,
+    onCommitPrev: onPrev,
+    onCommitNext: onNext,
+  });
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -59,22 +178,9 @@ const GroupLightbox = ({
 
   useEffect(() => {
     for (const file of preloadFiles) {
-      const img = new Image();
-      img.fetchPriority = 'low';
-      img.src = photoUrl(fragmentId, file, 'full');
+      void warmImage(photoUrl(fragmentId, file, 'full'));
     }
   }, [preloadFiles, fragmentId]);
-
-  const isAlwaysColumn = layout === 'column';
-  const combinedAR = photos.reduce((sum, p) => sum + p.width / p.height, 0);
-  const shouldStack = !isAlwaysColumn && combinedAR > 2;
-  const isAlwaysRow = !isAlwaysColumn && !shouldStack;
-
-  const containerCls = isAlwaysColumn
-    ? 'flex flex-col'
-    : shouldStack
-      ? 'flex flex-col sm:flex-row'
-      : 'flex';
 
   return (
     <div
@@ -86,8 +192,8 @@ const GroupLightbox = ({
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
-        ref={swipe.ref}
-        className='relative flex items-center justify-center w-full h-full p-4 sm:p-8'
+        ref={surfaceRef}
+        className='memories-swipe-surface absolute inset-0 overflow-hidden'
         onClick={e => e.stopPropagation()}
       >
         <button
@@ -102,80 +208,51 @@ const GroupLightbox = ({
           <button
             type='button'
             onClick={onPrev}
-            className='absolute left-2 sm:left-4 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
+            className='absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
           >
             &lt;
           </button>
         )}
 
         <div
-          className='flex flex-col items-center gap-4 max-w-full max-h-full'
-          style={swipe.style}
+          ref={trackRef}
+          className='memories-track absolute inset-0 flex'
+          style={{ width: '300%' }}
         >
-          <div
-            className={`${containerCls} gap-2 items-center justify-center`}
-            style={{ maxHeight: 'calc(100vh - 8rem)', maxWidth: '90vw' }}
-          >
-            {photos.map(p => {
-              const loaded = loadedSet.has(p.file);
-              return (
-                <button
-                  key={p.file}
-                  type='button'
-                  className={`relative overflow-hidden cursor-pointer min-h-0 max-h-full ${isAlwaysRow ? 'min-w-0' : shouldStack ? 'w-full sm:min-w-0 sm:w-auto' : ''}`}
-                  style={
-                    isAlwaysRow
-                      ? { flex: `${p.width / p.height} 1 0%` }
-                      : shouldStack
-                        ? { flex: '1 1 0%' }
-                        : undefined
-                  }
-                  onClick={() => onPhotoClick(p)}
-                >
-                  <img
-                    src={photoUrl(fragmentId, p.file, 'placeholder')}
-                    alt=''
-                    aria-hidden
-                    className={`absolute inset-0 w-full h-full object-contain scale-110 blur-md transition-opacity duration-500 ${loaded ? 'opacity-0' : 'opacity-100'}`}
-                  />
-                  <img
-                    src={photoUrl(fragmentId, p.file, 'full')}
-                    alt={p.alt ?? p.caption ?? ''}
-                    decoding='async'
-                    className={`object-contain w-full h-full transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
-                    onLoad={() =>
-                      setLoadedSet(prev => new Set(prev).add(p.file))
-                    }
-                  />
-                </button>
-              );
-            })}
-          </div>
-
-          <div
-            className={`flex items-center gap-4 text-[10px] font-mono transition-opacity duration-500 ${photos.every(p => loadedSet.has(p.file)) ? 'opacity-100' : 'opacity-0'}`}
-          >
-            <span className='text-white/30'>{counter}</span>
-            {caption && (
-              <span className='text-white/50 signal-prose'>
-                <Markdown>{caption}</Markdown>
-              </span>
-            )}
-          </div>
+          <PhotoCell photo={neighbors.prev} fragmentId={fragmentId} />
+          <GroupCell
+            photos={photos}
+            fragmentId={fragmentId}
+            layout={layout}
+            onPhotoClick={onPhotoClick}
+          />
+          <PhotoCell photo={neighbors.next} fragmentId={fragmentId} />
         </div>
 
         {onNext && (
           <button
             type='button'
             onClick={onNext}
-            className='absolute right-2 sm:right-4 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
+            className='absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
           >
             &gt;
           </button>
         )}
+
+        <div className='absolute bottom-4 left-0 right-0 z-10 flex justify-center pointer-events-none px-4'>
+          <div className='flex items-baseline gap-4 text-[10px] font-mono max-w-full pointer-events-auto'>
+            <span className='text-white/30 shrink-0'>{counter}</span>
+            {caption && (
+              <span className='text-white/50 signal-prose min-w-0'>
+                <Markdown>{caption}</Markdown>
+              </span>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );
 };
 
 export { GroupLightbox };
+export type { Neighbors };

--- a/src/screens/Memories/components/Lightbox.tsx
+++ b/src/screens/Memories/components/Lightbox.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import Markdown from 'react-markdown';
 
 import type { PhotoMeta } from '../types';
 
 import { photoUrl } from '../data';
+import { warmImage } from './imageCache';
+import { PhotoCell } from './PhotoCell';
 import { useSwipe } from './useSwipe';
+
+type Neighbors = {
+  prev: PhotoMeta | null;
+  next: PhotoMeta | null;
+};
 
 const Lightbox = ({
   photo,
@@ -13,6 +20,7 @@ const Lightbox = ({
   onClose,
   onPrev,
   onNext,
+  neighbors,
   preloadFiles,
 }: {
   photo: PhotoMeta;
@@ -21,16 +29,18 @@ const Lightbox = ({
   onClose: () => void;
   onPrev: (() => void) | null;
   onNext: (() => void) | null;
+  neighbors: Neighbors;
   preloadFiles: string[];
 }) => {
-  const [loaded, setLoaded] = useState(false);
-  const swipe = useSwipe({ onSwipeLeft: onNext, onSwipeRight: onPrev });
   const callbacksRef = useRef({ onClose, onPrev, onNext });
   callbacksRef.current = { onClose, onPrev, onNext };
 
-  useEffect(() => {
-    setLoaded(false);
-  }, [photo.file]);
+  const { surfaceRef, trackRef } = useSwipe({
+    hasPrev: !!onPrev,
+    hasNext: !!onNext,
+    onCommitPrev: onPrev,
+    onCommitNext: onNext,
+  });
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -49,11 +59,14 @@ const Lightbox = ({
     };
   }, []);
 
+  // Warm distant neighbors (distance 2-3) so subsequent swipes are also
+  // flicker-free. The immediate neighbors (distance 1) are already
+  // DOM-resident in the prev/next cells, so the browser fetches them
+  // automatically; we just need to populate the warm cache for them via
+  // their `<img onLoad>` handlers.
   useEffect(() => {
     for (const file of preloadFiles) {
-      const img = new Image();
-      img.fetchPriority = 'low';
-      img.src = photoUrl(fragmentId, file, 'full');
+      void warmImage(photoUrl(fragmentId, file, 'full'));
     }
   }, [preloadFiles, fragmentId]);
 
@@ -67,8 +80,8 @@ const Lightbox = ({
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
-        ref={swipe.ref}
-        className='relative flex items-center justify-center w-full h-full p-4 sm:p-8'
+        ref={surfaceRef}
+        className='memories-swipe-surface absolute inset-0 overflow-hidden'
         onClick={e => e.stopPropagation()}
       >
         <button
@@ -83,42 +96,34 @@ const Lightbox = ({
           <button
             type='button'
             onClick={onPrev}
-            className='absolute left-2 sm:left-4 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
+            className='absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
           >
             &lt;
           </button>
         )}
 
         <div
-          className='flex flex-col items-center gap-3 max-w-full max-h-full'
-          style={swipe.style}
+          ref={trackRef}
+          className='memories-track absolute inset-0 flex'
+          style={{ width: '300%' }}
         >
-          <div
-            className='relative overflow-hidden'
-            style={{
-              aspectRatio: `${photo.width} / ${photo.height}`,
-              maxHeight: 'calc(100vh - 8rem)',
-              width: `min(calc(100vw - 4rem), calc((100vh - 8rem) * ${photo.width / photo.height}))`,
-            }}
-          >
-            <img
-              src={photoUrl(fragmentId, photo.file, 'placeholder')}
-              alt=''
-              aria-hidden
-              className={`absolute inset-0 w-full h-full object-contain scale-110 blur-md transition-opacity duration-500 ${loaded ? 'opacity-0' : 'opacity-100'}`}
-            />
-            <img
-              src={photoUrl(fragmentId, photo.file, 'full')}
-              alt={photo.alt ?? photo.caption ?? ''}
-              decoding='async'
-              className={`absolute inset-0 w-full h-full object-contain transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
-              onLoad={() => setLoaded(true)}
-            />
-          </div>
+          <PhotoCell photo={neighbors.prev} fragmentId={fragmentId} />
+          <PhotoCell photo={photo} fragmentId={fragmentId} />
+          <PhotoCell photo={neighbors.next} fragmentId={fragmentId} />
+        </div>
 
-          <div
-            className={`flex items-baseline gap-4 text-[10px] font-mono max-w-full transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        {onNext && (
+          <button
+            type='button'
+            onClick={onNext}
+            className='absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
           >
+            &gt;
+          </button>
+        )}
+
+        <div className='absolute bottom-4 left-0 right-0 z-10 flex justify-center pointer-events-none px-4'>
+          <div className='flex items-baseline gap-4 text-[10px] font-mono max-w-full pointer-events-auto'>
             <span className='text-white/30 shrink-0'>{counter}</span>
             {photo.caption && (
               <span className='text-white/50 signal-prose min-w-0'>
@@ -137,19 +142,10 @@ const Lightbox = ({
             )}
           </div>
         </div>
-
-        {onNext && (
-          <button
-            type='button'
-            onClick={onNext}
-            className='absolute right-2 sm:right-4 z-10 text-white/30 hover:text-white text-lg font-mono transition-colors duration-300'
-          >
-            &gt;
-          </button>
-        )}
       </div>
     </div>
   );
 };
 
 export { Lightbox };
+export type { Neighbors };

--- a/src/screens/Memories/components/PhotoCell.tsx
+++ b/src/screens/Memories/components/PhotoCell.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+
+import type { PhotoMeta } from '../types';
+
+import { photoUrl } from '../data';
+import { isWarm, markWarm } from './imageCache';
+
+/**
+ * Renders one photo (placeholder + full image) inside a carousel cell.
+ * `loaded` is initialized from the warm-image cache so neighbors that
+ * have already been preloaded + decoded skip the placeholder fade
+ * entirely on swipe commit.
+ *
+ * Used by `Lightbox` for the prev / center / next cells, and by
+ * `GroupLightbox` for the prev / next cells (the center cell of
+ * `GroupLightbox` renders a multi-photo group layout instead).
+ */
+const PhotoCell = ({
+  photo,
+  fragmentId,
+}: {
+  photo: PhotoMeta | null;
+  fragmentId: string;
+}) => {
+  if (!photo) {
+    return <div className='memories-track-cell' aria-hidden />;
+  }
+  return <PhotoCellInner photo={photo} fragmentId={fragmentId} />;
+};
+
+const PhotoCellInner = ({
+  photo,
+  fragmentId,
+}: {
+  photo: PhotoMeta;
+  fragmentId: string;
+}) => {
+  const fullSrc = photoUrl(fragmentId, photo.file, 'full');
+  const placeholderSrc = photoUrl(fragmentId, photo.file, 'placeholder');
+  const [loaded, setLoaded] = useState(() => isWarm(fullSrc));
+
+  useEffect(() => {
+    setLoaded(isWarm(fullSrc));
+  }, [fullSrc]);
+
+  return (
+    <div className='memories-track-cell flex items-center justify-center'>
+      <div
+        className='relative overflow-hidden'
+        style={{
+          aspectRatio: `${photo.width} / ${photo.height}`,
+          maxHeight: 'calc(100vh - 8rem)',
+          width: `min(calc(100vw - 4rem), calc((100vh - 8rem) * ${photo.width / photo.height}))`,
+        }}
+      >
+        <img
+          src={placeholderSrc}
+          alt=''
+          aria-hidden
+          className={`absolute inset-0 w-full h-full object-contain scale-110 blur-md transition-opacity duration-500 ${loaded ? 'opacity-0' : 'opacity-100'}`}
+        />
+        <img
+          src={fullSrc}
+          alt={photo.alt ?? photo.caption ?? ''}
+          decoding='async'
+          draggable={false}
+          className={`absolute inset-0 w-full h-full object-contain transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+          onLoad={() => {
+            markWarm(fullSrc);
+            setLoaded(true);
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export { PhotoCell };

--- a/src/screens/Memories/components/imageCache.ts
+++ b/src/screens/Memories/components/imageCache.ts
@@ -1,0 +1,41 @@
+/**
+ * Module-level cache of image src strings whose bitmaps have been decoded
+ * via `img.decode()`. Used by the lightboxes to skip the placeholder fade
+ * on warm neighbors after a swipe.
+ *
+ * `warmImage(src)` kicks off a fetch + decode and resolves once the bitmap
+ * is ready to paint without further work; the resolved src is recorded in
+ * `decoded`. `markWarm` is the manual entry point used from real `<img>`
+ * `onLoad` handlers so cold loads also populate the cache.
+ *
+ * Rejection (cancelled load, broken image) is swallowed — the real `<img>`
+ * mount will retry on its own. We only mark warm on successful decode so
+ * `isWarm` never lies.
+ */
+
+const decoded = new Set<string>();
+
+export function warmImage(src: string): Promise<void> {
+  if (decoded.has(src)) return Promise.resolve();
+  if (typeof Image === 'undefined') return Promise.resolve();
+  const img = new Image();
+  img.decoding = 'async';
+  img.fetchPriority = 'low';
+  img.src = src;
+  return img.decode().then(
+    () => {
+      decoded.add(src);
+    },
+    () => {
+      /* swallow; will retry on real mount */
+    },
+  );
+}
+
+export function isWarm(src: string): boolean {
+  return decoded.has(src);
+}
+
+export function markWarm(src: string): void {
+  decoded.add(src);
+}

--- a/src/screens/Memories/components/useSwipe.ts
+++ b/src/screens/Memories/components/useSwipe.ts
@@ -1,121 +1,359 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+/**
+ * DOM-driven horizontal-swipe hook for the Memories lightbox carousel.
+ *
+ * The hook drives a 3-cell horizontal track:
+ *
+ *     [ prev ][ center ][ next ]
+ *      -W       0         +W      (where W = surface width)
+ *
+ * The track sits at `translate3d(-W, 0, 0)` at rest so the center cell
+ * occupies the visible area. During a horizontal drag the hook writes
+ * `translate3d(-W + dx, 0, 0)` directly to `trackRef.current.style`
+ * inside a single rAF per pointermove, with no React state churn. On
+ * commit the hook animates the track to `0` (prev) or `-2W` (next),
+ * fires `onCommitPrev` / `onCommitNext` after `transitionend`, then
+ * synchronously resets the transform to `-W` with `transition: none`
+ * so the next React render (which has swapped photo props into the
+ * center cell) lands flicker-free.
+ *
+ * The hook is the *only* writer of `trackRef.current.style.transform`
+ * and `style.transition`. Components must not pass an inline transform
+ * style on the track element or React re-renders will clobber the
+ * hook's writes mid-drag.
+ *
+ * `setPointerCapture` is intentionally deferred until axis lock
+ * resolves to `'h'`. Calling it on `pointerdown` would steal `click`
+ * events from buttons inside the gesture surface (close, prev, next,
+ * group-cell drill-in). After a horizontal-locked gesture ends we set
+ * `consumedClickRef`, which a capture-phase `click` listener on the
+ * surface uses to swallow the trailing synthesized click exactly once.
+ *
+ * Velocity-based commit duration: a hard flick lands in ~180ms, a
+ * slow controlled drag in ~360ms, with `cubic-bezier(0.2, 0.8, 0.2, 1)`
+ * deceleration. Boundary rubber-banding (factor 0.2) is preserved.
+ */
+
+const AXIS_LOCK_THRESHOLD_PX = 10;
+const COMMIT_DISTANCE_PX = 60;
+const COMMIT_VELOCITY_PX_MS = 0.3;
+const RUBBERBAND_FACTOR = 0.2;
+const MIN_DURATION_MS = 180;
+const MAX_DURATION_MS = 360;
+const EASING = 'cubic-bezier(0.2, 0.8, 0.2, 1)';
+
+type Phase = 'idle' | 'committing';
 
 const useSwipe = ({
-  onSwipeLeft,
-  onSwipeRight,
+  hasPrev,
+  hasNext,
+  onCommitPrev,
+  onCommitNext,
 }: {
-  onSwipeLeft: (() => void) | null;
-  onSwipeRight: (() => void) | null;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onCommitPrev: (() => void) | null;
+  onCommitNext: (() => void) | null;
 }) => {
-  const [offsetX, setOffsetX] = useState(0);
-  const [animating, setAnimating] = useState(false);
+  const [phase, setPhase] = useState<Phase>('idle');
 
-  const callbacksRef = useRef({ onSwipeLeft, onSwipeRight });
-  callbacksRef.current = { onSwipeLeft, onSwipeRight };
+  // Latest callbacks so the imperative event listeners don't need to
+  // re-bind when the parent re-renders.
+  const callbacksRef = useRef({ hasPrev, hasNext, onCommitPrev, onCommitNext });
+  callbacksRef.current = { hasPrev, hasNext, onCommitPrev, onCommitNext };
 
-  const currentOffsetRef = useRef(0);
-  const nodeRef = useRef<HTMLElement | null>(null);
+  // Mirror `phase` into a ref so closures inside the effect bodies
+  // (resize handler, animation callbacks) read the current value
+  // without forcing the effects to re-run on every phase change.
+  const phaseRef = useRef<Phase>('idle');
+  phaseRef.current = phase;
 
-  const touch = useRef({
+  const surfaceNodeRef = useRef<HTMLDivElement | null>(null);
+  const trackNodeRef = useRef<HTMLDivElement | null>(null);
+
+  // Per-gesture state lives in refs to avoid React re-renders during drag.
+  const cellWidthRef = useRef(0);
+  const dragRef = useRef({
+    pointerId: -1,
     startX: 0,
     startY: 0,
     startTime: 0,
     locked: null as 'h' | 'v' | null,
-    active: false,
+    dx: 0,
+    captured: false,
+    rafScheduled: false,
   });
+  const consumedClickRef = useRef(false);
 
-  const ref = useCallback((node: HTMLElement | null) => {
-    nodeRef.current = node;
+  const setRestingTransform = useCallback(() => {
+    const track = trackNodeRef.current;
+    if (!track) return;
+    const w = cellWidthRef.current;
+    track.style.transition = 'none';
+    track.style.transform = `translate3d(${-w}px, 0, 0)`;
   }, []);
 
-  useEffect(() => {
-    const node = nodeRef.current;
-    if (!node) return;
+  const writeTrackOffset = useCallback((dx: number) => {
+    const track = trackNodeRef.current;
+    if (!track) return;
+    const w = cellWidthRef.current;
+    track.style.transition = 'none';
+    track.style.transform = `translate3d(${-w + dx}px, 0, 0)`;
+  }, []);
 
-    const onStart = (e: TouchEvent) => {
-      const t = e.touches[0];
-      touch.current = {
-        startX: t.clientX,
-        startY: t.clientY,
-        startTime: Date.now(),
-        locked: null,
-        active: true,
+  const animateTrackTo = useCallback(
+    (targetDx: number, durationMs: number, onDone: () => void) => {
+      const track = trackNodeRef.current;
+      if (!track) {
+        onDone();
+        return;
+      }
+      const w = cellWidthRef.current;
+      const targetTransform = `translate3d(${-w + targetDx}px, 0, 0)`;
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        track.removeEventListener('transitionend', finish);
+        clearTimeout(timeoutId);
+        onDone();
       };
-      setAnimating(false);
-      setOffsetX(0);
-      currentOffsetRef.current = 0;
+      track.addEventListener('transitionend', finish);
+      // Belt-and-braces: Safari occasionally drops `transitionend` after a
+      // rapid sequence of style writes. The +50ms slack is well below
+      // human flicker perception.
+      const timeoutId = window.setTimeout(finish, durationMs + 50);
+      track.style.transition = `transform ${durationMs}ms ${EASING}`;
+      track.style.transform = targetTransform;
+    },
+    [],
+  );
+
+  // Set the resting transform whenever the track node is attached or the
+  // surface size changes. Layout effect so we run before paint.
+  useLayoutEffect(() => {
+    const surface = surfaceNodeRef.current;
+    if (!surface) return;
+    const measure = () => {
+      const rect = surface.getBoundingClientRect();
+      if (rect.width > 0) {
+        cellWidthRef.current = rect.width;
+        // Only re-apply resting transform if no drag or commit
+        // animation is active. Reset mid-commit would cancel the
+        // transition and snap the track to -W with the wrong
+        // bitmap visible.
+        if (
+          dragRef.current.pointerId === -1 &&
+          phaseRef.current === 'idle'
+        ) {
+          setRestingTransform();
+        }
+      }
+    };
+    measure();
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(measure);
+      ro.observe(surface);
+      return () => ro.disconnect();
+    }
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [setRestingTransform]);
+
+  // Bind pointer + click listeners exactly once per surface node mount.
+  useLayoutEffect(() => {
+    const surface = surfaceNodeRef.current;
+    if (!surface) return;
+
+    const onPointerDown = (e: PointerEvent) => {
+      // Ignore secondary buttons / multi-touch follow-ups.
+      if (e.button !== 0 && e.pointerType === 'mouse') return;
+      if (dragRef.current.pointerId !== -1) return;
+
+      const rect = surface.getBoundingClientRect();
+      if (rect.width > 0) cellWidthRef.current = rect.width;
+
+      dragRef.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        startTime: performance.now(),
+        locked: null,
+        dx: 0,
+        captured: false,
+        rafScheduled: false,
+      };
     };
 
-    const onMove = (e: TouchEvent) => {
-      const state = touch.current;
-      if (!state.active) return;
+    const flushDx = () => {
+      dragRef.current.rafScheduled = false;
+      const { locked, dx } = dragRef.current;
+      if (locked !== 'h') return;
+      writeTrackOffset(dx);
+    };
 
-      const t = e.touches[0];
-      const dx = t.clientX - state.startX;
-      const dy = t.clientY - state.startY;
+    const onPointerMove = (e: PointerEvent) => {
+      const state = dragRef.current;
+      if (state.pointerId !== e.pointerId) return;
+
+      const dx = e.clientX - state.startX;
+      const dy = e.clientY - state.startY;
 
       if (!state.locked) {
-        if (Math.abs(dx) < 10 && Math.abs(dy) < 10) return;
+        if (
+          Math.abs(dx) < AXIS_LOCK_THRESHOLD_PX &&
+          Math.abs(dy) < AXIS_LOCK_THRESHOLD_PX
+        ) {
+          return;
+        }
         state.locked = Math.abs(dx) >= Math.abs(dy) ? 'h' : 'v';
+        if (state.locked === 'h') {
+          // Capture only after axis lock so taps on inner buttons
+          // (close, prev, next, drill-in) keep firing their click
+          // handlers normally.
+          try {
+            surface.setPointerCapture(e.pointerId);
+            state.captured = true;
+          } catch {
+            /* setPointerCapture can throw if pointer already released */
+          }
+        }
       }
 
-      if (state.locked === 'v') return;
+      if (state.locked !== 'h') return;
 
-      e.preventDefault();
+      const { hasPrev, hasNext } = callbacksRef.current;
+      const atBoundary = (dx > 0 && !hasPrev) || (dx < 0 && !hasNext);
+      state.dx = atBoundary ? dx * RUBBERBAND_FACTOR : dx;
 
-      const { onSwipeLeft, onSwipeRight } = callbacksRef.current;
-      const atBoundary = (dx > 0 && !onSwipeRight) || (dx < 0 && !onSwipeLeft);
-      const offset = atBoundary ? dx * 0.2 : dx;
-      currentOffsetRef.current = offset;
-      setOffsetX(offset);
+      if (!state.rafScheduled) {
+        state.rafScheduled = true;
+        requestAnimationFrame(flushDx);
+      }
     };
 
-    const onEnd = () => {
-      const state = touch.current;
-      if (!state.active) return;
-      state.active = false;
+    const endGesture = (e: PointerEvent) => {
+      const state = dragRef.current;
+      if (state.pointerId !== e.pointerId) return;
 
-      if (state.locked !== 'h') {
-        setOffsetX(0);
-        currentOffsetRef.current = 0;
+      const wasHorizontal = state.locked === 'h';
+      const dx = state.dx;
+      const elapsed = Math.max(1, performance.now() - state.startTime);
+      const cellWidth = cellWidthRef.current;
+
+      // Clear gesture state up front so re-entrancy from the commit
+      // callback (e.g. wouter's navigate) sees an idle hook.
+      if (state.captured) {
+        try {
+          surface.releasePointerCapture(e.pointerId);
+        } catch {
+          /* already released */
+        }
+      }
+      dragRef.current = {
+        pointerId: -1,
+        startX: 0,
+        startY: 0,
+        startTime: 0,
+        locked: null,
+        dx: 0,
+        captured: false,
+        rafScheduled: false,
+      };
+
+      if (!wasHorizontal) {
+        // Vertical or untriggered tap — leave transform alone.
         return;
       }
 
-      const ox = currentOffsetRef.current;
-      const elapsed = Date.now() - state.startTime;
-      const velocity = Math.abs(ox) / elapsed;
-      const triggered = Math.abs(ox) > 60 || velocity > 0.3;
+      // Suppress the trailing click some browsers fire after a
+      // captured horizontal-locked gesture. The trailing click
+      // arrives within a few ms; clear the flag after a short
+      // window so a stale value doesn't eat an unrelated click
+      // from the next user interaction.
+      consumedClickRef.current = true;
+      window.setTimeout(() => {
+        consumedClickRef.current = false;
+      }, 350);
 
-      const { onSwipeLeft, onSwipeRight } = callbacksRef.current;
-      if (triggered && ox < 0 && onSwipeLeft) {
-        onSwipeLeft();
-      } else if (triggered && ox > 0 && onSwipeRight) {
-        onSwipeRight();
+      const { hasPrev, hasNext, onCommitPrev, onCommitNext } =
+        callbacksRef.current;
+      const velocity = Math.abs(dx) / elapsed; // px/ms
+      const triggered =
+        Math.abs(dx) > COMMIT_DISTANCE_PX || velocity > COMMIT_VELOCITY_PX_MS;
+      const goingPrev = dx > 0 && hasPrev;
+      const goingNext = dx < 0 && hasNext;
+      const willCommit = triggered && (goingPrev || goingNext);
+
+      const targetDx = willCommit ? (goingPrev ? cellWidth : -cellWidth) : 0;
+      const remaining = Math.abs(targetDx - dx);
+      const duration = Math.max(
+        MIN_DURATION_MS,
+        Math.min(MAX_DURATION_MS, remaining / Math.max(velocity, 0.5)),
+      );
+
+      setPhase('committing');
+      animateTrackTo(targetDx, duration, () => {
+        if (willCommit) {
+          if (goingPrev) onCommitPrev?.();
+          else if (goingNext) onCommitNext?.();
+        }
+        // Snap track back to resting position with no transition.
+        // The parent's wouter navigate (called above) will swap
+        // `photo` into the center cell on the next React render.
+        setRestingTransform();
+        setPhase('idle');
+      });
+    };
+
+    const onClickCapture = (e: MouseEvent) => {
+      if (consumedClickRef.current) {
+        consumedClickRef.current = false;
+        e.stopPropagation();
+        e.preventDefault();
       }
-
-      setAnimating(true);
-      setOffsetX(0);
-      currentOffsetRef.current = 0;
     };
 
-    node.addEventListener('touchstart', onStart, { passive: true });
-    node.addEventListener('touchmove', onMove, { passive: false });
-    node.addEventListener('touchend', onEnd, { passive: true });
+    surface.addEventListener('pointerdown', onPointerDown);
+    surface.addEventListener('pointermove', onPointerMove);
+    surface.addEventListener('pointerup', endGesture);
+    surface.addEventListener('pointercancel', endGesture);
+    surface.addEventListener('click', onClickCapture, true);
+
     return () => {
-      node.removeEventListener('touchstart', onStart);
-      node.removeEventListener('touchmove', onMove);
-      node.removeEventListener('touchend', onEnd);
+      surface.removeEventListener('pointerdown', onPointerDown);
+      surface.removeEventListener('pointermove', onPointerMove);
+      surface.removeEventListener('pointerup', endGesture);
+      surface.removeEventListener('pointercancel', endGesture);
+      surface.removeEventListener('click', onClickCapture, true);
     };
-  });
+  }, [animateTrackTo, setRestingTransform, writeTrackOffset]);
 
-  const style: React.CSSProperties = {
-    transform: offsetX ? `translateX(${offsetX}px)` : undefined,
-    transition: animating
-      ? 'transform 300ms cubic-bezier(0.2, 0, 0, 1)'
-      : 'none',
-  };
+  // Apply resting transform synchronously when the track first attaches.
+  useEffect(() => {
+    setRestingTransform();
+  }, [setRestingTransform]);
 
-  return { ref, style };
+  const surfaceRef = useCallback((node: HTMLDivElement | null) => {
+    surfaceNodeRef.current = node;
+  }, []);
+
+  const trackRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      trackNodeRef.current = node;
+      if (node) setRestingTransform();
+    },
+    [setRestingTransform],
+  );
+
+  return { surfaceRef, trackRef, phase };
 };
 
 export { useSwipe };

--- a/src/screens/Memories/components/useSwipe.ts
+++ b/src/screens/Memories/components/useSwipe.ts
@@ -75,7 +75,13 @@ const useSwipe = ({
   const phaseRef = useRef<Phase>('idle');
   phaseRef.current = phase;
 
-  const surfaceNodeRef = useRef<HTMLDivElement | null>(null);
+  // Surface node is held in state so the listener-binding layout effect
+  // re-runs if the node is ever swapped — `surfaceRef` is a callback ref
+  // and a plain ref would silently leave listeners bound to a detached
+  // node. The track node is kept as a plain ref since its writes happen
+  // imperatively from inside event handlers and don't need to retrigger
+  // any effect on swap.
+  const [surfaceNode, setSurfaceNode] = useState<HTMLDivElement | null>(null);
   const trackNodeRef = useRef<HTMLDivElement | null>(null);
 
   // Per-gesture state lives in refs to avoid React re-renders during drag.
@@ -92,10 +98,21 @@ const useSwipe = ({
     startTime: 0,
     locked: null as 'h' | 'v' | null,
     dx: 0,
+    // Raw `e.clientX - startX` before any rubber-banding. Used to decide
+    // whether to arm click suppression after a horizontal-locked gesture
+    // — the rubber-banded `dx` underreports travel near no-neighbor
+    // boundaries (factor 0.2) and would let the synthesized click leak
+    // into inner buttons after a deliberate axis-locked swipe.
+    rawDx: 0,
     captured: false,
     rafScheduled: false,
   });
   const consumedClickRef = useRef(false);
+  // Active commit/snap-back animation finalizer so a fresh `pointerdown`
+  // (which `onPointerMove` would silently cancel via `transition: none`)
+  // can tear down the pending `transitionend` listener and timeout
+  // fallback before they fire mid-drag and yank the track to center.
+  const pendingAnimationRef = useRef<{ cancel: () => void } | null>(null);
 
   const setRestingTransform = useCallback(() => {
     const track = trackNodeRef.current;
@@ -128,13 +145,24 @@ const useSwipe = ({
         done = true;
         track.removeEventListener('transitionend', finish);
         clearTimeout(timeoutId);
+        pendingAnimationRef.current = null;
         onDone();
+      };
+      const cancel = () => {
+        if (done) return;
+        done = true;
+        track.removeEventListener('transitionend', finish);
+        clearTimeout(timeoutId);
+        pendingAnimationRef.current = null;
+        // Intentionally does not invoke `onDone` — the new gesture
+        // takes over ownership of the transform.
       };
       track.addEventListener('transitionend', finish);
       // Belt-and-braces: Safari occasionally drops `transitionend` after a
       // rapid sequence of style writes. The +50ms slack is well below
       // human flicker perception.
       const timeoutId = window.setTimeout(finish, durationMs + 50);
+      pendingAnimationRef.current = { cancel };
       track.style.transition = `transform ${durationMs}ms ${EASING}`;
       track.style.transform = targetTransform;
     },
@@ -144,7 +172,7 @@ const useSwipe = ({
   // Set the resting transform whenever the track node is attached or the
   // surface size changes. Layout effect so we run before paint.
   useLayoutEffect(() => {
-    const surface = surfaceNodeRef.current;
+    const surface = surfaceNode;
     if (!surface) return;
     const measure = () => {
       const rect = surface.getBoundingClientRect();
@@ -171,17 +199,26 @@ const useSwipe = ({
     }
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, [setRestingTransform]);
+  }, [setRestingTransform, surfaceNode]);
 
   // Bind pointer + click listeners exactly once per surface node mount.
   useLayoutEffect(() => {
-    const surface = surfaceNodeRef.current;
+    const surface = surfaceNode;
     if (!surface) return;
 
     const onPointerDown = (e: PointerEvent) => {
       // Ignore secondary buttons / multi-touch follow-ups.
       if (e.button !== 0 && e.pointerType === 'mouse') return;
       if (dragRef.current.pointerId !== -1) return;
+
+      // Tear down any in-flight commit/snap-back animation. The first
+      // `pointermove` will write `transition: none` and silently cancel
+      // the CSS transition, so the pending `transitionend` will never
+      // fire — but the +50ms timeout fallback would still call `onDone`
+      // mid-drag without this cancel, yanking the track back to center
+      // (and potentially re-firing the navigate callback for commits).
+      pendingAnimationRef.current?.cancel();
+      pendingAnimationRef.current = null;
 
       const rect = surface.getBoundingClientRect();
       if (rect.width > 0) cellWidthRef.current = rect.width;
@@ -193,6 +230,7 @@ const useSwipe = ({
         startTime: performance.now(),
         locked: null,
         dx: 0,
+        rawDx: 0,
         captured: false,
         rafScheduled: false,
       };
@@ -237,6 +275,7 @@ const useSwipe = ({
 
       const { hasPrev, hasNext } = callbacksRef.current;
       const atBoundary = (dx > 0 && !hasPrev) || (dx < 0 && !hasNext);
+      state.rawDx = dx;
       state.dx = atBoundary ? dx * RUBBERBAND_FACTOR : dx;
 
       if (!state.rafScheduled) {
@@ -251,6 +290,7 @@ const useSwipe = ({
 
       const wasHorizontal = state.locked === 'h';
       const dx = state.dx;
+      const rawDx = state.rawDx;
       const elapsed = Math.max(1, performance.now() - state.startTime);
       const cellWidth = cellWidthRef.current;
 
@@ -270,12 +310,22 @@ const useSwipe = ({
         startTime: 0,
         locked: null,
         dx: 0,
+        rawDx: 0,
         captured: false,
         rafScheduled: false,
       };
 
       if (!wasHorizontal) {
-        // Vertical or untriggered tap — leave transform alone.
+        // Vertical or untriggered tap — leave transform alone, but
+        // drain any width parked by a `ResizeObserver` callback that
+        // fired during the locked-vertical drag and re-anchor the
+        // resting transform against it. Otherwise the center cell
+        // sits off-axis until the next `pointerdown` re-measures.
+        if (pendingCellWidthRef.current !== null) {
+          cellWidthRef.current = pendingCellWidthRef.current;
+          pendingCellWidthRef.current = null;
+          setRestingTransform();
+        }
         return;
       }
 
@@ -283,12 +333,16 @@ const useSwipe = ({
       // captured horizontal-locked gesture. Only arm when the
       // gesture actually travelled past the axis-lock threshold —
       // a tiny axis-locked wiggle that settles back near origin
-      // shouldn't eat a subsequent deliberate tap. Keep the window
-      // tight: the synthesized click arrives within a few ms of
-      // pointerup, well under 50ms, but a 350ms blanket would
-      // swallow legitimate taps on `[close]`, prev/next, or a
-      // group photo within the same interaction beat.
-      if (Math.abs(dx) > AXIS_LOCK_THRESHOLD_PX) {
+      // shouldn't eat a subsequent deliberate tap. Use the *raw*
+      // pointer delta, not the rubber-banded `dx`: at no-neighbor
+      // boundaries the rubber-band factor (0.2) shrinks a 50px
+      // swipe to 10px, which would slip past this guard and let
+      // the synthesized click drill into a `GroupPhotoButton`.
+      // Keep the window tight: the synthesized click arrives within
+      // a few ms of pointerup, well under 50ms, but a 350ms blanket
+      // would swallow legitimate taps on `[close]`, prev/next, or
+      // a group photo within the same interaction beat.
+      if (Math.abs(rawDx) > AXIS_LOCK_THRESHOLD_PX) {
         consumedClickRef.current = true;
         window.setTimeout(() => {
           consumedClickRef.current = false;
@@ -352,8 +406,12 @@ const useSwipe = ({
       surface.removeEventListener('pointerup', endGesture);
       surface.removeEventListener('pointercancel', endGesture);
       surface.removeEventListener('click', onClickCapture, true);
+      // Drop any in-flight animation finalizer so it can't fire
+      // against a detached track after unmount.
+      pendingAnimationRef.current?.cancel();
+      pendingAnimationRef.current = null;
     };
-  }, [animateTrackTo, setRestingTransform, writeTrackOffset]);
+  }, [animateTrackTo, setRestingTransform, surfaceNode, writeTrackOffset]);
 
   // Apply resting transform synchronously when the track first attaches.
   useEffect(() => {
@@ -361,7 +419,7 @@ const useSwipe = ({
   }, [setRestingTransform]);
 
   const surfaceRef = useCallback((node: HTMLDivElement | null) => {
-    surfaceNodeRef.current = node;
+    setSurfaceNode(node);
   }, []);
 
   const trackRef = useCallback(
@@ -372,7 +430,11 @@ const useSwipe = ({
     [setRestingTransform],
   );
 
-  return { surfaceRef, trackRef, phase };
+  // `phase` is intentionally not exposed: no consumer disables controls
+  // during commit, and exposing dead API encourages drift. The state is
+  // still tracked internally so the resize handler can defer width
+  // writes that would invalidate an in-flight animation target.
+  return { surfaceRef, trackRef };
 };
 
 export { useSwipe };

--- a/src/screens/Memories/components/useSwipe.ts
+++ b/src/screens/Memories/components/useSwipe.ts
@@ -80,6 +80,11 @@ const useSwipe = ({
 
   // Per-gesture state lives in refs to avoid React re-renders during drag.
   const cellWidthRef = useRef(0);
+  // When a resize fires mid-commit/mid-drag, applying the new width
+  // immediately would invalidate the in-flight `animateTrackTo` target
+  // (which captured the old width) and land off-center. Park the new
+  // width here and pick it up at the next idle moment.
+  const pendingCellWidthRef = useRef<number | null>(null);
   const dragRef = useRef({
     pointerId: -1,
     startX: 0,
@@ -143,18 +148,19 @@ const useSwipe = ({
     if (!surface) return;
     const measure = () => {
       const rect = surface.getBoundingClientRect();
-      if (rect.width > 0) {
+      if (rect.width <= 0) return;
+      // Defer both the width write and the resting transform reset
+      // until idle. Mutating `cellWidthRef.current` mid-commit would
+      // make the in-flight `animateTrackTo` (which already captured
+      // the old width for its target transform) land off-center
+      // against the new width. Resetting the transform mid-commit
+      // would cancel the transition with the wrong bitmap visible.
+      if (dragRef.current.pointerId === -1 && phaseRef.current === 'idle') {
         cellWidthRef.current = rect.width;
-        // Only re-apply resting transform if no drag or commit
-        // animation is active. Reset mid-commit would cancel the
-        // transition and snap the track to -W with the wrong
-        // bitmap visible.
-        if (
-          dragRef.current.pointerId === -1 &&
-          phaseRef.current === 'idle'
-        ) {
-          setRestingTransform();
-        }
+        pendingCellWidthRef.current = null;
+        setRestingTransform();
+      } else {
+        pendingCellWidthRef.current = rect.width;
       }
     };
     measure();
@@ -274,14 +280,20 @@ const useSwipe = ({
       }
 
       // Suppress the trailing click some browsers fire after a
-      // captured horizontal-locked gesture. The trailing click
-      // arrives within a few ms; clear the flag after a short
-      // window so a stale value doesn't eat an unrelated click
-      // from the next user interaction.
-      consumedClickRef.current = true;
-      window.setTimeout(() => {
-        consumedClickRef.current = false;
-      }, 350);
+      // captured horizontal-locked gesture. Only arm when the
+      // gesture actually travelled past the axis-lock threshold —
+      // a tiny axis-locked wiggle that settles back near origin
+      // shouldn't eat a subsequent deliberate tap. Keep the window
+      // tight: the synthesized click arrives within a few ms of
+      // pointerup, well under 50ms, but a 350ms blanket would
+      // swallow legitimate taps on `[close]`, prev/next, or a
+      // group photo within the same interaction beat.
+      if (Math.abs(dx) > AXIS_LOCK_THRESHOLD_PX) {
+        consumedClickRef.current = true;
+        window.setTimeout(() => {
+          consumedClickRef.current = false;
+        }, 50);
+      }
 
       const { hasPrev, hasNext, onCommitPrev, onCommitNext } =
         callbacksRef.current;
@@ -304,6 +316,13 @@ const useSwipe = ({
         if (willCommit) {
           if (goingPrev) onCommitPrev?.();
           else if (goingNext) onCommitNext?.();
+        }
+        // Apply any width that arrived from a mid-commit resize
+        // before snapping back to rest, so the resting transform
+        // is computed against the current surface width.
+        if (pendingCellWidthRef.current !== null) {
+          cellWidthRef.current = pendingCellWidthRef.current;
+          pendingCellWidthRef.current = null;
         }
         // Snap track back to resting position with no transition.
         // The parent's wouter navigate (called above) will swap


### PR DESCRIPTION
## Summary

Rewrites the Memories lightbox swipe to feel native on mobile: 1:1 finger-tracked drag, the next photo visible during the slide, no placeholder flash on commit, and velocity-based easing.

## Commentary

Three problems compounded into the current jitter: every `touchmove` re-rendered the whole lightbox tree, the `useSwipe` `useEffect` had no deps array so listeners were torn down and re-bound on every drag frame, and only the current photo translated — committing snapped it back to center while the new image popped in mid-fade.

Fix is layered:

- **`useSwipe` rewrite** — Pointer Events with `setPointerCapture` deferred until axis lock (so taps on close / prev / next / drill-in still fire), rAF-throttled offset writes straight to `track.style.transform`, no React state during drag, listeners bound exactly once via `useLayoutEffect`. Velocity-based commit duration (180–360ms) with `cubic-bezier(0.2, 0.8, 0.2, 1)`. Capture-phase `click` interceptor + `consumedClickRef` eats the trailing click after a horizontal-locked gesture — armed off the *raw* pointer delta (not the rubber-banded value, so no-neighbor boundary swipes still suppress correctly), with a tight 50ms window so deliberate taps on `[close]` / prev / next / group-photo issued right after a swipe still fire.
- **3-cell carousel track** — `Lightbox` and `GroupLightbox` render prev / center / next cells keyed **by position, not by file** so the post-commit reset is flicker-free. The hook animates the track to the neighbor cell, fires the wouter `navigate(...)`, then snaps back to `-cellWidth` in the same task; the React render flushes the new photo into the now-visible center cell.
- **Warm-image cache** (`imageCache.ts`) — `warmImage(src)` resolves once `img.decode()` succeeds and records the src in a module-level `Set`. `PhotoCell` initializes `loaded` from `isWarm(...)`, so warm neighbors mount with `opacity: 1` from the first frame — no placeholder fade between swipes.
- **Neighbors prop** — `FragmentDetail` computes `{ prev, next }` from existing `gridItems` / `groupPhotos` ordering. Group neighbors use the cover photo (first photo); intra-group boundaries return `null`, preserving today's "no drilling out via swipe" behavior.
- **CSS hints** — `.memories-swipe-surface { touch-action: pan-y }` so the browser keeps vertical scroll and we never need non-passive `preventDefault()`. `.memories-track { will-change: transform; transform: translateZ(0); user-select: none }` to lock the layer onto the compositor.
- **Mid-commit resize safety** — `ResizeObserver` measurements that arrive while a commit animation is in flight no longer mutate `cellWidthRef`; the new width is parked in `pendingCellWidthRef` and applied at the end of the commit (and now also on the vertical / untriggered early-return path), so rotate / devtools toggles during a slide or vertical-locked drag can't make the track land off-center.
- **Animation cancellation on re-grab** — A new `pointerdown` arriving mid-commit/mid-snap-back tears down the in-flight `transitionend` listener and `setTimeout(durationMs + 50)` fallback. Without this, the first `pointermove` writes `transition: none` and silently cancels the CSS transition; the timeout would still fire later inside the new drag, yanking the track to center (or re-firing the navigate callback).
- **Surface listener-binding hardening** — Surface node held in `useState`, so the listener-binding `useLayoutEffect` actually re-runs if the surface DOM node is ever swapped, instead of leaving listeners bound to a detached node.
- **Hook order in `FragmentDetail`** — moved the `!fragment` early return below all `useMemo` calls so the hook count is stable across render paths (Rules of Hooks).
- **Public-API hygiene** — `useSwipe` no longer returns `phase` since no consumer reads it; the state is still tracked internally for the resize deferral guard.

Spec: \`docs/wu-json/specs/archived/2026-04-27-memories-mobile-swipe-feel.md\` (status: implemented).