### PR TITLE
fix: improve scrollbar visibility in dark/light mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -829,7 +829,7 @@ html[data-theme-flash-reset] .nav-glitch-active {
 /* Firefox */
 html {
   scrollbar-width: thin;
-  scrollbar-color: var(--color-ink-hair) transparent;
+  scrollbar-color: var(--color-ink-ghost) transparent;
 }
 
 /* WebKit */
@@ -843,12 +843,12 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(--color-ink-hair);
+  background-color: var(--color-ink-ghost);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: var(--color-ink-trace);
+  background-color: var(--color-ink-faint);
 }
 
 ::-webkit-scrollbar-corner {


### PR DESCRIPTION
## Summary
The scrollbar thumb was using the `--color-ink-hair` token (5% opacity in dark, 7% in light), making it effectively invisible in both themes. Bumped the thumb to more visible theme-aware tokens while keeping it understated.

## Commentary
Changes in `src/index.css`:
- Thumb: `--color-ink-hair` → `--color-ink-ghost` (0.2 dark / 0.3 light)
- Thumb hover: `--color-ink-trace` → `--color-ink-faint` (0.3 dark / 0.42 light)
- Firefox `scrollbar-color`: `--color-ink-hair` → `--color-ink-ghost`