### PR TITLE
feat: monochrome text selection per theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1039,6 +1039,17 @@ html {
   }
 }
 
+/* Text selection — monochrome inverse of the active surface. Ink-colored
+   highlight with surface-colored glyphs reads cleanly in both themes. */
+::selection {
+  background-color: var(--color-ink);
+  color: var(--color-surface);
+}
+::-moz-selection {
+  background-color: var(--color-ink);
+  color: var(--color-surface);
+}
+
 /*
  * Light-theme overrides.
  *


### PR DESCRIPTION
## Summary
Adds `::selection` rules in `src/index.css` that flip the highlight to the inverse of the active surface — white-on-black-text in dark mode, black-on-white-text in light mode.