### PR TITLE
feat: clean up signal id and timestamp display

### DIFF
--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -50,13 +50,13 @@ const SignalDetail = ({ id }: { id: string }) => {
               className='bio-glitch text-white/20 text-xs font-mono'
               style={jitter()}
             >
-              [{s.id}]
+              [{s.id.replace(/^\d{4}-\d{2}-\d{2}-/, '')}]
             </span>
             <span
               className='bio-glitch text-white/30 text-xs font-mono'
               style={jitter()}
             >
-              {s.timestamp}
+              {s.timestamp.replace(/ \/\/ /g, ' · ')}
             </span>
             {s.location && (
               <span

--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -56,7 +56,7 @@ const SignalDetail = ({ id }: { id: string }) => {
               className='bio-glitch text-white/30 text-xs font-mono'
               style={jitter()}
             >
-              {s.timestamp.replace(/ \/\/ /g, ' · ')}
+              {s.timestamp.replace(/ \/\/ /g, ' ')}
             </span>
             {s.location && (
               <span

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -104,10 +104,10 @@ const SignalsScreen = () => {
                     className={`flex items-baseline gap-3 flex-wrap ${s.title ? 'mb-2' : 'mb-1'}`}
                   >
                     <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>
-                      [{s.id}]
+                      [{s.id.replace(/^\d{4}-\d{2}-\d{2}-/, '')}]
                     </span>
                     <span className='text-white/30 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/45'>
-                      {s.timestamp}
+                      {s.timestamp.replace(/ \/\/ /g, ' · ')}
                     </span>
                     {s.location && (
                       <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -107,7 +107,7 @@ const SignalsScreen = () => {
                       [{s.id.replace(/^\d{4}-\d{2}-\d{2}-/, '')}]
                     </span>
                     <span className='text-white/30 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/45'>
-                      {s.timestamp.replace(/ \/\/ /g, ' · ')}
+                      {s.timestamp.replace(/ \/\/ /g, ' ')}
                     </span>
                     {s.location && (
                       <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>


### PR DESCRIPTION
## Summary

Strip the date prefix from signal IDs in brackets (the date was redundant with the timestamp), and replace the `//` separator in timestamps with a simple space for a cleaner, more minimal look.

## Before

```
[2026-04-28-farewells]  2026.04.28 // 09:55:10    — San Francisco, US
```

## After

```
[farewells]  2026.04.28 09:55:10    — San Francisco, US
```