### PR TITLE
fix: remove bracketed identifier from signal list and detail views

### DIFF
--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -47,12 +47,6 @@ const SignalDetail = ({ id }: { id: string }) => {
             className={`flex items-baseline gap-3 flex-wrap ${s.title ? 'mb-2' : ''}`}
           >
             <span
-              className='bio-glitch text-white/20 text-xs font-mono'
-              style={jitter()}
-            >
-              [{s.id.replace(/^\d{4}-\d{2}-\d{2}-/, '')}]
-            </span>
-            <span
               className='bio-glitch text-white/30 text-xs font-mono'
               style={jitter()}
             >

--- a/src/screens/Signals/index.tsx
+++ b/src/screens/Signals/index.tsx
@@ -103,9 +103,6 @@ const SignalsScreen = () => {
                   <div
                     className={`flex items-baseline gap-3 flex-wrap ${s.title ? 'mb-2' : 'mb-1'}`}
                   >
-                    <span className='text-white/20 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/40'>
-                      [{s.id.replace(/^\d{4}-\d{2}-\d{2}-/, '')}]
-                    </span>
                     <span className='text-white/30 text-xs font-mono shrink-0 transition-colors duration-300 group-hover:text-white/45'>
                       {s.timestamp.replace(/ \/\/ /g, ' ')}
                     </span>


### PR DESCRIPTION
## Summary

Removed the bracketed slug identifier (e.g. `[farewells]`) from signal list items and detail headers. Signal entries now display only the timestamp and, when available, the location — cleaner and less redundant.