### PR TITLE
fix: spider lily stamens invisible on mobile light mode

### DIFF
--- a/src/screens/Home/SpiderLily/geometry.ts
+++ b/src/screens/Home/SpiderLily/geometry.ts
@@ -534,7 +534,7 @@ function buildEllipseFan(
   return { vertices, indices };
 }
 
-const STAMEN_HALF_WIDTH = 0.4;
+export const STAMEN_HALF_WIDTH = 0.4;
 const ANTHER_SEGMENTS = 16;
 const CENTER_SEGMENTS = 16;
 const CENTER_RADIUS = 3;
@@ -544,9 +544,19 @@ export const PETAL_MESHES: PetalMesh[] = PETALS.map(p => {
   return { ...mesh, pivot: [p.cx, p.cy] };
 });
 
-export const STAMEN_MESHES: Mesh[] = STAMENS.map(s =>
-  buildStroke(samplePath(parsePath(s.d)), STAMEN_HALF_WIDTH),
-);
+// Sampled centerline points per stamen — kept around so the renderer can
+// rebuild stamen stroke meshes at a wider half-width on small/low-DPR
+// canvases, where the default 0.4 viewBox-unit half-width is sub-device-pixel
+// and MSAA-4x produces such low coverage that the line goes nearly
+// transparent (invisible against light-mode white; barely off against
+// dark-mode black, which is why the bug is mobile + light only).
+const STAMEN_POINTS: Pt[][] = STAMENS.map(s => samplePath(parsePath(s.d)));
+
+export function buildStamenMeshes(halfWidth: number): Mesh[] {
+  return STAMEN_POINTS.map(pts => buildStroke(pts, halfWidth));
+}
+
+export const STAMEN_MESHES: Mesh[] = buildStamenMeshes(STAMEN_HALF_WIDTH);
 
 export const ANTHER_MESHES: Mesh[] = STAMENS.map(s =>
   buildEllipseFan(

--- a/src/screens/Home/SpiderLily/renderer.ts
+++ b/src/screens/Home/SpiderLily/renderer.ts
@@ -1,9 +1,10 @@
 import {
   ANTHER_MESHES,
+  buildStamenMeshes,
   CENTER_MESH,
   type Mesh,
   PETAL_MESHES,
-  STAMEN_MESHES,
+  STAMEN_HALF_WIDTH,
   STEM_BOTTOM_Y,
   STEM_MESH,
   STEM_TOP_Y,
@@ -135,6 +136,7 @@ export class SpiderLilyRenderer {
   private width = 0;
   private height = 0;
   private projection = new Float32Array(9);
+  private stamenHalfWidth = STAMEN_HALF_WIDTH;
 
   colors: Colors = {
     ink: [1, 1, 1, 1],
@@ -270,10 +272,22 @@ export class SpiderLilyRenderer {
       pivotX: m.pivot[0],
       pivotY: m.pivot[1],
     }));
-    this.stamenMeshes = STAMEN_MESHES.map(m => this.buildMesh(m));
+    this.stamenMeshes = buildStamenMeshes(this.stamenHalfWidth).map(m =>
+      this.buildMesh(m),
+    );
     this.antherMeshes = ANTHER_MESHES.map(m => this.buildMesh(m));
     this.stemMesh = this.buildMesh(STEM_MESH);
     this.centerMesh = this.buildMesh(CENTER_MESH);
+  }
+
+  private rebuildStamenMeshes() {
+    const gl = this.gl;
+    for (const m of this.stamenMeshes) {
+      gl.deleteVertexArray(m.vao);
+    }
+    this.stamenMeshes = buildStamenMeshes(this.stamenHalfWidth).map(m =>
+      this.buildMesh(m),
+    );
   }
 
   private buildQuad() {
@@ -358,6 +372,22 @@ export class SpiderLilyRenderer {
     if (width === this.width && height === this.height) return;
     this.width = width;
     this.height = height;
+
+    // Inflate the stamen stroke half-width on small canvases so the line is
+    // at least ~1 device pixel wide. At the baked 0.4 viewBox units the
+    // stamens go sub-pixel on mobile (≤640 device px wide), which under
+    // MSAA-4x resolves to such low alpha that the line nearly vanishes —
+    // imperceptible against the dark-mode black surface but rendering as
+    // white-on-white in light mode. The viewBox is 800 units wide, so
+    // halfWidth_view = 0.5 * 800 / width gives ~1 device px of total width.
+    const requiredHalfWidth = Math.max(
+      STAMEN_HALF_WIDTH,
+      (0.5 * VIEWBOX.w) / width,
+    );
+    if (requiredHalfWidth !== this.stamenHalfWidth) {
+      this.stamenHalfWidth = requiredHalfWidth;
+      this.rebuildStamenMeshes();
+    }
 
     this.disposeMSAA(this.sceneMS as MSAAFramebuffer | null);
     this.disposeFBO(this.scene as Framebuffer | null);


### PR DESCRIPTION
## Summary
Inflate the spider lily stamen stroke width on small canvases so the line stays at least ~1 device pixel wide. The baked 0.4 viewBox-unit half-width was sub-pixel on mobile after the WebGL2 rewrite, which under MSAA-4x resolved to such low alpha that the stamens read as white-on-white in light mode.

## Commentary
- `geometry.ts` keeps the sampled centerline points and exposes a `buildStamenMeshes(halfWidth)` factory.
- `renderer.setSize` computes the required half-width from the current canvas device-pixel width and rebuilds the stamen VAOs when it changes.
- The threshold (`0.5 × VIEWBOX.w / width`) targets a ~1 device pixel total stroke, which is the minimum that MSAA-4x consistently covers. Mobile gets the visible bump; retina desktop barely changes.