### PR TITLE
fix: add black background to favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="black"/>
   <ellipse cx="50" cy="22" rx="10" ry="22" fill="white" transform="rotate(0 50 50)"/>
   <ellipse cx="50" cy="22" rx="10" ry="22" fill="white" transform="rotate(72 50 50)"/>
   <ellipse cx="50" cy="22" rx="10" ry="22" fill="white" transform="rotate(144 50 50)"/>


### PR DESCRIPTION
## Summary
Adds a black background to the flower favicon so the white petals remain visible on light-themed browser tabs.