### PR TITLE
fix: widen spider lily stamens to survive wide-blur composite

### DIFF
--- a/src/screens/Home/SpiderLily/renderer.ts
+++ b/src/screens/Home/SpiderLily/renderer.ts
@@ -373,16 +373,17 @@ export class SpiderLilyRenderer {
     this.width = width;
     this.height = height;
 
-    // Inflate the stamen stroke half-width on small canvases so the line is
-    // at least ~1 device pixel wide. At the baked 0.4 viewBox units the
-    // stamens go sub-pixel on mobile (≤640 device px wide), which under
-    // MSAA-4x resolves to such low alpha that the line nearly vanishes —
-    // imperceptible against the dark-mode black surface but rendering as
-    // white-on-white in light mode. The viewBox is 800 units wide, so
-    // halfWidth_view = 0.5 * 800 / width gives ~1 device px of total width.
+    // Inflate the stamen stroke half-width on small canvases so the line
+    // survives the wide-blur composite (stdDev ≈ 6 device px) that this
+    // renderer applies to every shape — the old SVG version blurred stamens
+    // with stdDev≈1.2 *viewBox* units only, so a 0.8-unit stroke stayed
+    // visible. Here the wide blur spreads a thin line's energy over ~12
+    // device px and washes the scene contribution down to nearly transparent;
+    // ~1 device px (target = 0.5) wasn't enough. Target ≥2 device px total
+    // width so the scene layer keeps usable alpha at the line center.
     const requiredHalfWidth = Math.max(
       STAMEN_HALF_WIDTH,
-      (0.5 * VIEWBOX.w) / width,
+      (1.0 * VIEWBOX.w) / width,
     );
     if (requiredHalfWidth !== this.stamenHalfWidth) {
       this.stamenHalfWidth = requiredHalfWidth;


### PR DESCRIPTION
## Summary
Bump the adaptive stamen half-width target from ~1 device pixel to ~2 device pixels. PR #98 addressed MSAA-4x coverage at sub-pixel widths, but the renderer's wide Gaussian blur (stdDev ≈ 6 device px, applied to every shape) still washes a 1 device px line down to near-transparent at the line center — visible in the latest screenshot as faint near-white stamens on the light-mode white background.

## Commentary
- The old SVG only blurred stamens with `stdDeviation='1.2'` viewBox units (≈1 device px), so the 0.8-unit stroke stayed legible. The new WebGL pipeline puts stamens through the full wide blur the SVG only applied to petals, which is what changed under the rewrite.
- Doubling the floor target (formula factor 0.5 → 1.0) roughly doubles the scene-layer alpha the composite sees at the line center.
- A more "correct" fix would route stamens around the wide blur, but that's a structural change; this is the minimum change to restore visibility.