### PR TITLE
fix: increase blockquote callout contrast in signal-prose for both themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -701,9 +701,11 @@ html[data-theme-flash-reset] .nav-glitch-active {
   padding-left: 1.25em;
 }
 .signal-prose blockquote {
-  border-left: 2px solid var(--color-ink-trace);
-  padding-left: 1em;
-  color: var(--color-ink-faint);
+  border-left: 2px solid var(--color-ink-ghost);
+  background: var(--color-ink-hair);
+  padding: 0.75em 1em;
+  border-radius: 0 4px 4px 0;
+  color: var(--color-ink-soft);
   margin: 0.75em 0;
 }
 .signal-prose h1,


### PR DESCRIPTION
## Summary

Blockquotes in signal-prose were nearly invisible in both dark and light themes. This improves contrast by bumping text from `--color-ink-faint` to `--color-ink-soft`, border from `--color-ink-trace` to `--color-ink-ghost`, and adding a subtle `--color-ink-hair` background with a soft right-side border-radius.

## Commentary

Before: border at 10% (dark) / 14% (light), text at 30% / 42%.  
After: border at 20% / 30%, text at 70% / 78%, plus a 5% / 7% background fill.

The `.signal-prose.signal-entry blockquote` override (wider margin) still applies via specificity and inherits the new color/padding.