### PR TITLE
feat(signals): japanese-minimal hover — nudge + hairline left border

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -933,11 +933,21 @@ html[data-theme-flash-reset] .nav-glitch-active {
 }
 
 /* Signal list item hover. Gated behind `(hover: hover)` so iOS Safari
-   doesn't strand the tint on the last-tapped card while scrolling — most
-   noticeable in light mode where the hair-line tint reads as a real
-   highlight. */
+   doesn't strand the tint on the last-tapped card while scrolling.
+   A single restrained gesture — a gentle nudge right and a hairline left
+   border that appears like a margin note marker. */
 @media (hover: hover) {
+  .signal-list-item {
+    border-left: 2px solid transparent;
+    transition:
+      transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.4s ease,
+      background-color 0.4s ease;
+  }
+
   .signal-list-item:hover {
+    transform: translateX(4px);
+    border-left-color: var(--color-ink-ghost);
     background-color: var(--color-ink-hair);
   }
 }

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -103,14 +103,14 @@ const SignalsScreen = () => {
                   <div
                     className={`flex items-baseline gap-3 flex-wrap ${s.title ? 'mb-2' : 'mb-1'}`}
                   >
-                    <span className='text-white/20 text-xs font-mono shrink-0'>
+                    <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>
                       [{s.id}]
                     </span>
-                    <span className='text-white/30 text-xs font-mono shrink-0'>
+                    <span className='text-white/30 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/45'>
                       {s.timestamp}
                     </span>
                     {s.location && (
-                      <span className='text-white/20 text-xs font-mono shrink-0'>
+                      <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>
                         — {s.location}
                       </span>
                     )}


### PR DESCRIPTION
## Summary

Replaces the barely-visible background tint hover on signal list items with a single restrained gesture: a 4px translateX nudge right paired with a 2px left border that fades in. Metadata text brightens subtly on hover via the existing group pattern.

## Commentary

The original hover was a 5% white background — effectively invisible. The new approach uses one deliberate motion and one clean line, with no glow, no gradient. The left-border animation uses `cubic-bezier(0.16, 1, 0.3, 1)` for a slow, decelerating settle. All hover effects are gated behind `@media (hover: hover)` so iOS Safari won't strand the state on the last-tapped card.