### PR TITLE
fix(signals): serve responsive variants for inline markdown images

### DIFF
--- a/src/screens/Signals/MarkdownBody.tsx
+++ b/src/screens/Signals/MarkdownBody.tsx
@@ -33,10 +33,15 @@ const MarkdownBody = ({ children }: { children: string }) => (
         height?: string | number;
       }) => {
         if (!src || !width || !height) return <img src={src} alt={alt} />;
+        const placeholderSrc = src.replace(/-full\.webp$/, '-placeholder.webp');
+        const smallSrc = src.replace(/-full\.webp$/, '-small.webp');
+        const thumbSrc = src.replace(/-full\.webp$/, '-thumb.webp');
         return (
           <ProgressiveImage
-            placeholderSrc={src.replace(/-full\.webp$/, '-placeholder.webp')}
-            src={src}
+            placeholderSrc={placeholderSrc}
+            src={thumbSrc}
+            srcSet={`${smallSrc} 480w, ${thumbSrc} 800w, ${src} 1600w`}
+            sizes='(min-width: 768px) 672px, 100vw'
             alt={alt ?? ''}
             width={Number(width)}
             height={Number(height)}


### PR DESCRIPTION
## Summary
Fix mobile scroll stutter on the Signals list by emitting `srcSet`/`sizes` for inline markdown images so the browser picks the small/thumb webp on phones instead of downloading and decoding the multi-megabyte desktop-resolution `-full.webp`.

## Commentary
`MarkdownBody`'s `<img>` handler was forwarding only the `-full.webp` source to `ProgressiveImage` with no responsive hints. Photo-only signal entries (e.g. `sidewalk-freq` at 1.2 MB / 2400×1800, `chinatown-wars` at 628 KB / 4506×3004) have a body length of 0, so they bypass the collapsed-list hero-thumb path in `index.tsx` and fall through to `MarkdownBody`. On mobile that meant pulling and decoding a desktop-sized raster into a ~400px column — the decode pause on each image landing showed up as scroll stutter, amplified on bad networks because the full-res requests serialized as `useInfiniteList` revealed more entries.

The fix mirrors the `CollapsedListHeroImage` pattern: emit `-small`/`-thumb`/`-full` candidates with `sizes='(min-width: 768px) 672px, 100vw'` so mobile selects 480w/800w and only high-DPR desktop picks the full image. `MarkdownBody` is shared with `SignalDetail`, so the detail view also stops over-fetching on mobile while still resolving to the full image on desktop. Verified all four entries with inline images have the variant files on disk.