### PR TITLE
fix: extend spider lily lite path to desktop Safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -481,13 +481,15 @@ html[data-theme-flash-reset] .nav-glitch-active {
 }
 
 /* Mobile / reduced-motion fallback for the spider lily.
-   iOS Safari can't composite the stacked SVG filters (feTurbulence + two
+   Safari/WebKit can't composite the stacked SVG filters (feTurbulence + two
    Gaussian blurs + per-stamen glow) at 60fps while the lily is animating.
-   SpiderLily.tsx drops those filters and the wind/sway rAF loop on coarse
-   pointers, and swaps the heavy #petal-glow for a slimmer two-pass
-   Gaussian blur merge (#petal-glow-lite) that self-colors from
-   SourceGraphic. Here we also skip the infinite breathing drop-shadow on
-   the container. Desktop behavior is unchanged. */
+   SpiderLily.tsx drops those filters and the wind/sway rAF loop on Safari,
+   coarse pointers, and reduce-motion, and swaps the heavy #petal-glow for
+   a slimmer two-pass Gaussian blur merge (#petal-glow-lite) that
+   self-colors from SourceGraphic. Here we also skip the infinite breathing
+   drop-shadow on the container for coarse-pointer / reduce-motion. (Safari
+   desktop keeps the breathing halo — its blur radius animates over 7s on a
+   static subtree, which WebKit can cache and re-blur cheaply.) */
 @media (prefers-reduced-motion: reduce), (pointer: coarse) {
   .spider-lily-container {
     animation: lily-glow-in 2.5s ease-out 1.2s forwards;

--- a/src/screens/Home/SpiderLily.tsx
+++ b/src/screens/Home/SpiderLily.tsx
@@ -346,16 +346,21 @@ const WIND_SPEED = 0.0008;
 const WIND_STRENGTH_X = 4.5;
 const WIND_STRENGTH_Y = 2.0;
 
-// Capability flags captured once at module load. iOS Safari chokes on the
+// Capability flags captured once at module load. Safari/WebKit chokes on the
 // stacked SVG filters (feTurbulence + two Gaussian blurs + per-stamen glow)
-// re-rasterizing every rAF, so on coarse-pointer devices and under Reduce
-// Motion we skip the filter chain and the wind/sway loop entirely. Desktop
+// re-rasterizing every rAF — the wind/sway loop writes `transform` to 26+
+// nodes inside the filtered group each frame, invalidating WebKit's filter
+// cache. Chromium (Skia) handles this fine; macOS and iOS Safari can't. So
+// on Safari, coarse-pointer devices, and under Reduce Motion we skip the
+// filter chain and the wind/sway loop entirely. Chromium/Firefox desktop
 // behavior is unchanged.
 const heavyEffectsEnabled = (() => {
   if (typeof window === 'undefined') return true;
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const coarse = window.matchMedia('(pointer: coarse)').matches;
-  return !reduce && !coarse;
+  const ua = navigator.userAgent;
+  const isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(ua);
+  return !reduce && !coarse && !isSafari;
 })();
 
 type Vec2 = { x: number; y: number };
@@ -643,15 +648,15 @@ const SpiderLily = ({ className }: { className?: string }) => {
           </filter>
         </defs>
       ) : (
-        /* Mobile / reduced-motion path. Mirrors the desktop #petal-glow
-           (wide blur + tight blur + SourceGraphic merge) at smaller radii.
-           On this branch the flower subtree is static — no rAF transform
-           writes inside the filtered group — so iOS Safari rasterizes the
-           filter once at paint time instead of every frame, which keeps
-           it cheap. Self-coloring via SourceGraphic avoids a `flood-color`
-           CSS theming seam that iOS ignores on `<feDropShadow>`; the halo
-           inherits the petals' ink color and tracks the active theme
-           automatically. */
+        /* Safari / mobile / reduced-motion path. Mirrors the desktop
+           #petal-glow (wide blur + tight blur + SourceGraphic merge) at
+           smaller radii. On this branch the flower subtree is static — no
+           rAF transform writes inside the filtered group — so WebKit
+           rasterizes the filter once at paint time instead of every frame,
+           which keeps it cheap. Self-coloring via SourceGraphic avoids a
+           `flood-color` CSS theming seam that iOS ignores on
+           `<feDropShadow>`; the halo inherits the petals' ink color and
+           tracks the active theme automatically. */
         <defs>
           <filter
             id='petal-glow-lite'


### PR DESCRIPTION
## Root cause

`SpiderLily.tsx`'s `heavyEffectsEnabled` capability flag only disabled the heavy SVG filter chain + rAF wind/sway loop for `prefers-reduced-motion` or `pointer: coarse`. That caught iOS Safari but left **macOS Safari** on the heavy path:

- `feTurbulence` + `feDisplacementMap` on the whole flower subtree
- Stacked dual `feGaussianBlur` (`#petal-glow`) on the flower head group
- Per-stamen `feGaussianBlur` glow on 24 elements
- A 60fps rAF loop writing `transform` to 14 petals + 12 stamens + the flower wrapper *inside* those filtered groups, invalidating WebKit's filter cache every frame

Chromium (Skia) absorbs this; WebKit's SVG filter pipeline can't, so frames drop.

## Fix

Add a Safari UA check to `heavyEffectsEnabled` so desktop Safari routes through the same lite-filter / no-rAF path mobile already uses. The lite path keeps the petal halo (single `#petal-glow-lite` two-pass blur, self-coloring from SourceGraphic) but skips `feTurbulence`, per-stamen glow, and the wind/sway loop — so WebKit rasterizes the filter once at paint time. Comments in `SpiderLily.tsx` and `index.css` updated to match the new scope.

Chromium/Firefox desktop behavior is unchanged.

## Test plan

- [ ] Open the home page in macOS Safari — flower blooms smoothly, glow visible, no jank during the entrance sequence
- [ ] Open in Chrome — full effect chain (ink texture, dual glow, wind sway, hover push) still present
- [ ] Open in iOS Safari — unchanged from before (already on the lite path via `pointer: coarse`)
- [ ] Toggle the theme by clicking the lily — works in all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)