### PR TITLE
feat: allow cloudflare quick tunnel hosts in dev server

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -13,6 +13,7 @@ export default defineConfig({
   server: {
     open: true,
     port: 3000,
+    allowedHosts: ['.trycloudflare.com'],
   },
   resolve: { alias: { src: path.resolve(__dirname, './src') } },
 });


### PR DESCRIPTION
## Summary
Adds `.trycloudflare.com` to Vite's `server.allowedHosts` so `cloudflared tunnel` URLs aren't rejected by the dev server's host check.

## Commentary
The leading dot makes it a wildcard, so any fresh `*.trycloudflare.com` quick-tunnel URL works without re-editing the config. Only affects the dev server — no prod impact.