### PR TITLE
fix: stop landing page from vertically scrolling on mobile

### DIFF
--- a/src/screens/Home/sections/MainBanner/index.tsx
+++ b/src/screens/Home/sections/MainBanner/index.tsx
@@ -11,7 +11,7 @@ const bioClass =
 const MainBanner = () => {
   const jitter = useJitter();
   return (
-    <div className='w-full h-screen bg-black flex items-center justify-center md:pr-40'>
+    <div className='w-full h-dvh bg-black flex items-center justify-center md:pr-40'>
       <div className='flex flex-col items-start gap-6 md:gap-8 max-w-md lg:max-w-lg px-6'>
         <div
           className='bio-glitch w-80 sm:w-88 md:w-[26rem] lg:w-[30rem]'


### PR DESCRIPTION
## Summary
On mobile the landing page was vertically scrollable into an empty region below the centered content. Swap `h-screen` for `h-dvh` on `MainBanner` so the container matches the actual visible viewport.

## Commentary
`h-screen` (= `100vh`) resolves to the viewport height with browser chrome hidden, so while the URL bar is showing the container is taller than the visible area. The `<main>` ancestor in `RootLayout` has `overflow-y-auto`, which then surfaces that extra height as a scrollable empty strip. `h-dvh` uses the dynamic viewport unit, so the container tracks the currently visible area and no overflow is created. Every other screen uses `min-h-screen` because it's intentionally scrollable — `MainBanner` is the only viewport-locked screen, so this change is isolated.

I wasn't able to test this in a mobile browser from my environment — worth a quick spot-check on iOS Safari / mobile Chrome to confirm the scroll is gone and that the URL-bar show/hide transition doesn't introduce visible jank.