### PR TITLE
fix: slim custom scrollbar that matches dark/light theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -912,6 +912,41 @@ html[data-theme-flash-reset] .nav-glitch-active {
   }
 }
 
+/* ── Scrollbar ───────────────────────────────────────────────────────
+   Slim, understated scrollbar that blends into the surface.  WebKit
+   (Chrome / Safari / Edge) gets the full treatment; Firefox uses the
+   standard `scrollbar-width` / `scrollbar-color` shorthand.
+   ─────────────────────────────────────────────────────────────────── */
+
+/* Firefox */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-ink-hair) transparent;
+}
+
+/* WebKit */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--color-ink-hair);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-ink-trace);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 @layer base {
   html,
   body {


### PR DESCRIPTION
## Summary

Replaces the default browser scrollbar with a slim 6px custom scrollbar styled via CSS custom properties, so it blends unobtrusively into the existing dark and light themes.

## Commentary

Uses `scrollbar-width: thin` + `scrollbar-color` for Firefox, and `::-webkit-scrollbar` pseudo-elements for Chrome/Safari/Edge. The thumb draws from `--color-ink-hair` (barely visible) and brightens to `--color-ink-trace` on hover — both tokens already flip between themes, so the scrollbar is equally subtle on black and white surfaces.