### PR TITLE
fix: bump mobile text sizing while preserving desktop sizes

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -44,7 +44,7 @@ const NavLink = ({
   onClick?: () => void;
   children: React.ReactNode;
 }) => {
-  const className = `group flex items-center gap-1.5 font-pixel text-xs uppercase transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`;
+  const className = `group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`;
 
   return (
     <Link to={to} onClick={onClick} className={className}>

--- a/src/index.css
+++ b/src/index.css
@@ -744,11 +744,17 @@ html[data-theme-flash-reset] .nav-glitch-active {
   content: '// refs';
   display: block;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.625rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--color-ink-ghost);
   margin-bottom: 0.65rem;
+}
+
+@media (min-width: 640px) {
+  .signal-prose section[data-footnotes]::before {
+    font-size: 0.625rem;
+  }
 }
 
 .signal-prose section[data-footnotes] > h2#footnote-label {
@@ -767,8 +773,14 @@ html[data-theme-flash-reset] .nav-glitch-active {
   list-style-type: decimal;
   padding-left: 1.25rem;
   margin: 0;
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   color: var(--color-ink-muted);
+}
+
+@media (min-width: 640px) {
+  .signal-prose section[data-footnotes] ol {
+    font-size: 0.7rem;
+  }
 }
 
 .signal-prose section[data-footnotes] li {

--- a/src/screens/Constructs/ConstructDetail.tsx
+++ b/src/screens/Constructs/ConstructDetail.tsx
@@ -22,7 +22,7 @@ const ConstructDetail = ({ id }: { id: string }) => {
           </p>
           <Link
             to='/constructs'
-            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+            className='mt-4 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           >
             {'< return to constructs'}
           </Link>
@@ -36,7 +36,7 @@ const ConstructDetail = ({ id }: { id: string }) => {
       <div className='max-w-2xl mx-auto px-6 py-16 pb-32'>
         <Link
           to='/constructs'
-          className='bio-glitch inline-block mb-8 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+          className='bio-glitch inline-block mb-8 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           style={jitter()}
         >
           {'< return to constructs'}
@@ -77,7 +77,7 @@ const ConstructDetail = ({ id }: { id: string }) => {
         </header>
 
         <div
-          className='bio-glitch signal-prose text-white/70 text-xs sm:text-sm font-mono leading-loose'
+          className='bio-glitch signal-prose text-white/70 text-sm font-mono leading-loose'
           style={jitter()}
         >
           <Markdown
@@ -117,7 +117,7 @@ const ConstructDetail = ({ id }: { id: string }) => {
         </div>
 
         <footer className='mt-12 pt-6 border-t border-white/5'>
-          <p className='text-white/20 text-[10px] font-mono uppercase tracking-widest'>
+          <p className='text-white/20 text-xs sm:text-[10px] font-mono uppercase tracking-widest'>
             {'// end'}
           </p>
         </footer>

--- a/src/screens/Constructs/index.tsx
+++ b/src/screens/Constructs/index.tsx
@@ -42,7 +42,7 @@ const ConstructsScreen = () => {
                 className='rounded-sm grayscale'
               />
               <div className='mt-3'>
-                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                <h2 className='text-white text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
                   {c.title}
                 </h2>
                 <div className='flex items-baseline gap-2 mt-1'>

--- a/src/screens/Gallery/index.tsx
+++ b/src/screens/Gallery/index.tsx
@@ -1346,7 +1346,7 @@ const GalleryScreen = ({ fragmentId }: { fragmentId?: string }) => {
   const hintBase =
     'font-pixel text-[color:var(--color-ink-faint)] text-sm tracking-[0.2em] select-none';
   const hintSub =
-    'font-pixel text-[color:var(--color-ink-ghost)] text-[10px] tracking-[0.15em] select-none mt-2';
+    'font-pixel text-[color:var(--color-ink-ghost)] text-xs sm:text-[10px] tracking-[0.15em] select-none mt-2';
 
   return (
     <div

--- a/src/screens/Heroes/HeroDetail.tsx
+++ b/src/screens/Heroes/HeroDetail.tsx
@@ -22,7 +22,7 @@ const HeroDetail = ({ id }: { id: string }) => {
           </p>
           <Link
             to='/heroes'
-            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+            className='mt-4 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           >
             {'< return to heroes'}
           </Link>
@@ -36,7 +36,7 @@ const HeroDetail = ({ id }: { id: string }) => {
       <div className='max-w-2xl mx-auto px-6 py-16 pb-32'>
         <Link
           to='/heroes'
-          className='bio-glitch inline-block mb-8 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+          className='bio-glitch inline-block mb-8 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           style={jitter()}
         >
           {'< return to heroes'}
@@ -79,7 +79,7 @@ const HeroDetail = ({ id }: { id: string }) => {
         </header>
 
         <div
-          className='bio-glitch signal-prose text-white/70 text-xs sm:text-sm font-mono leading-loose'
+          className='bio-glitch signal-prose text-white/70 text-sm font-mono leading-loose'
           style={jitter()}
         >
           <Markdown
@@ -119,7 +119,7 @@ const HeroDetail = ({ id }: { id: string }) => {
         </div>
 
         <footer className='mt-12 pt-6 border-t border-white/5'>
-          <p className='text-white/20 text-[10px] font-mono uppercase tracking-widest'>
+          <p className='text-white/20 text-xs sm:text-[10px] font-mono uppercase tracking-widest'>
             {'// end'}
           </p>
         </footer>

--- a/src/screens/Heroes/index.tsx
+++ b/src/screens/Heroes/index.tsx
@@ -42,7 +42,7 @@ const HeroesScreen = () => {
                 className='rounded-sm grayscale'
               />
               <div className='mt-3'>
-                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                <h2 className='text-white text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
                   {h.title}
                 </h2>
                 <div className='flex items-baseline gap-2 mt-1'>

--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -3,10 +3,10 @@ import { useJitter } from 'src/hooks/useJitter';
 import { SpiderLily } from '../../SpiderLily';
 
 const linkClass =
-  'font-mono text-xs uppercase tracking-widest text-white/50 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300';
+  'font-mono text-sm sm:text-xs uppercase tracking-widest text-white/50 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300';
 
 const bioClass =
-  'bio-glitch text-white text-xs sm:text-sm font-pixel text-left leading-relaxed';
+  'bio-glitch text-white text-sm font-pixel text-left leading-relaxed';
 
 const MainBanner = () => {
   const jitter = useJitter();
@@ -28,7 +28,7 @@ const MainBanner = () => {
         </div>
         <div className='flex flex-col gap-4'>
           <p
-            className='bio-glitch text-white text-sm sm:text-base font-pixel text-left leading-relaxed [text-shadow:0_0_8px_rgba(255,255,255,0.4)]'
+            className='bio-glitch text-white text-base font-pixel text-left leading-relaxed [text-shadow:0_0_8px_rgba(255,255,255,0.4)]'
             style={jitter()}
           >
             {'[BLOOM AND WILT]'}
@@ -55,7 +55,7 @@ const MainBanner = () => {
           >
             GitHub
           </a>
-          <span className='text-white/20 text-xs'>/</span>
+          <span className='text-white/20 text-sm sm:text-xs'>/</span>
           <a
             href='https://www.linkedin.com/in/wu-json/'
             target='_blank'
@@ -64,7 +64,7 @@ const MainBanner = () => {
           >
             LinkedIn
           </a>
-          <span className='text-white/20 text-xs'>/</span>
+          <span className='text-white/20 text-sm sm:text-xs'>/</span>
           <a
             href='https://www.instagram.com/jasoncuiwu/'
             target='_blank'
@@ -73,7 +73,7 @@ const MainBanner = () => {
           >
             Instagram
           </a>
-          <span className='text-white/20 text-xs'>/</span>
+          <span className='text-white/20 text-sm sm:text-xs'>/</span>
           <a
             href='https://x.com/jasoncuiwu'
             target='_blank'

--- a/src/screens/Memories/FragmentDetail.tsx
+++ b/src/screens/Memories/FragmentDetail.tsx
@@ -155,7 +155,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
           </p>
           <Link
             to='/memories'
-            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+            className='mt-4 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           >
             {'< return to memories'}
           </Link>
@@ -341,7 +341,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
       <div className='max-w-4xl mx-auto px-6 py-16 pb-32'>
         <Link
           to='/memories'
-          className='bio-glitch inline-block mb-8 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+          className='bio-glitch inline-block mb-8 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           style={jitter()}
         >
           {'< return to memories'}
@@ -356,13 +356,13 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
           </h1>
           <div className='flex items-baseline gap-3 flex-wrap'>
             <span
-              className='bio-glitch text-white/30 text-[10px] font-mono'
+              className='bio-glitch text-white/30 text-xs sm:text-[10px] font-mono'
               style={jitter()}
             >
               {fragment.date}
             </span>
             <span
-              className='bio-glitch text-white/20 text-[10px] font-mono'
+              className='bio-glitch text-white/20 text-xs sm:text-[10px] font-mono'
               style={jitter()}
             >
               — {fragment.location}
@@ -370,7 +370,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
           </div>
           <Link
             to={`/gallery/${fragment.id}`}
-            className='bio-glitch text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300 mt-3 inline-block'
+            className='bio-glitch text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300 mt-3 inline-block'
             style={jitter()}
           >
             {'> view in interactive gallery'}
@@ -379,7 +379,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
 
         {fragment.description && (
           <div
-            className='bio-glitch signal-prose text-white/70 text-xs sm:text-sm font-mono leading-loose mb-12'
+            className='bio-glitch signal-prose text-white/70 text-sm font-mono leading-loose mb-12'
             style={jitter()}
           >
             <Markdown>{fragment.description}</Markdown>
@@ -474,7 +474,7 @@ const FragmentDetail = ({ id, photo }: { id: string; photo?: string }) => {
         </div>
 
         <footer className='mt-12 pt-6 border-t border-white/5'>
-          <p className='text-white/20 text-[10px] font-mono uppercase tracking-widest'>
+          <p className='text-white/20 text-xs sm:text-[10px] font-mono uppercase tracking-widest'>
             {'// end'}
           </p>
         </footer>

--- a/src/screens/Memories/components/GroupSlide.tsx
+++ b/src/screens/Memories/components/GroupSlide.tsx
@@ -126,7 +126,7 @@ const GroupSlide = ({
       </div>
 
       <div
-        className={`flex items-center gap-4 text-[10px] font-mono transition-opacity duration-500 ${allLoaded ? 'opacity-100' : 'opacity-0'}`}
+        className={`flex items-center gap-4 text-xs sm:text-[10px] font-mono transition-opacity duration-500 ${allLoaded ? 'opacity-100' : 'opacity-0'}`}
       >
         <span className='text-white/30'>{counter}</span>
         {caption && (

--- a/src/screens/Memories/components/PhotoSlide.tsx
+++ b/src/screens/Memories/components/PhotoSlide.tsx
@@ -69,7 +69,7 @@ const PhotoSlide = ({
       </div>
 
       <div
-        className={`flex items-baseline gap-4 text-[10px] font-mono max-w-full transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        className={`flex items-baseline gap-4 text-xs sm:text-[10px] font-mono max-w-full transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
       >
         <span className='text-white/30 shrink-0'>{counter}</span>
         {photo.caption && (

--- a/src/screens/Memories/index.tsx
+++ b/src/screens/Memories/index.tsx
@@ -42,14 +42,14 @@ const MemoriesScreen = () => {
                 className={`rounded-sm ${f.coverClassName ?? ''}`}
               />
               <div className='mt-3'>
-                <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
+                <h2 className='text-white text-sm font-pixel uppercase tracking-wide group-hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'>
                   {f.title}
                 </h2>
                 <div className='flex items-baseline gap-2 mt-1'>
-                  <span className='text-white/30 text-[10px] font-mono'>
+                  <span className='text-white/30 text-xs sm:text-[10px] font-mono'>
                     {f.date}
                   </span>
-                  <span className='text-white/20 text-[10px] font-mono'>
+                  <span className='text-white/20 text-xs sm:text-[10px] font-mono'>
                     — {f.location}
                   </span>
                 </div>

--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -20,7 +20,7 @@ const SignalDetail = ({ id }: { id: string }) => {
           </p>
           <Link
             to='/signals'
-            className='mt-4 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+            className='mt-4 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           >
             {'< return to signals'}
           </Link>
@@ -34,7 +34,7 @@ const SignalDetail = ({ id }: { id: string }) => {
       <div className='max-w-2xl mx-auto px-6 py-16 pb-32'>
         <Link
           to='/signals'
-          className='bio-glitch inline-block mb-8 text-white/30 text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
+          className='bio-glitch inline-block mb-8 text-white/30 text-xs sm:text-[10px] font-mono uppercase tracking-widest hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)] transition-all duration-300'
           style={jitter()}
         >
           {'< return to signals'}
@@ -78,14 +78,14 @@ const SignalDetail = ({ id }: { id: string }) => {
         </header>
 
         <div
-          className='bio-glitch signal-prose signal-entry text-white/70 text-xs sm:text-sm font-mono'
+          className='bio-glitch signal-prose signal-entry text-white/70 text-sm font-mono'
           style={jitter()}
         >
           <MarkdownBody>{s.body}</MarkdownBody>
         </div>
 
         <footer className='mt-12 pt-6 border-t border-white/5'>
-          <p className='text-white/20 text-[10px] font-mono uppercase tracking-widest'>
+          <p className='text-white/20 text-xs sm:text-[10px] font-mono uppercase tracking-widest'>
             {'// end'}
           </p>
         </footer>

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -117,12 +117,12 @@ const SignalsScreen = () => {
                   </div>
 
                   {s.title && (
-                    <h2 className='text-white text-xs sm:text-sm font-pixel uppercase tracking-wide mb-2'>
+                    <h2 className='text-white text-sm font-pixel uppercase tracking-wide mb-2'>
                       {s.title}
                     </h2>
                   )}
 
-                  <div className='signal-prose signal-entry signal-list text-white/70 text-xs sm:text-sm font-mono'>
+                  <div className='signal-prose signal-entry signal-list text-white/70 text-sm font-mono'>
                     {collapsed ? (
                       <>
                         {hero && (
@@ -134,7 +134,7 @@ const SignalsScreen = () => {
                         {excerpt ? (
                           <p className='leading-relaxed'>{excerpt}</p>
                         ) : (
-                          <p className='text-white/25 text-[10px] font-mono'>
+                          <p className='text-white/25 text-xs sm:text-[10px] font-mono'>
                             {'// preview truncated — open for full signal'}
                           </p>
                         )}
@@ -155,7 +155,7 @@ const SignalsScreen = () => {
             className='mt-8 flex justify-center'
             aria-hidden
           >
-            <span className='text-white/20 text-[10px] font-mono uppercase tracking-widest'>
+            <span className='text-white/20 text-xs sm:text-[10px] font-mono uppercase tracking-widest'>
               {'// loading more signal…'}
             </span>
           </div>


### PR DESCRIPTION
## Summary

Bumps mobile text sizes across the site without changing desktop sizes at all.

### Changes

| Element | Mobile before | Mobile after | Desktop |
|---|---|---|---|
| Body/prose text | 12px | **14px** | 14px (unchanged) |
| List titles | 12px | **14px** | 14px (unchanged) |
| Bio text (home) | 12px | **14px** | 14px (unchanged) |
| [BLOOM AND WILT] | 14px | **16px** | 16px (unchanged) |
| Nav links | 12px | **14px** | 12px (unchanged) |
| Footer links | 12px | **14px** | 12px (unchanged) |
| Utility text | 10px | **12px** | 10px (unchanged) |
| Footnote labels | 10px | **12px** | 10px (unchanged) |

### Approach

- Removed responsive breakpoints for primary content (e.g., `text-xs sm:text-sm` → just `text-sm`) — mobile gets the bump, desktop stays the same
- Added inverse responsive fallbacks where needed (e.g., `text-sm sm:text-xs`, `text-xs sm:text-[10px]`)
- Page/detail headers left unchanged to avoid mobile overflow
- All metadata, section subtitles, and secondary chrome left at original sizes