### PR TITLE
feat: optimize signals body typography for reading

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -555,12 +555,14 @@ html[data-theme-flash-reset] .nav-glitch-active {
 .signal-prose ol ol {
   padding-left: 1.25em;
 }
+/* Quotes carry body content — the border + background tint already set them
+   apart, so the text tracks the body ink instead of dropping to a softer token. */
 .signal-prose blockquote {
   border-left: 2px solid var(--color-ink-ghost);
   background: var(--color-ink-hair);
   padding: 0.75em 1em;
   border-radius: 0 4px 4px 0;
-  color: var(--color-ink-soft);
+  color: inherit;
   margin: 0.75em 0;
 }
 .signal-prose h1,
@@ -921,6 +923,9 @@ html {
 
 /* Opacity-tinted white text — map each percentage used in the codebase to an
    ink token. Values correspond to what Tailwind generates for text-white/<n>. */
+[data-theme='light'] .text-white\/90 {
+  color: var(--color-ink-soft);
+}
 [data-theme='light'] .text-white\/80 {
   color: var(--color-ink-soft);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -406,13 +406,19 @@ html[data-theme-flash-reset] .nav-glitch-active {
 
 /* Signal entries only — long-form rhythm (generous paragraph gaps like overreacted-style blogs) */
 .signal-prose.signal-entry {
-  line-height: 1.78;
+  line-height: 1.8;
 }
 .signal-prose.signal-entry p {
   margin-bottom: 1.45em;
 }
 .signal-prose.signal-entry p:last-child {
   margin-bottom: 0;
+}
+/* Avoid single-word orphan lines in long-form bodies (no-op where unsupported) */
+.signal-prose.signal-entry p,
+.signal-prose.signal-entry li,
+.signal-prose.signal-entry blockquote {
+  text-wrap: pretty;
 }
 .signal-prose.signal-entry h1,
 .signal-prose.signal-entry h2,
@@ -461,13 +467,17 @@ html[data-theme-flash-reset] .nav-glitch-active {
   color: var(--color-ink);
   font-weight: 600;
 }
+/* Emphasis must not drop below body contrast — it marks the words that
+   matter most, so it inherits the body ink instead of a muted token. */
 .signal-prose em {
   font-style: italic;
-  color: var(--color-ink-muted);
+  color: inherit;
 }
 .signal-prose a {
   text-decoration: underline;
   text-decoration-color: var(--color-ink-faint);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
   transition: all 300ms;
 }
 .signal-prose a:hover {
@@ -562,6 +572,7 @@ html[data-theme-flash-reset] .nav-glitch-active {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 1em 0 0.5em;
+  text-wrap: balance;
 }
 .signal-prose h1 {
   font-size: 1.5em;

--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -75,7 +75,7 @@ const SignalDetail = ({ id }: { id: string }) => {
         </header>
 
         <div
-          className='bio-glitch signal-prose signal-entry text-white/80 text-[15px] font-mono'
+          className='bio-glitch signal-prose signal-entry text-white/90 text-[15px] font-mono'
           style={jitter()}
         >
           <MarkdownBody>{s.body}</MarkdownBody>

--- a/src/screens/Signals/SignalDetail.tsx
+++ b/src/screens/Signals/SignalDetail.tsx
@@ -75,7 +75,7 @@ const SignalDetail = ({ id }: { id: string }) => {
         </header>
 
         <div
-          className='bio-glitch signal-prose signal-entry text-white/70 text-sm font-mono'
+          className='bio-glitch signal-prose signal-entry text-white/80 text-[15px] font-mono'
           style={jitter()}
         >
           <MarkdownBody>{s.body}</MarkdownBody>


### PR DESCRIPTION
## Summary
Tunes the signals detail page typography for long-form reading in both dark and light mode: larger, higher-contrast body text, full-contrast emphasis and quotes, orphan-free paragraph wrapping, and cleaner link underlines.

## Commentary
- Detail body goes from `text-sm text-white/70` to `text-[15px] text-white/90` — dark mode was reading muted at 70–80% white. Light mode maps `/90` to the existing soft-ink token (`--color-ink-soft`), so paper stays calm while dark gets the brightness.
- `<em>` previously rendered in `--color-ink-muted` and blockquotes in `--color-ink-soft`, both dimmer than the surrounding body; each now inherits the body ink so emphasized words and quoted content never drop below body contrast (the quote border + tint still set it apart).
- `text-wrap: pretty` on entry paragraphs/lists/blockquotes and `text-wrap: balance` on prose headings (progressive enhancement, no-op where unsupported).
- Link underlines get `text-underline-offset: 0.2em` and 1px thickness so descenders stay clean.
- Verified with dev-server screenshots of a signal post in both themes.