### PR TITLE
feat: collapsible desktop sidebar

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -54,16 +54,43 @@ const NavLink = ({
   );
 };
 
+// Collapse action styled as a dimmer sibling of the nav links so it reads
+// as a footer/utility item rather than a route. Pinned to the bottom of
+// the nav column with mt-auto.
+const CollapseLink = ({ onClick }: { onClick: () => void }) => (
+  <button
+    type='button'
+    onClick={onClick}
+    aria-label='Collapse sidebar'
+    className='mt-auto group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/45 hover:text-white/85 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.25)]'
+  >
+    <svg
+      width='12'
+      height='12'
+      viewBox='0 0 10 14'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      className='shrink-0'
+    >
+      <polyline points='6 1 2 7 6 13' />
+    </svg>
+    Collapse
+  </button>
+);
+
 const Sidebar = ({
   isMobileOpen,
   onClose,
   isDesktopCollapsed,
-  onDesktopHoverChange,
+  onDesktopToggle,
 }: {
   isMobileOpen: boolean;
   onClose: () => void;
   isDesktopCollapsed: boolean;
-  onDesktopHoverChange: (hovered: boolean) => void;
+  onDesktopToggle: () => void;
 }) => {
   const [pathname] = useLocation();
 
@@ -112,14 +139,13 @@ const Sidebar = ({
       {/* Desktop sidebar */}
       <nav
         aria-hidden={isDesktopCollapsed}
-        onMouseEnter={() => onDesktopHoverChange(true)}
-        onMouseLeave={() => onDesktopHoverChange(false)}
-        className={`hidden md:flex flex-col items-start gap-5 px-4 py-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
+        className={`hidden md:flex flex-col px-4 py-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
       >
         <div
-          className={`flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}
+          className={`flex-1 flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}
         >
           {links()}
+          <CollapseLink onClick={onDesktopToggle} />
         </div>
       </nav>
 

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -58,10 +58,12 @@ const Sidebar = ({
   isMobileOpen,
   onClose,
   isDesktopCollapsed,
+  onDesktopHoverChange,
 }: {
   isMobileOpen: boolean;
   onClose: () => void;
   isDesktopCollapsed: boolean;
+  onDesktopHoverChange: (hovered: boolean) => void;
 }) => {
   const [pathname] = useLocation();
 
@@ -110,6 +112,8 @@ const Sidebar = ({
       {/* Desktop sidebar */}
       <nav
         aria-hidden={isDesktopCollapsed}
+        onMouseEnter={() => onDesktopHoverChange(true)}
+        onMouseLeave={() => onDesktopHoverChange(false)}
         className={`hidden md:flex flex-col items-start gap-5 px-4 py-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
       >
         <div

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -67,7 +67,7 @@ const CollapseLink = ({ onClick }: { onClick: () => void }) => (
     className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/40 hover:text-white/80 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.2)]'
   >
     <span aria-hidden className='block w-[14px] h-[14px] shrink-0' />
-    Hide
+    隠す
   </button>
 );
 

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -55,27 +55,29 @@ const NavLink = ({
 };
 
 // Collapse action styled as a dimmer sibling of the nav links so it reads
-// as a footer/utility item rather than a route. Pinned to the bottom of
-// the nav column with mt-auto.
+// as a footer/utility item rather than a route. Sits directly below the
+// last link so it stays close to the content; the chevron is sized to
+// match the LunarTear marker's 14×14 footprint, keeping the text column
+// aligned with the nav links above.
 const CollapseLink = ({ onClick }: { onClick: () => void }) => (
   <button
     type='button'
     onClick={onClick}
     aria-label='Collapse sidebar'
-    className='mt-auto group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/45 hover:text-white/85 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.25)]'
+    className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/45 hover:text-white/85 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.25)]'
   >
     <svg
-      width='12'
-      height='12'
-      viewBox='0 0 10 14'
+      width='14'
+      height='14'
+      viewBox='0 0 14 14'
       fill='none'
       stroke='currentColor'
-      strokeWidth='1.5'
+      strokeWidth='1'
       strokeLinecap='round'
       strokeLinejoin='round'
       className='shrink-0'
     >
-      <polyline points='6 1 2 7 6 13' />
+      <polyline points='11 2 3 7 11 12' />
     </svg>
     Collapse
   </button>
@@ -142,7 +144,7 @@ const Sidebar = ({
         className={`hidden md:flex flex-col px-4 py-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
       >
         <div
-          className={`flex-1 flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}
+          className={`flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}
         >
           {links()}
           <CollapseLink onClick={onDesktopToggle} />

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -110,7 +110,7 @@ const Sidebar = ({
       {/* Desktop sidebar */}
       <nav
         aria-hidden={isDesktopCollapsed}
-        className={`hidden md:flex flex-col items-start gap-5 px-4 pt-14 pb-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
+        className={`hidden md:flex flex-col items-start gap-5 px-4 py-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
       >
         <div
           className={`flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -44,7 +44,7 @@ const NavLink = ({
   onClick?: () => void;
   children: React.ReactNode;
 }) => {
-  const className = `group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`;
+  const className = `group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 ${active ? 'nav-glitch-active text-white [text-shadow:0_0_8px_rgba(255,255,255,0.6)]' : 'text-white/80 hover:text-white hover:[text-shadow:0_0_6px_rgba(255,255,255,0.3)]'}`;
 
   return (
     <Link to={to} onClick={onClick} className={className}>
@@ -57,9 +57,11 @@ const NavLink = ({
 const Sidebar = ({
   isMobileOpen,
   onClose,
+  isDesktopCollapsed,
 }: {
   isMobileOpen: boolean;
   onClose: () => void;
+  isDesktopCollapsed: boolean;
 }) => {
   const [pathname] = useLocation();
 
@@ -106,8 +108,15 @@ const Sidebar = ({
   return (
     <>
       {/* Desktop sidebar */}
-      <nav className='hidden md:flex flex-col items-start gap-5 w-40 px-4 h-full bg-black py-6'>
-        {links()}
+      <nav
+        aria-hidden={isDesktopCollapsed}
+        className={`hidden md:flex flex-col items-start gap-5 px-4 pt-14 pb-6 h-full bg-black overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${isDesktopCollapsed ? 'w-0' : 'w-40'}`}
+      >
+        <div
+          className={`flex flex-col items-start gap-5 transition-[opacity,transform] duration-300 ease-out ${isDesktopCollapsed ? 'opacity-0 -translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0 delay-150'}`}
+        >
+          {links()}
+        </div>
       </nav>
 
       {/* Mobile overlay */}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -54,31 +54,19 @@ const NavLink = ({
   );
 };
 
-// Collapse action styled as a dimmer sibling of the nav links so it reads
-// as a footer/utility item rather than a route. Sits directly below the
-// last link so it stays close to the content; the chevron is sized to
-// match the LunarTear marker's 14×14 footprint, keeping the text column
-// aligned with the nav links above.
+// Collapse action styled as a dimmer sibling of the nav links. Inactive
+// nav links don't render a visible marker (their LunarTear is opacity-0
+// but still occupies space), so Collapse uses a transparent spacer of the
+// same footprint to keep the text column aligned and avoid the visual
+// weight of a permanent icon next to the inactive links above.
 const CollapseLink = ({ onClick }: { onClick: () => void }) => (
   <button
     type='button'
     onClick={onClick}
     aria-label='Collapse sidebar'
-    className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/45 hover:text-white/85 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.25)]'
+    className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/40 hover:text-white/80 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.2)]'
   >
-    <svg
-      width='14'
-      height='14'
-      viewBox='0 0 14 14'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='1'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-      className='shrink-0'
-    >
-      <polyline points='11 2 3 7 11 12' />
-    </svg>
+    <span aria-hidden className='block w-[14px] h-[14px] shrink-0' />
     Collapse
   </button>
 );

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -63,11 +63,11 @@ const CollapseLink = ({ onClick }: { onClick: () => void }) => (
   <button
     type='button'
     onClick={onClick}
-    aria-label='Collapse sidebar'
+    aria-label='Hide sidebar'
     className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/40 hover:text-white/80 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.2)]'
   >
     <span aria-hidden className='block w-[14px] h-[14px] shrink-0' />
-    Collapse
+    Hide
   </button>
 );
 

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -64,7 +64,7 @@ const CollapseLink = ({ onClick }: { onClick: () => void }) => (
     type='button'
     onClick={onClick}
     aria-label='Hide sidebar'
-    className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap transition-all duration-300 text-white/40 hover:text-white/80 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.2)]'
+    className='group flex items-center gap-1.5 font-pixel text-sm md:text-xs uppercase whitespace-nowrap cursor-pointer transition-all duration-300 text-white/40 hover:text-white/80 hover:[text-shadow:0_0_6px_rgba(255,255,255,0.2)]'
   >
     <span aria-hidden className='block w-[14px] h-[14px] shrink-0' />
     隠す

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
-@import 'tailwindcss';
 @import url('https://fonts.googleapis.com/css2?family=DotGothic16&display=swap');
+@import 'tailwindcss';
 
 /* Theming: data-theme on <html> drives every palette swap. Default is dark;
    light mode is activated by clicking the home-page spider lily. See

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import url('https://fonts.googleapis.com/css2?family=DotGothic16&display=swap');
 
 /* Theming: data-theme on <html> drives every palette swap. Default is dark;
    light mode is activated by clicking the home-page spider lily. See
@@ -121,7 +122,7 @@
   --font-mono:
     'Geist Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, 'Liberation Mono', 'Courier New', monospace;
-  --font-pixel: 'Geist Pixel Circle';
+  --font-pixel: 'Geist Pixel Circle', 'DotGothic16', sans-serif;
 
   --color-surface-token: var(--color-surface);
   --color-ink-token: var(--color-ink);

--- a/src/index.css
+++ b/src/index.css
@@ -276,10 +276,10 @@ html[data-theme-flash-reset] .nav-glitch-active {
     opacity 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-@keyframes navigator-label-rise {
+@keyframes atlas-char-rise {
   from {
     opacity: 0;
-    transform: translateY(-6px);
+    transform: translateY(-4px);
   }
   to {
     opacity: 1;
@@ -287,8 +287,8 @@ html[data-theme-flash-reset] .nav-glitch-active {
   }
 }
 
-.navigator-label {
-  animation: navigator-label-rise 400ms 100ms ease-out both;
+.atlas-char-rise {
+  animation: atlas-char-rise 350ms ease-out both;
 }
 
 /* Spider lily — side view bloom animation */

--- a/src/index.css
+++ b/src/index.css
@@ -276,6 +276,21 @@ html[data-theme-flash-reset] .nav-glitch-active {
     opacity 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+@keyframes navigator-label-rise {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.navigator-label {
+  animation: navigator-label-rise 400ms 100ms ease-out both;
+}
+
 /* Spider lily — side view bloom animation */
 
 @keyframes lily-stem-rise {

--- a/src/index.css
+++ b/src/index.css
@@ -276,20 +276,6 @@ html[data-theme-flash-reset] .nav-glitch-active {
     opacity 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.sidebar-petal {
-  transform-origin: 50px 50px;
-  transition:
-    transform 500ms cubic-bezier(0.34, 1.56, 0.64, 1),
-    opacity 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.sidebar-center {
-  transform-origin: 50px 50px;
-  transition:
-    transform 500ms cubic-bezier(0.34, 1.56, 0.64, 1),
-    opacity 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
 /* Spider lily — side view bloom animation */
 
 @keyframes lily-stem-rise {

--- a/src/index.css
+++ b/src/index.css
@@ -276,6 +276,20 @@ html[data-theme-flash-reset] .nav-glitch-active {
     opacity 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+.sidebar-petal {
+  transform-origin: 50px 50px;
+  transition:
+    transform 500ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.sidebar-center {
+  transform-origin: 50px 50px;
+  transition:
+    transform 500ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 500ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 /* Spider lily — side view bloom animation */
 
 @keyframes lily-stem-rise {

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -109,6 +109,8 @@ const MenuToggle = ({
 // nav-glitch only fires on first paint when the sidebar boots already
 // collapsed — subsequent toggles fall back to the plain opacity fade so
 // flipping the sidebar doesn't feel jittery.
+const ATLAS_CHARS = ['A', 't', 'l', 'a', 's'];
+
 const SidebarToggle = ({
   visible,
   onClick,
@@ -117,10 +119,23 @@ const SidebarToggle = ({
   onClick: () => void;
 }) => {
   const isFirstRenderRef = useRef(true);
-  const glitchOnLoad = visible && isFirstRenderRef.current;
+  // riseKey re-mounts each Atlas character span on subsequent transitions
+  // into the collapsed state, replaying the per-character rise. The glitch
+  // and char-rise are mutually exclusive: glitch fires only on first paint
+  // (if booting collapsed), char-rise fires only on subsequent collapses.
+  const [riseKey, setRiseKey] = useState(0);
+
   useEffect(() => {
-    isFirstRenderRef.current = false;
-  }, []);
+    if (!isFirstRenderRef.current && visible) {
+      setRiseKey(k => k + 1);
+    }
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+    }
+  }, [visible]);
+
+  const glitchOnLoad = visible && isFirstRenderRef.current;
+  const charAnimClass = isFirstRenderRef.current ? '' : 'atlas-char-rise';
 
   return (
     <button
@@ -145,8 +160,20 @@ const SidebarToggle = ({
       >
         <polyline points='9 1 1 7 9 13' />
       </svg>
-      <span className='navigator-label font-pixel text-[11px] uppercase tracking-[0.55em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
-        Atlas
+      <span
+        aria-label='Atlas'
+        className='flex flex-col items-center gap-[0.55em] font-pixel text-[11px] uppercase text-[var(--color-ink-muted)] select-none'
+      >
+        {ATLAS_CHARS.map((c, i) => (
+          <span
+            key={`${riseKey}-${i}`}
+            aria-hidden
+            style={{ animationDelay: `${i * 70}ms` }}
+            className={charAnimClass}
+          >
+            {c}
+          </span>
+        ))}
       </span>
     </button>
   );

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -102,10 +102,10 @@ const MenuToggle = ({
   </button>
 );
 
-// Desktop-only sidebar collapse toggle. Reuses the LunarTear flower:
-// expanded = full bloom (5 petals out), collapsed = closed bud (petals
-// retract toward the center). Petals stagger so it feels like a flower
-// folding/unfolding.
+// Desktop-only sidebar collapse toggle. Sits in the gutter at the right
+// edge of the sidebar so it never collides with the link column or the
+// active-route LunarTear marker. When the sidebar collapses, the toggle
+// slides over to the screen's left edge so it remains reachable.
 const SidebarToggle = ({
   collapsed,
   onClick,
@@ -118,44 +118,20 @@ const SidebarToggle = ({
     onClick={onClick}
     aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
     aria-expanded={!collapsed}
-    className='hidden md:flex fixed top-4 left-4 z-[60] justify-center items-center w-8 h-8 group'
+    className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-[60] justify-center items-center w-7 h-10 group transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-0' : 'left-[8.5rem]'}`}
   >
     <svg
-      width='20'
-      height='20'
-      viewBox='0 0 100 100'
+      width='10'
+      height='14'
+      viewBox='0 0 10 14'
       fill='none'
-      className='menu-flower text-[var(--color-ink)] transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:scale-110'
+      stroke='currentColor'
+      strokeWidth='1.25'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      className={`text-white/35 group-hover:text-white/90 group-hover:[filter:drop-shadow(0_0_5px_rgba(255,255,255,0.45))] transition-[transform,color,filter] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${collapsed ? 'rotate-180' : ''}`}
     >
-      {PETAL_ANGLES.map((angle, i) => (
-        <ellipse
-          key={angle}
-          cx='50'
-          cy='22'
-          rx='10'
-          ry='22'
-          fill='currentColor'
-          className='sidebar-petal'
-          style={{
-            transform: `rotate(${angle}deg) scale(${collapsed ? 0 : 1})`,
-            opacity: collapsed ? 0 : 0.85,
-            transitionDelay: collapsed
-              ? `${(PETAL_ANGLES.length - 1 - i) * 50}ms`
-              : `${i * 50}ms`,
-          }}
-        />
-      ))}
-      <circle
-        cx='50'
-        cy='50'
-        r='8'
-        fill='currentColor'
-        className='sidebar-center'
-        style={{
-          transform: `scale(${collapsed ? 1.05 : 1})`,
-          opacity: collapsed ? 1 : 0.95,
-        }}
-      />
+      <polyline points='6 1 2 7 6 13' />
     </svg>
   </button>
 );

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -120,7 +120,7 @@ const SidebarToggle = ({
     aria-expanded={!visible}
     aria-hidden={!visible}
     tabIndex={visible ? 0 : -1}
-    className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+    className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto nav-glitch-active' : 'opacity-0 pointer-events-none'}`}
   >
     <svg
       width='12'

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -145,7 +145,7 @@ const SidebarToggle = ({
       aria-expanded={!visible}
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
-      className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} ${glitchOnLoad ? 'nav-glitch-active' : ''}`}
+      className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 cursor-pointer transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} ${glitchOnLoad ? 'nav-glitch-active' : ''}`}
     >
       <svg
         width='12'

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -102,15 +102,86 @@ const MenuToggle = ({
   </button>
 );
 
+// Desktop-only sidebar collapse toggle. Reuses the LunarTear flower:
+// expanded = full bloom (5 petals out), collapsed = closed bud (petals
+// retract toward the center). Petals stagger so it feels like a flower
+// folding/unfolding.
+const SidebarToggle = ({
+  collapsed,
+  onClick,
+}: {
+  collapsed: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type='button'
+    onClick={onClick}
+    aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+    aria-expanded={!collapsed}
+    className='hidden md:flex fixed top-4 left-4 z-[60] justify-center items-center w-8 h-8 group'
+  >
+    <svg
+      width='20'
+      height='20'
+      viewBox='0 0 100 100'
+      fill='none'
+      className='menu-flower text-[var(--color-ink)] transition-transform duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:scale-110'
+    >
+      {PETAL_ANGLES.map((angle, i) => (
+        <ellipse
+          key={angle}
+          cx='50'
+          cy='22'
+          rx='10'
+          ry='22'
+          fill='currentColor'
+          className='sidebar-petal'
+          style={{
+            transform: `rotate(${angle}deg) scale(${collapsed ? 0 : 1})`,
+            opacity: collapsed ? 0 : 0.85,
+            transitionDelay: collapsed
+              ? `${(PETAL_ANGLES.length - 1 - i) * 50}ms`
+              : `${i * 50}ms`,
+          }}
+        />
+      ))}
+      <circle
+        cx='50'
+        cy='50'
+        r='8'
+        fill='currentColor'
+        className='sidebar-center'
+        style={{
+          transform: `scale(${collapsed ? 1.05 : 1})`,
+          opacity: collapsed ? 1 : 0.95,
+        }}
+      />
+    </svg>
+  </button>
+);
+
+const SIDEBAR_COLLAPSED_KEY = 'sidebarCollapsed';
+
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   const mainRef = useRef<HTMLElement>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+  });
 
   const closeMobileMenu = useCallback(() => setIsMobileMenuOpen(false), []);
   const toggleMobileMenu = useCallback(
     () => setIsMobileMenuOpen(prev => !prev),
     [],
   );
+  const toggleSidebar = useCallback(() => {
+    setIsSidebarCollapsed(prev => {
+      const next = !prev;
+      window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     document.body.style.overflow = isMobileMenuOpen ? 'hidden' : '';
@@ -121,7 +192,12 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className='flex h-full w-full overflow-hidden'>
-      <Sidebar isMobileOpen={isMobileMenuOpen} onClose={closeMobileMenu} />
+      <Sidebar
+        isMobileOpen={isMobileMenuOpen}
+        onClose={closeMobileMenu}
+        isDesktopCollapsed={isSidebarCollapsed}
+      />
+      <SidebarToggle collapsed={isSidebarCollapsed} onClick={toggleSidebar} />
       <MenuToggle open={isMobileMenuOpen} onClick={toggleMobileMenu} />
       <main ref={mainRef} className='flex-1 min-w-0 overflow-y-auto'>
         {children}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -154,13 +154,14 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
     if (typeof window === 'undefined') return false;
     return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
   });
-  // Multiple independent hover sources (sidebar nav, the toggle button, the
-  // collapsed hot zone) are tracked separately so a mouseleave on one
-  // doesn't override an active hover on another when the regions overlap.
+  // Sidebar nav and toggle button track hover independently so a mouseleave
+  // on one doesn't override an active hover on the other when the regions
+  // overlap. When the sidebar is collapsed the toggle stays visible
+  // unconditionally — without the sidebar there's no other affordance to
+  // signal that nav is reachable.
   const [sidebarHovered, setSidebarHovered] = useState(false);
   const [toggleHovered, setToggleHovered] = useState(false);
-  const [hotZoneHovered, setHotZoneHovered] = useState(false);
-  const showToggle = sidebarHovered || toggleHovered || hotZoneHovered;
+  const showToggle = isSidebarCollapsed || sidebarHovered || toggleHovered;
 
   const closeMobileMenu = useCallback(() => setIsMobileMenuOpen(false), []);
   const toggleMobileMenu = useCallback(
@@ -196,17 +197,6 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         onClick={toggleSidebar}
         onHoverChange={setToggleHovered}
       />
-      {isSidebarCollapsed && (
-        <button
-          type='button'
-          onClick={toggleSidebar}
-          onMouseEnter={() => setHotZoneHovered(true)}
-          onMouseLeave={() => setHotZoneHovered(false)}
-          aria-label='Expand sidebar'
-          tabIndex={-1}
-          className='hidden md:block fixed top-0 bottom-0 left-0 w-3 z-[55]'
-        />
-      )}
       <MenuToggle open={isMobileMenuOpen} onClick={toggleMobileMenu} />
       <main ref={mainRef} className='flex-1 min-w-0 overflow-y-auto'>
         {children}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -103,43 +103,54 @@ const MenuToggle = ({
 );
 
 // Collapsed-state expand handle. Renders as a tall left-edge column with a
-// chevron above a vertical "NAVIGATOR" pixel label, turning the empty rail
+// chevron above a vertical "ATLAS" pixel label, turning the empty rail
 // into a deliberate design element. Always rendered so its opacity can
-// animate; pointer-events are disabled when the sidebar is expanded.
+// animate; pointer-events are disabled when the sidebar is expanded. The
+// nav-glitch only fires on first paint when the sidebar boots already
+// collapsed — subsequent toggles fall back to the plain opacity fade so
+// flipping the sidebar doesn't feel jittery.
 const SidebarToggle = ({
   visible,
   onClick,
 }: {
   visible: boolean;
   onClick: () => void;
-}) => (
-  <button
-    type='button'
-    onClick={onClick}
-    aria-label='Expand sidebar'
-    aria-expanded={!visible}
-    aria-hidden={!visible}
-    tabIndex={visible ? 0 : -1}
-    className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto nav-glitch-active' : 'opacity-0 pointer-events-none'}`}
-  >
-    <svg
-      width='12'
-      height='16'
-      viewBox='0 0 10 14'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='1'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-      className='text-[var(--color-ink)] [filter:drop-shadow(0_0_5px_var(--color-glow-strong))] rotate-180'
+}) => {
+  const isFirstRenderRef = useRef(true);
+  const glitchOnLoad = visible && isFirstRenderRef.current;
+  useEffect(() => {
+    isFirstRenderRef.current = false;
+  }, []);
+
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-label='Expand sidebar'
+      aria-expanded={!visible}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} ${glitchOnLoad ? 'nav-glitch-active' : ''}`}
     >
-      <polyline points='9 1 1 7 9 13' />
-    </svg>
-    <span className='navigator-label font-pixel text-[11px] uppercase tracking-[0.55em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
-      Atlas
-    </span>
-  </button>
-);
+      <svg
+        width='12'
+        height='16'
+        viewBox='0 0 10 14'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        className='text-[var(--color-ink)] [filter:drop-shadow(0_0_5px_var(--color-glow-strong))] rotate-180'
+      >
+        <polyline points='9 1 1 7 9 13' />
+      </svg>
+      <span className='navigator-label font-pixel text-[11px] uppercase tracking-[0.55em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
+        Atlas
+      </span>
+    </button>
+  );
+};
 
 const SIDEBAR_COLLAPSED_KEY = 'sidebarCollapsed';
 

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -127,7 +127,7 @@ const SidebarToggle = ({
     onMouseLeave={() => onHoverChange(false)}
     aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
     aria-expanded={!collapsed}
-    className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-[60] justify-center items-center w-9 h-9 transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-1' : 'left-[8rem]'} ${visible ? 'pointer-events-auto' : 'pointer-events-none'}`}
+    className={`hidden md:flex fixed top-20 z-[60] justify-center items-center w-9 h-9 transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-1' : 'left-[8rem]'} ${visible ? 'pointer-events-auto' : 'pointer-events-none'}`}
   >
     <svg
       width='12'

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -102,10 +102,11 @@ const MenuToggle = ({
   </button>
 );
 
-// Desktop-only sidebar collapse toggle. Sits in the gutter at the right
-// edge of the sidebar so it never collides with the link column or the
-// active-route LunarTear marker. When the sidebar collapses, the toggle
-// slides over to the screen's left edge so it remains reachable.
+// Desktop-only sidebar collapse toggle. Sits at the bottom of the sidebar's
+// right edge (when expanded) and slides to the screen's bottom-left corner
+// (when collapsed) so it always has a corner or boundary to anchor against
+// — never floating in the middle. A persistent soft glow makes it
+// discoverable at rest.
 const SidebarToggle = ({
   collapsed,
   onClick,
@@ -118,18 +119,18 @@ const SidebarToggle = ({
     onClick={onClick}
     aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
     aria-expanded={!collapsed}
-    className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-[60] justify-center items-center w-7 h-10 group transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-0' : 'left-[8.5rem]'}`}
+    className={`hidden md:flex fixed bottom-6 z-[60] justify-center items-center w-9 h-9 group transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-2' : 'left-[8rem]'}`}
   >
     <svg
-      width='10'
-      height='14'
+      width='12'
+      height='16'
       viewBox='0 0 10 14'
       fill='none'
       stroke='currentColor'
-      strokeWidth='1.25'
+      strokeWidth='1.5'
       strokeLinecap='round'
       strokeLinejoin='round'
-      className={`text-white/35 group-hover:text-white/90 group-hover:[filter:drop-shadow(0_0_5px_rgba(255,255,255,0.45))] transition-[transform,color,filter] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${collapsed ? 'rotate-180' : ''}`}
+      className={`text-white/55 [filter:drop-shadow(0_0_3px_rgba(255,255,255,0.2))] group-hover:text-white group-hover:[filter:drop-shadow(0_0_6px_rgba(255,255,255,0.55))] transition-[transform,color,filter] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${collapsed ? 'rotate-180' : ''}`}
     >
       <polyline points='6 1 2 7 6 13' />
     </svg>

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -102,32 +102,25 @@ const MenuToggle = ({
   </button>
 );
 
-// Desktop-only sidebar collapse toggle. Hidden at rest; revealed when the
-// sidebar (or, when collapsed, the screen's left-edge hot zone) is hovered.
-// Sits at the right edge of the sidebar near the link content when
-// expanded, and at the screen's left edge when collapsed. The chevron
-// color flips between hardcoded white (over the always-black sidebar) and
-// var(--color-ink) (over the themed main content) so it stays visible in
-// both light and dark mode.
+// Collapsed-state expand handle. Renders as a tall left-edge column with a
+// chevron above a vertical "NAVIGATOR" pixel label, turning the empty rail
+// into a deliberate design element. Always rendered so its opacity can
+// animate; pointer-events are disabled when the sidebar is expanded.
 const SidebarToggle = ({
-  collapsed,
   visible,
   onClick,
-  onHoverChange,
 }: {
-  collapsed: boolean;
   visible: boolean;
   onClick: () => void;
-  onHoverChange: (hovered: boolean) => void;
 }) => (
   <button
     type='button'
     onClick={onClick}
-    onMouseEnter={() => onHoverChange(true)}
-    onMouseLeave={() => onHoverChange(false)}
-    aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-    aria-expanded={!collapsed}
-    className={`hidden md:flex fixed top-20 z-[60] justify-center items-center w-9 h-9 transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-1' : 'left-[8rem]'} ${visible ? 'pointer-events-auto' : 'pointer-events-none'}`}
+    aria-label='Expand sidebar'
+    aria-expanded={!visible}
+    aria-hidden={!visible}
+    tabIndex={visible ? 0 : -1}
+    className={`hidden md:flex fixed top-20 left-3 z-[60] flex-col items-center gap-3 transition-opacity duration-500 ease-out ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
   >
     <svg
       width='12'
@@ -138,10 +131,13 @@ const SidebarToggle = ({
       strokeWidth='1.5'
       strokeLinecap='round'
       strokeLinejoin='round'
-      className={`${collapsed ? 'text-[var(--color-ink)]' : 'text-white'} ${visible ? `opacity-100 ${collapsed ? '[filter:drop-shadow(0_0_5px_var(--color-glow-strong))]' : '[filter:drop-shadow(0_0_5px_rgba(255,255,255,0.45))]'}` : 'opacity-0'} transition-[opacity,transform,filter,color] duration-300 ease-out ${collapsed ? 'rotate-180' : ''}`}
+      className='text-[var(--color-ink)] [filter:drop-shadow(0_0_5px_var(--color-glow-strong))] rotate-180'
     >
       <polyline points='6 1 2 7 6 13' />
     </svg>
+    <span className='navigator-label font-pixel text-[10px] uppercase tracking-[0.45em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
+      Navigator
+    </span>
   </button>
 );
 
@@ -154,14 +150,6 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
     if (typeof window === 'undefined') return false;
     return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
   });
-  // Sidebar nav and toggle button track hover independently so a mouseleave
-  // on one doesn't override an active hover on the other when the regions
-  // overlap. When the sidebar is collapsed the toggle stays visible
-  // unconditionally — without the sidebar there's no other affordance to
-  // signal that nav is reachable.
-  const [sidebarHovered, setSidebarHovered] = useState(false);
-  const [toggleHovered, setToggleHovered] = useState(false);
-  const showToggle = isSidebarCollapsed || sidebarHovered || toggleHovered;
 
   const closeMobileMenu = useCallback(() => setIsMobileMenuOpen(false), []);
   const toggleMobileMenu = useCallback(
@@ -189,14 +177,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         isMobileOpen={isMobileMenuOpen}
         onClose={closeMobileMenu}
         isDesktopCollapsed={isSidebarCollapsed}
-        onDesktopHoverChange={setSidebarHovered}
+        onDesktopToggle={toggleSidebar}
       />
-      <SidebarToggle
-        collapsed={isSidebarCollapsed}
-        visible={showToggle}
-        onClick={toggleSidebar}
-        onHoverChange={setToggleHovered}
-      />
+      <SidebarToggle visible={isSidebarCollapsed} onClick={toggleSidebar} />
       <MenuToggle open={isMobileMenuOpen} onClick={toggleMobileMenu} />
       <main ref={mainRef} className='flex-1 min-w-0 overflow-y-auto'>
         {children}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -102,24 +102,32 @@ const MenuToggle = ({
   </button>
 );
 
-// Desktop-only sidebar collapse toggle. Sits at the bottom of the sidebar's
-// right edge (when expanded) and slides to the screen's bottom-left corner
-// (when collapsed) so it always has a corner or boundary to anchor against
-// — never floating in the middle. A persistent soft glow makes it
-// discoverable at rest.
+// Desktop-only sidebar collapse toggle. Hidden at rest; revealed when the
+// sidebar (or, when collapsed, the screen's left-edge hot zone) is hovered.
+// Sits at the right edge of the sidebar near the link content when
+// expanded, and at the screen's left edge when collapsed. The chevron
+// color flips between hardcoded white (over the always-black sidebar) and
+// var(--color-ink) (over the themed main content) so it stays visible in
+// both light and dark mode.
 const SidebarToggle = ({
   collapsed,
+  visible,
   onClick,
+  onHoverChange,
 }: {
   collapsed: boolean;
+  visible: boolean;
   onClick: () => void;
+  onHoverChange: (hovered: boolean) => void;
 }) => (
   <button
     type='button'
     onClick={onClick}
+    onMouseEnter={() => onHoverChange(true)}
+    onMouseLeave={() => onHoverChange(false)}
     aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
     aria-expanded={!collapsed}
-    className={`hidden md:flex fixed bottom-6 z-[60] justify-center items-center w-9 h-9 group transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-2' : 'left-[8rem]'}`}
+    className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-[60] justify-center items-center w-9 h-9 transition-[left] duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${collapsed ? 'left-1' : 'left-[8rem]'} ${visible ? 'pointer-events-auto' : 'pointer-events-none'}`}
   >
     <svg
       width='12'
@@ -130,7 +138,7 @@ const SidebarToggle = ({
       strokeWidth='1.5'
       strokeLinecap='round'
       strokeLinejoin='round'
-      className={`text-white/55 [filter:drop-shadow(0_0_3px_rgba(255,255,255,0.2))] group-hover:text-white group-hover:[filter:drop-shadow(0_0_6px_rgba(255,255,255,0.55))] transition-[transform,color,filter] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${collapsed ? 'rotate-180' : ''}`}
+      className={`${collapsed ? 'text-[var(--color-ink)]' : 'text-white'} ${visible ? `opacity-100 ${collapsed ? '[filter:drop-shadow(0_0_5px_var(--color-glow-strong))]' : '[filter:drop-shadow(0_0_5px_rgba(255,255,255,0.45))]'}` : 'opacity-0'} transition-[opacity,transform,filter,color] duration-300 ease-out ${collapsed ? 'rotate-180' : ''}`}
     >
       <polyline points='6 1 2 7 6 13' />
     </svg>
@@ -146,6 +154,13 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
     if (typeof window === 'undefined') return false;
     return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
   });
+  // Multiple independent hover sources (sidebar nav, the toggle button, the
+  // collapsed hot zone) are tracked separately so a mouseleave on one
+  // doesn't override an active hover on another when the regions overlap.
+  const [sidebarHovered, setSidebarHovered] = useState(false);
+  const [toggleHovered, setToggleHovered] = useState(false);
+  const [hotZoneHovered, setHotZoneHovered] = useState(false);
+  const showToggle = sidebarHovered || toggleHovered || hotZoneHovered;
 
   const closeMobileMenu = useCallback(() => setIsMobileMenuOpen(false), []);
   const toggleMobileMenu = useCallback(
@@ -173,8 +188,25 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         isMobileOpen={isMobileMenuOpen}
         onClose={closeMobileMenu}
         isDesktopCollapsed={isSidebarCollapsed}
+        onDesktopHoverChange={setSidebarHovered}
       />
-      <SidebarToggle collapsed={isSidebarCollapsed} onClick={toggleSidebar} />
+      <SidebarToggle
+        collapsed={isSidebarCollapsed}
+        visible={showToggle}
+        onClick={toggleSidebar}
+        onHoverChange={setToggleHovered}
+      />
+      {isSidebarCollapsed && (
+        <button
+          type='button'
+          onClick={toggleSidebar}
+          onMouseEnter={() => setHotZoneHovered(true)}
+          onMouseLeave={() => setHotZoneHovered(false)}
+          aria-label='Expand sidebar'
+          tabIndex={-1}
+          className='hidden md:block fixed top-0 bottom-0 left-0 w-3 z-[55]'
+        />
+      )}
       <MenuToggle open={isMobileMenuOpen} onClick={toggleMobileMenu} />
       <main ref={mainRef} className='flex-1 min-w-0 overflow-y-auto'>
         {children}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -128,15 +128,15 @@ const SidebarToggle = ({
       viewBox='0 0 10 14'
       fill='none'
       stroke='currentColor'
-      strokeWidth='1.5'
+      strokeWidth='1'
       strokeLinecap='round'
       strokeLinejoin='round'
       className='text-[var(--color-ink)] [filter:drop-shadow(0_0_5px_var(--color-glow-strong))] rotate-180'
     >
-      <polyline points='6 1 2 7 6 13' />
+      <polyline points='9 1 1 7 9 13' />
     </svg>
-    <span className='navigator-label font-pixel text-[10px] uppercase tracking-[0.45em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
-      Navigator
+    <span className='navigator-label font-pixel text-[11px] uppercase tracking-[0.55em] text-[var(--color-ink-muted)] [writing-mode:vertical-rl] [text-orientation:upright] select-none'>
+      Atlas
     </span>
   </button>
 );

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -109,7 +109,7 @@ const MenuToggle = ({
 // nav-glitch only fires on first paint when the sidebar boots already
 // collapsed — subsequent toggles fall back to the plain opacity fade so
 // flipping the sidebar doesn't feel jittery.
-const ATLAS_CHARS = ['A', 't', 'l', 'a', 's'];
+const ATLAS_CHARS = ['ア', 'ト', 'ラ', 'ス'];
 
 const SidebarToggle = ({
   visible,
@@ -162,7 +162,7 @@ const SidebarToggle = ({
       </svg>
       <span
         aria-label='Atlas'
-        className='flex flex-col items-center gap-[0.55em] font-pixel text-[11px] uppercase text-[var(--color-ink-muted)] select-none'
+        className='flex flex-col items-center gap-[0.45em] font-pixel text-[13px] text-[var(--color-ink-muted)] select-none'
       >
         {ATLAS_CHARS.map((c, i) => (
           <span


### PR DESCRIPTION
## Summary
Adds a desktop-only collapsible sidebar. The expanded sidebar gets a 隠す (Hide) action at the bottom of the nav list; the collapsed state shows a chevron + vertical アトラス (Atlas) label at the screen's left edge. Collapsed state is persisted to `localStorage`.

## Commentary
- **Hide affordance** — A 隠す button styled as a dimmer sibling of the nav links sits directly under "Heroes". A 14×14 transparent spacer keeps its text column aligned with the inactive nav links above (which render their LunarTear at `opacity-0`).
- **Atlas rail** — When collapsed, a fixed left-edge column shows a slim chevron above per-character katakana (ア・ト・ラ・ス) stacked via flex-col. Theme-aware colors (`var(--color-ink)` + `var(--color-glow-strong)`) keep both glyph and glow legible in light and dark mode.
- **Entrance choreography** —
  - On *first paint* if the sidebar boots collapsed, the chevron + label glitch in via the existing `nav-glitch-active` (same animation that drives the active nav link and bio).
  - On *subsequent* collapses, the glitch is suppressed and each Atlas character rises with a 70ms stagger (`atlas-char-rise`). A `riseKey` increments on every transition into the collapsed state so the keyed spans re-mount and replay the animation.
  - First-paint vs. subsequent is tracked with a `useRef` first-render flag, flipped off in the post-mount effect.
- **Mobile behavior** is unchanged — the existing menu flower at top-right still drives the mobile overlay.
- **Caveat**: Geist Pixel doesn't include CJK glyphs, so 隠す and アトラス fall back to the system Japanese font.