### PR TITLE
fix: parse 4-digit hex shorthand in spider lily color reader

### DIFF
--- a/src/screens/Home/SpiderLily/index.tsx
+++ b/src/screens/Home/SpiderLily/index.tsx
@@ -66,7 +66,13 @@ function parseCssColor(input: string): ColorVec {
   const s = input.trim();
   if (s.startsWith('#')) {
     let hex = s.slice(1);
-    if (hex.length === 3)
+    // Expand shorthand: #RGB and #RGBA both double each nibble.
+    // The 4-digit form matters in prod because Lightning CSS minifies
+    // light-mode `rgba(0, 0, 0, 0.6)` to `#0009` — without this branch
+    // the value falls through to the rgba parser, only finds one number,
+    // and bails to the default white, which is why the stamens (the only
+    // ink-muted shape) rendered white-on-white on deployed light mode.
+    if (hex.length === 3 || hex.length === 4)
       hex = hex
         .split('')
         .map(c => c + c)


### PR DESCRIPTION
## Summary
Actual root cause of the prod-only white-stamens-in-light-mode bug: Lightning CSS (under \`vite build\`) minifies light-mode \`rgba(0, 0, 0, 0.6)\` to the \`#RGBA\` shorthand \`#0009\`, and \`parseCssColor\` had no branch for 4-digit hex — it fell through to the rgba parser, matched a single token, and bailed to the default white. Treat 4-digit hex like 3-digit (double each nibble) and the existing 8-digit branch handles the result.

## Commentary
- \`ink\` (\`#000\`) and \`inkSoft\` (\`#000000c7\`) hit the working 3- and 8-digit branches, which is why only the inkMuted-colored stamens turned white.
- Dev didn't reproduce because Vite doesn't minify CSS; dark mode didn't reproduce because its muted value minifies to 8 digits (\`#ffffff80\`).
- Keeping the thickness fixes from #98/#99 — they still help readability under the wide-blur composite.